### PR TITLE
General SHC

### DIFF
--- a/src/common.cuh
+++ b/src/common.cuh
@@ -252,7 +252,9 @@ struct Parameters
 // All the CPU data
 struct CPU_Data
 {
-    int *NN; int *NL; int *fv_index; 
+    int *NN; int *NL; int *fv_index;
+    int *a_map; int *b_map;
+    int *count_a; int *count_b;
     int *type; int *label; int *group_size; int *group_size_sum;
     int *type_local;              // local atom type (for force)
     int *type_size; // number of atoms for each type
@@ -275,7 +277,6 @@ struct GPU_Data
 {
     int *NN; int *NL;             // global neighbor list
     int *NN_local; int *NL_local; // local neighbor list
-    int *fv_index;                // for SHC calculations
     int *type;                    // atom type (for force)
     int *type_local;              // local atom type (for force)
     int *label;                   // group label 
@@ -299,8 +300,10 @@ struct GPU_Data
     real *box_length;       // box length in each direction
     real *thermo;           // some thermodynamic quantities
     real *fv; real *fv_all; // for SHC calculations
+    int *fv_index;  // for SHC calculations
+    int *a_map; int *b_map;
+	int *count_a; int *count_b;
 };
-
 
 
 

--- a/src/eam.cu
+++ b/src/eam.cu
@@ -479,12 +479,12 @@ static __global__ void find_force_eam_step2
 				g_fv[index_12 + 3]  += f21x;
 				g_fv[index_12 + 4]  += f21y;
 				g_fv[index_12 + 5]  += f21z;
-				g_fv[index_12 + 6]  += vx1;
-				g_fv[index_12 + 7]  += vy1;
-				g_fv[index_12 + 8]  += vz1;
-				g_fv[index_12 + 9]  += LDG(g_vx, n2);
-				g_fv[index_12 + 10] += LDG(g_vy, n2);
-				g_fv[index_12 + 11] += LDG(g_vz, n2);
+				g_fv[index_12 + 6]  = vx1;
+				g_fv[index_12 + 7]  = vy1;
+				g_fv[index_12 + 8]  = vz1;
+				g_fv[index_12 + 9]  = LDG(g_vx, n2);
+				g_fv[index_12 + 10] = LDG(g_vy, n2);
+				g_fv[index_12 + 11] = LDG(g_vz, n2);
 			}
         }
 

--- a/src/eam.cu
+++ b/src/eam.cu
@@ -364,7 +364,8 @@ static __global__ void find_force_eam_step2
 #endif
     real *g_fx, real *g_fy, real *g_fz,
     real *g_sx, real *g_sy, real *g_sz, real *g_pe, 
-    real *g_h, int *g_label, int *g_fv_index, real *g_fv 
+    real *g_h, int *g_label, int *g_fv_index, real *g_fv,
+    int *g_a_map, int *g_b_map, int *g_count_b
 )
 {
     int n1 = blockIdx.x * blockDim.x + threadIdx.x + N1;
@@ -467,25 +468,24 @@ static __global__ void find_force_eam_step2
             }
  
             // accumulate heat across some sections (for NEMD)
-            if (cal_q)
-            {
-                int index_12 = g_fv_index[n1] * 12;
-                if (index_12 >= 0 && g_fv_index[n1 + N] == n2)
-                {
-                    g_fv[index_12 + 0]  += f12x;
-                    g_fv[index_12 + 1]  += f12y;
-                    g_fv[index_12 + 2]  += f12z;
-                    g_fv[index_12 + 3]  += f21x;
-                    g_fv[index_12 + 4]  += f21y;
-                    g_fv[index_12 + 5]  += f21z;
-                    g_fv[index_12 + 6]  += vx1;
-                    g_fv[index_12 + 7]  += vy1;
-                    g_fv[index_12 + 8]  += vz1;
-                    g_fv[index_12 + 9]  += LDG(g_vx, n2);
-                    g_fv[index_12 + 10] += LDG(g_vy, n2);
-                    g_fv[index_12 + 11] += LDG(g_vz, n2);
-                }  
-            }
+			//		check if AB pair possible & exists
+			if (cal_q && g_a_map[n1] != -1 && g_b_map[n2] != -1 &&
+					g_fv_index[g_a_map[n1] * *(g_count_b) + g_b_map[n2]] != -1)
+			{
+				int index_12 = g_fv_index[g_a_map[n1] * *(g_count_b) + g_b_map[n2]] * 12;
+				g_fv[index_12 + 0]  += f12x;
+				g_fv[index_12 + 1]  += f12y;
+				g_fv[index_12 + 2]  += f12z;
+				g_fv[index_12 + 3]  += f21x;
+				g_fv[index_12 + 4]  += f21y;
+				g_fv[index_12 + 5]  += f21z;
+				g_fv[index_12 + 6]  += vx1;
+				g_fv[index_12 + 7]  += vy1;
+				g_fv[index_12 + 8]  += vz1;
+				g_fv[index_12 + 9]  += LDG(g_vx, n2);
+				g_fv[index_12 + 10] += LDG(g_vy, n2);
+				g_fv[index_12 + 11] += LDG(g_vz, n2);
+			}
         }
 
         // add driving force
@@ -548,8 +548,11 @@ void EAM::compute(Parameters *para, GPU_Data *gpu_data)
     real *h = gpu_data->heat_per_atom;   
     
     int *label = gpu_data->label;
-    int *fv_index = gpu_data->fv_index;
-    real *fv = gpu_data->fv;
+	int *fv_index = gpu_data->fv_index;
+	int *a_map = gpu_data->a_map;
+	int *b_map = gpu_data->b_map;
+	int *count_b = gpu_data->count_b;
+	real *fv = gpu_data->fv;
    
     real *Fp = eam_data.Fp;
 
@@ -570,33 +573,48 @@ void EAM::compute(Parameters *para, GPU_Data *gpu_data)
             (
                 fe_x, fe_y, fe_z, eam2004zhou, eam2006dai,
                 N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, Fp, x, y, z, vx, vy, vz, 
-                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv
+                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv,
+                a_map, b_map, count_b
             );
         }
-        else if (para->shc.compute)
+        else if (para->shc.compute && !para->hnemd.compute)
         {
-            find_force_eam_step1<0><<<grid_size, BLOCK_SIZE_FORCE>>>
-            (
-                eam2004zhou, eam2006dai, N, N1, N2, pbc_x, pbc_y, pbc_z, 
-                NN, NL, x, y, z, box_length, Fp, pe
-            );
+        	find_force_eam_step2<0, 0, 1, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
+			(
+				fe_x, fe_y, fe_z, eam2004zhou, eam2006dai,
+				N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, Fp, x, y, z, vx, vy, vz,
+				box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv,
+				a_map, b_map, count_b
+			);
         }
-        else if (para->hnemd.compute)
+        else if (para->hnemd.compute && !para->shc.compute)
         {
             find_force_eam_step2<0, 0, 0, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
                 fe_x, fe_y, fe_z, eam2004zhou, eam2006dai, 
                 N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, Fp, x, y, z, vx, vy, vz, 
-                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv
+                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv,
+                a_map, b_map, count_b
             );
         }
+        else if (para->hnemd.compute && para->shc.compute)
+		{
+			find_force_eam_step2<0, 0, 1, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
+			(
+				fe_x, fe_y, fe_z, eam2004zhou, eam2006dai,
+				N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, Fp, x, y, z, vx, vy, vz,
+				box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv,
+				a_map, b_map, count_b
+			);
+		}
         else
         {
             find_force_eam_step2<0, 0, 0, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
                 fe_x, fe_y, fe_z, eam2004zhou, eam2006dai,
                 N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, Fp, x, y, z, vx, vy, vz, 
-                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv
+                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv,
+                a_map, b_map, count_b
             );
         }
     }
@@ -614,34 +632,48 @@ void EAM::compute(Parameters *para, GPU_Data *gpu_data)
             (
                 fe_x, fe_y, fe_z, eam2004zhou, eam2006dai,
                 N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, Fp, x, y, z, vx, vy, vz, 
-                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv
+                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv,
+                a_map, b_map, count_b
             );
         }
-        else if (para->shc.compute)
+        else if (para->shc.compute && !para->hnemd.compute)
         {
             find_force_eam_step2<1, 0, 1, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
                 fe_x, fe_y, fe_z, eam2004zhou, eam2006dai, 
                 N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, Fp, x, y, z, vx, vy, vz, 
-                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv
+                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv,
+                a_map, b_map, count_b
             );
         }
-        else if (para->hnemd.compute)
+        else if (para->hnemd.compute && !para->shc.compute)
         {
             find_force_eam_step2<1, 0, 0, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
                 fe_x, fe_y, fe_z, eam2004zhou, eam2006dai, 
                 N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, Fp, x, y, z, vx, vy, vz, 
-                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv
+                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv,
+                a_map, b_map, count_b
             );
         }
+        else if (para->hnemd.compute && para->shc.compute)
+		{
+			find_force_eam_step2<1, 0, 1, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
+			(
+				fe_x, fe_y, fe_z, eam2004zhou, eam2006dai,
+				N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, Fp, x, y, z, vx, vy, vz,
+				box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv,
+				a_map, b_map, count_b
+			);
+		}
         else
         {
             find_force_eam_step2<1, 0, 0, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
                 fe_x, fe_y, fe_z, eam2004zhou, eam2006dai,
                 N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, Fp, x, y, z, vx, vy, vz, 
-                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv
+                box_length, fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv,
+                a_map, b_map, count_b
             );
         }
     }

--- a/src/force.inc
+++ b/src/force.inc
@@ -23,8 +23,6 @@
 ------------------------------------------------------------------------------*/
 
 
-
-
 template <int cal_j, int cal_q, int cal_k>
 static __global__ void find_force_many_body
 (
@@ -48,7 +46,8 @@ static __global__ void find_force_many_body
 #endif
     real *g_fx, real *g_fy, real *g_fz,
     real *g_sx, real *g_sy, real *g_sz,
-    real *g_h, int *g_label, int *g_fv_index, real *g_fv 
+    real *g_h, int *g_label, int *g_fv_index, real *g_fv,
+    int *g_a_map, int *g_b_map, int *g_count_b
 )
 {
     int n1 = blockIdx.x * blockDim.x + threadIdx.x + N1;
@@ -144,24 +143,23 @@ static __global__ void find_force_many_body
             }
  
             // accumulate heat across some sections (for NEMD)
-            if (cal_q)
+            //		check if AB pair possible & exists
+            if (cal_q && g_a_map[n1] != -1 && g_b_map[n2] != -1 &&
+            		g_fv_index[g_a_map[n1] * *(g_count_b) + g_b_map[n2]] != -1)
             {
-                int index_12 = g_fv_index[n1] * 12;
-                if (index_12 >= 0 && g_fv_index[n1 + number_of_particles] == n2)
-                {
-                    g_fv[index_12 + 0]  += f12x;
-                    g_fv[index_12 + 1]  += f12y;
-                    g_fv[index_12 + 2]  += f12z;
-                    g_fv[index_12 + 3]  += f21x;
-                    g_fv[index_12 + 4]  += f21y;
-                    g_fv[index_12 + 5]  += f21z;
-                    g_fv[index_12 + 6]  += vx1;
-                    g_fv[index_12 + 7]  += vy1;
-                    g_fv[index_12 + 8]  += vz1;
-                    g_fv[index_12 + 9]  += LDG(g_vx, n2);
-                    g_fv[index_12 + 10] += LDG(g_vy, n2);
-                    g_fv[index_12 + 11] += LDG(g_vz, n2);
-                }  
+				int index_12 = g_fv_index[g_a_map[n1] * *(g_count_b) + g_b_map[n2]] * 12;
+				g_fv[index_12 + 0]  += f12x;
+				g_fv[index_12 + 1]  += f12y;
+				g_fv[index_12 + 2]  += f12z;
+				g_fv[index_12 + 3]  += f21x;
+				g_fv[index_12 + 4]  += f21y;
+				g_fv[index_12 + 5]  += f21z;
+				g_fv[index_12 + 6]  += vx1;
+				g_fv[index_12 + 7]  += vy1;
+				g_fv[index_12 + 8]  += vz1;
+				g_fv[index_12 + 9]  += LDG(g_vx, n2);
+				g_fv[index_12 + 10] += LDG(g_vy, n2);
+				g_fv[index_12 + 11] += LDG(g_vz, n2);
             }
         }
 

--- a/src/force.inc
+++ b/src/force.inc
@@ -154,12 +154,12 @@ static __global__ void find_force_many_body
 				g_fv[index_12 + 3]  += f21x;
 				g_fv[index_12 + 4]  += f21y;
 				g_fv[index_12 + 5]  += f21z;
-				g_fv[index_12 + 6]  += vx1;
-				g_fv[index_12 + 7]  += vy1;
-				g_fv[index_12 + 8]  += vz1;
-				g_fv[index_12 + 9]  += LDG(g_vx, n2);
-				g_fv[index_12 + 10] += LDG(g_vy, n2);
-				g_fv[index_12 + 11] += LDG(g_vz, n2);
+				g_fv[index_12 + 6]  = vx1;
+				g_fv[index_12 + 7]  = vy1;
+				g_fv[index_12 + 8]  = vz1;
+				g_fv[index_12 + 9]  = LDG(g_vx, n2);
+				g_fv[index_12 + 10] = LDG(g_vy, n2);
+				g_fv[index_12 + 11] = LDG(g_vz, n2);
             }
         }
 

--- a/src/pair.cu
+++ b/src/pair.cu
@@ -308,12 +308,12 @@ static __global__ void gpu_find_force
 				g_fv[index_12 + 3]  += f21x;
 				g_fv[index_12 + 4]  += f21y;
 				g_fv[index_12 + 5]  += f21z;
-				g_fv[index_12 + 6]  += vx1;
-				g_fv[index_12 + 7]  += vy1;
-				g_fv[index_12 + 8]  += vz1;
-				g_fv[index_12 + 9]  += LDG(g_vx, n2);
-				g_fv[index_12 + 10] += LDG(g_vy, n2);
-				g_fv[index_12 + 11] += LDG(g_vz, n2);
+				g_fv[index_12 + 6]  = vx1;
+				g_fv[index_12 + 7]  = vy1;
+				g_fv[index_12 + 8]  = vz1;
+				g_fv[index_12 + 9]  = LDG(g_vx, n2);
+				g_fv[index_12 + 10] = LDG(g_vy, n2);
+				g_fv[index_12 + 11] = LDG(g_vz, n2);
 			}
         }
 
@@ -401,7 +401,7 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
-        else if (para->shc.compute)
+        else if (para->shc.compute && !para->hnemd.compute)
         {
             gpu_find_force<0, 0, 1, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
@@ -410,7 +410,7 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
-        else if (para->hnemd.compute)
+        else if (para->hnemd.compute && !para->shc.compute)
         {
             gpu_find_force<0, 0, 0, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
@@ -419,6 +419,15 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
+        else if (para->hnemd.compute && para->shc.compute)
+		{
+			gpu_find_force<0, 0, 1, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
+			(
+				fe_x, fe_y, fe_z, lj_para, ri_para,
+				N, pbc_x, pbc_y, pbc_z, NN, NL, type, x, y, z, vx, vy, vz, box,
+				fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
+			);
+		}
         else
         {
             gpu_find_force<0, 0, 0, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
@@ -442,7 +451,7 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
-        else if (para->shc.compute)
+        else if (para->shc.compute && !para->hnemd.compute)
         {
             gpu_find_force<1, 0, 1, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
@@ -451,7 +460,7 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
-        else if (para->hnemd.compute)
+        else if (para->hnemd.compute && !para->shc.compute)
         {
             gpu_find_force<1, 0, 0, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
@@ -460,6 +469,15 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
+        else if (para->hnemd.compute && para->shc.compute)
+		{
+			gpu_find_force<1, 0, 1, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
+			(
+				fe_x, fe_y, fe_z, lj_para, ri_para,
+				N, pbc_x, pbc_y, pbc_z, NN, NL, type, x, y, z, vx, vy, vz, box,
+				fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
+			);
+		}
         else
         {
             gpu_find_force<1, 0, 0, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
@@ -483,7 +501,7 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
-        else if (para->shc.compute)
+        else if (para->shc.compute && !para->hnemd.compute)
         {
             gpu_find_force<2, 0, 1, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
@@ -492,9 +510,18 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
-        else if (para->hnemd.compute)
+        else if (para->hnemd.compute && !para->shc.compute)
         {
             gpu_find_force<2, 0, 0, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
+            (
+                fe_x, fe_y, fe_z, lj_para, ri_para,
+                N, pbc_x, pbc_y, pbc_z, NN, NL, type, x, y, z, vx, vy, vz, box,
+                fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
+            );
+        }
+        else if (para->hnemd.compute && para->shc.compute)
+        {
+            gpu_find_force<2, 0, 1, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
                 fe_x, fe_y, fe_z, lj_para, ri_para,
                 N, pbc_x, pbc_y, pbc_z, NN, NL, type, x, y, z, vx, vy, vz, box,
@@ -524,7 +551,7 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
-        else if (para->shc.compute)
+        else if (para->shc.compute && !para->hnemd.compute)
         {
             gpu_find_force<3, 0, 1, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
@@ -533,7 +560,7 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
-        else if (para->hnemd.compute)
+        else if (para->hnemd.compute && !para->shc.compute)
         {
             gpu_find_force<3, 0, 0, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
@@ -542,6 +569,15 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
+        else if (para->hnemd.compute && para->shc.compute)
+		{
+			gpu_find_force<3, 0, 1, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
+			(
+				fe_x, fe_y, fe_z, lj_para, ri_para,
+				N, pbc_x, pbc_y, pbc_z, NN, NL, type, x, y, z, vx, vy, vz, box,
+				fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
+			);
+		}
         else
         {
             gpu_find_force<3, 0, 0, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
@@ -565,7 +601,7 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
-        else if (para->shc.compute)
+        else if (para->shc.compute && !para->hnemd.compute)
         {
             gpu_find_force<4, 0, 1, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
@@ -574,7 +610,7 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
-        else if (para->hnemd.compute)
+        else if (para->hnemd.compute && !para->shc.compute)
         {
             gpu_find_force<4, 0, 0, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
@@ -583,6 +619,15 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
+        else if (para->hnemd.compute && para->shc.compute)
+		{
+			gpu_find_force<4, 0, 1, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
+			(
+				fe_x, fe_y, fe_z, lj_para, ri_para,
+				N, pbc_x, pbc_y, pbc_z, NN, NL, type, x, y, z, vx, vy, vz, box,
+				fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
+			);
+		}
         else
         {
             gpu_find_force<4, 0, 0, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
@@ -606,7 +651,7 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
-        else if (para->shc.compute)
+        else if (para->shc.compute && !para->hnemd.compute)
         {
             gpu_find_force<5, 0, 1, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
@@ -615,7 +660,7 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
-        else if (para->hnemd.compute)
+        else if (para->hnemd.compute && !para->shc.compute)
         {
             gpu_find_force<5, 0, 0, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
             (
@@ -624,6 +669,15 @@ void Pair::compute(Parameters *para, GPU_Data *gpu_data)
                 fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
             );
         }
+        else if (para->hnemd.compute && para->shc.compute)
+		{
+			gpu_find_force<5, 0, 1, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
+			(
+				fe_x, fe_y, fe_z, lj_para, ri_para,
+				N, pbc_x, pbc_y, pbc_z, NN, NL, type, x, y, z, vx, vy, vz, box,
+				fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
+			);
+		}
         else
         {
             gpu_find_force<5, 0, 0, 0><<<grid_size, BLOCK_SIZE_FORCE>>>

--- a/src/rebo_mos2.cu
+++ b/src/rebo_mos2.cu
@@ -986,12 +986,12 @@ static __global__ void find_force_step0
 				g_fv[index_12 + 3]  += f21x;
 				g_fv[index_12 + 4]  += f21y;
 				g_fv[index_12 + 5]  += f21z;
-				g_fv[index_12 + 6]  += vx1;
-				g_fv[index_12 + 7]  += vy1;
-				g_fv[index_12 + 8]  += vz1;
-				g_fv[index_12 + 9]  += LDG(g_vx, n2);
-				g_fv[index_12 + 10] += LDG(g_vy, n2);
-				g_fv[index_12 + 11] += LDG(g_vz, n2);
+				g_fv[index_12 + 6]  = vx1;
+				g_fv[index_12 + 7]  = vy1;
+				g_fv[index_12 + 8]  = vz1;
+				g_fv[index_12 + 9]  = LDG(g_vx, n2);
+				g_fv[index_12 + 10] = LDG(g_vy, n2);
+				g_fv[index_12 + 11] = LDG(g_vz, n2);
 			}
         }
 

--- a/src/rebo_mos2.cu
+++ b/src/rebo_mos2.cu
@@ -874,7 +874,8 @@ static __global__ void find_force_step0
     real *g_box, real *g_p,  real *g_pp,
     real *g_fx, real *g_fy, real *g_fz,
     real *g_sx, real *g_sy, real *g_sz, real *g_potential, 
-    real *g_h, int *g_label, int *g_fv_index, real *g_fv 
+    real *g_h, int *g_label, int *g_fv_index, real *g_fv,
+    int *g_a_map, int *g_b_map, int *g_count_b
 )
 {
     int n1 = blockIdx.x * blockDim.x + threadIdx.x + N1; // particle index
@@ -973,25 +974,25 @@ static __global__ void find_force_step0
                 s_h5 += (f21x*vx1+f21y*vy1+f21z*vz1)*z12; // z-all
             } 
 
-            if (cal_q) // heat across some section (NEMD)
-            {
-                int index_12 = g_fv_index[n1] * 12;
-                if (index_12 >= 0 && g_fv_index[n1 + number_of_particles] == n2)
-                {
-                    g_fv[index_12 + 0]  += f12x;
-                    g_fv[index_12 + 1]  += f12y;
-                    g_fv[index_12 + 2]  += f12z;
-                    g_fv[index_12 + 3]  += f21x;
-                    g_fv[index_12 + 4]  += f21y;
-                    g_fv[index_12 + 5]  += f21z;
-                    g_fv[index_12 + 6]  += vx1;
-                    g_fv[index_12 + 7]  += vy1;
-                    g_fv[index_12 + 8]  += vz1;
-                    g_fv[index_12 + 9]  += LDG(g_vx, n2);
-                    g_fv[index_12 + 10] += LDG(g_vy, n2);
-                    g_fv[index_12 + 11] += LDG(g_vz, n2);
-                }  
-            }
+            // accumulate heat across some sections (for NEMD)
+			//		check if AB pair possible & exists
+			if (cal_q && g_a_map[n1] != -1 && g_b_map[n2] != -1 &&
+					g_fv_index[g_a_map[n1] * *(g_count_b) + g_b_map[n2]] != -1)
+			{
+				int index_12 = g_fv_index[g_a_map[n1] * *(g_count_b) + g_b_map[n2]] * 12;
+				g_fv[index_12 + 0]  += f12x;
+				g_fv[index_12 + 1]  += f12y;
+				g_fv[index_12 + 2]  += f12z;
+				g_fv[index_12 + 3]  += f21x;
+				g_fv[index_12 + 4]  += f21y;
+				g_fv[index_12 + 5]  += f21z;
+				g_fv[index_12 + 6]  += vx1;
+				g_fv[index_12 + 7]  += vy1;
+				g_fv[index_12 + 8]  += vz1;
+				g_fv[index_12 + 9]  += LDG(g_vx, n2);
+				g_fv[index_12 + 10] += LDG(g_vy, n2);
+				g_fv[index_12 + 11] += LDG(g_vz, n2);
+			}
         }
 
         g_NN_local[n1] = count; // now the local neighbor list has been built
@@ -1239,8 +1240,12 @@ void REBO_MOS::compute(Parameters *para, GPU_Data *gpu_data)
     real *sz = gpu_data->virial_per_atom_z; 
     real *pe = gpu_data->potential_per_atom;
     real *h = gpu_data->heat_per_atom;   
+
     int *label = gpu_data->label;
     int *fv_index = gpu_data->fv_index;
+    int *a_map = gpu_data->a_map;
+	int *b_map = gpu_data->b_map;
+	int *count_b = gpu_data->count_b;
     real *fv = gpu_data->fv; 
 
     real fe_x = para->hnemd.fe_x;
@@ -1261,40 +1266,50 @@ void REBO_MOS::compute(Parameters *para, GPU_Data *gpu_data)
 
         find_force_step0<1, 0, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
         (
-            fe_x, fe_y, fe_z, 
-            N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, NN_local, NL_local, type, 
-            x, y, z, vx, vy, vz, box, p, pp,
-            fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv
+			fe_x, fe_y, fe_z,
+			N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, NN_local, NL_local, type,
+			x, y, z, vx, vy, vz, box, p, pp, fx, fy, fz,
+			sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
-    else if (para->hnemd.compute)
+    else if (para->hnemd.compute && !para->shc.compute)
     {
         find_force_step0<0, 0, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
         (
-            fe_x, fe_y, fe_z, 
-            N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, NN_local, NL_local, type, 
-            x, y, z, vx, vy, vz, box, p, pp,
-            fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv
+			fe_x, fe_y, fe_z,
+			N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, NN_local, NL_local, type,
+			x, y, z, vx, vy, vz, box, p, pp, fx, fy, fz,
+			sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
-    else if (para->shc.compute)
+    else if (para->shc.compute && !para->hnemd.compute)
     {
         find_force_step0<0, 1, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
         (
-            fe_x, fe_y, fe_z, 
-            N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, NN_local, NL_local, type, 
-            x, y, z, vx, vy, vz, box, p, pp,
-            fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv
+			fe_x, fe_y, fe_z,
+			N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, NN_local, NL_local, type,
+			x, y, z, vx, vy, vz, box, p, pp, fx, fy, fz,
+			sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
+    else if (para->shc.compute && para->hnemd.compute)
+	{
+		find_force_step0<0, 1, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
+		(
+			fe_x, fe_y, fe_z,
+			N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, NN_local, NL_local, type,
+			x, y, z, vx, vy, vz, box, p, pp, fx, fy, fz,
+			sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
+		);
+	}
     else
     {
         find_force_step0<0, 0, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
         (
-            fe_x, fe_y, fe_z, 
-            N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, NN_local, NL_local, type, 
-            x, y, z, vx, vy, vz, box, p, pp,
-            fx, fy, fz, sx, sy, sz, pe, h, label, fv_index, fv
+			fe_x, fe_y, fe_z,
+			N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, NN_local, NL_local, type,
+			x, y, z, vx, vy, vz, box, p, pp, fx, fy, fz,
+			sx, sy, sz, pe, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
 
@@ -1316,12 +1331,12 @@ void REBO_MOS::compute(Parameters *para, GPU_Data *gpu_data)
         find_force_many_body<1, 0, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
         (
             fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, 
-            NN_local, NL_local, 
-            f12x, f12y, f12z, x, y, z, vx, vy, vz, 
-            box, fx, fy, fz, sx, sy, sz, h, label, fv_index, fv
+            NN_local, NL_local, f12x, f12y, f12z,
+            x, y, z, vx, vy, vz, box, fx, fy, fz,
+            sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
-    else if (para->hnemd.compute)
+    else if (para->hnemd.compute && !para->shc.compute)
     {
         find_force_step2<<<grid_size, BLOCK_SIZE_FORCE>>>
         (
@@ -1330,13 +1345,13 @@ void REBO_MOS::compute(Parameters *para, GPU_Data *gpu_data)
         );
         find_force_many_body<0, 0, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
         (
-            fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, 
-            NN_local, NL_local, 
-            f12x, f12y, f12z, x, y, z, vx, vy, vz, 
-            box, fx, fy, fz, sx, sy, sz, h, label, fv_index, fv
+			fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z,
+			NN_local, NL_local, f12x, f12y, f12z,
+			x, y, z, vx, vy, vz, box, fx, fy, fz,
+			sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
-    else if (para->shc.compute)
+    else if (para->shc.compute && !para->hnemd.compute)
     {
         find_force_step2<<<grid_size, BLOCK_SIZE_FORCE>>>
         (
@@ -1345,10 +1360,25 @@ void REBO_MOS::compute(Parameters *para, GPU_Data *gpu_data)
         );
         find_force_many_body<0, 1, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
         (
-            fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, 
-            NN_local, NL_local, 
-            f12x, f12y, f12z, x, y, z, vx, vy, vz, 
-            box, fx, fy, fz, sx, sy, sz, h, label, fv_index, fv
+			fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z,
+			NN_local, NL_local, f12x, f12y, f12z,
+			x, y, z, vx, vy, vz, box, fx, fy, fz,
+			sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
+        );
+    }
+    else if (para->shc.compute && para->hnemd.compute)
+    {
+        find_force_step2<<<grid_size, BLOCK_SIZE_FORCE>>>
+        (
+            N, N1, N2, pbc_x, pbc_y, pbc_z, NN_local, NL_local, type,
+            b, bp, pp, x, y, z, box, pe, f12x, f12y, f12z
+        );
+        find_force_many_body<0, 1, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
+        (
+			fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z,
+			NN_local, NL_local, f12x, f12y, f12z,
+			x, y, z, vx, vy, vz, box, fx, fy, fz,
+			sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
     else
@@ -1360,10 +1390,10 @@ void REBO_MOS::compute(Parameters *para, GPU_Data *gpu_data)
         );
         find_force_many_body<0, 0, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
         (
-            fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, 
-            NN_local, NL_local, 
-            f12x, f12y, f12z, x, y, z, vx, vy, vz, 
-            box, fx, fy, fz, sx, sy, sz, h, label, fv_index, fv
+			fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z,
+			NN_local, NL_local, f12x, f12y, f12z,
+			x, y, z, vx, vy, vz, box, fx, fy, fz,
+			sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
 }

--- a/src/sw.cu
+++ b/src/sw.cu
@@ -477,8 +477,11 @@ void SW2::compute(Parameters *para, GPU_Data *gpu_data)
     real *h = gpu_data->heat_per_atom; 
     
     int *label = gpu_data->label;
-    int *fv_index = gpu_data->fv_index;
-    real *fv = gpu_data->fv;
+	int *fv_index = gpu_data->fv_index;
+	int *a_map = gpu_data->a_map;
+	int *b_map = gpu_data->b_map;
+	int *count_b = gpu_data->count_b;
+	real *fv = gpu_data->fv;
 
     real *f12x = sw2_data.f12x; 
     real *f12y = sw2_data.f12y; 
@@ -500,12 +503,12 @@ void SW2::compute(Parameters *para, GPU_Data *gpu_data)
 
         find_force_many_body<1, 0, 0><<<grid_size, BLOCK_SIZE_SW>>>
         (
-            fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, 
-            f12x, f12y, f12z, x, y, z, vx, vy, vz, 
-            box_length, fx, fy, fz, sx, sy, sz, h, label, fv_index, fv
+			fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL,
+			f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz,
+			sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
-    else if (para->hnemd.compute)
+    else if (para->hnemd.compute && !para->shc.compute)
     {
         gpu_find_force_sw3_partial<<<grid_size, BLOCK_SIZE_SW>>> 
         (
@@ -515,12 +518,12 @@ void SW2::compute(Parameters *para, GPU_Data *gpu_data)
 
         find_force_many_body<0, 0, 1><<<grid_size, BLOCK_SIZE_SW>>>
         (
-            fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, 
-            f12x, f12y, f12z, x, y, z, vx, vy, vz, 
-            box_length, fx, fy, fz, sx, sy, sz, h, label, fv_index, fv
+			fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL,
+			f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz,
+			sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
-    else if (para->shc.compute)
+    else if (para->shc.compute && !para->hnemd.compute)
     {
         gpu_find_force_sw3_partial<<<grid_size, BLOCK_SIZE_SW>>> 
         (
@@ -530,9 +533,24 @@ void SW2::compute(Parameters *para, GPU_Data *gpu_data)
 
         find_force_many_body<0, 1, 0><<<grid_size, BLOCK_SIZE_SW>>>
         (
-            fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, 
-            f12x, f12y, f12z, x, y, z, vx, vy, vz, 
-            box_length, fx, fy, fz, sx, sy, sz, h, label, fv_index, fv
+			fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL,
+			f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz,
+			sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
+        );
+    }
+    else if (para->shc.compute && para->hnemd.compute)
+    {
+        gpu_find_force_sw3_partial<<<grid_size, BLOCK_SIZE_SW>>>
+        (
+            N, N1, N2, pbc_x, pbc_y, pbc_z, sw2_para, NN, NL, type, x, y, z,
+            box_length, pe, f12x, f12y, f12z
+        );
+
+        find_force_many_body<0, 1, 1><<<grid_size, BLOCK_SIZE_SW>>>
+        (
+			fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL,
+			f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz,
+			sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
     else
@@ -546,8 +564,8 @@ void SW2::compute(Parameters *para, GPU_Data *gpu_data)
         find_force_many_body<0, 0, 0><<<grid_size, BLOCK_SIZE_SW>>>
         (
             fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, 
-            f12x, f12y, f12z, x, y, z, vx, vy, vz, 
-            box_length, fx, fy, fz, sx, sy, sz, h, label, fv_index, fv
+            f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz,
+            sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
 

--- a/src/tersoff.cu
+++ b/src/tersoff.cu
@@ -590,6 +590,9 @@ void Tersoff2::compute(Parameters *para, GPU_Data *gpu_data)
     
     int *label = gpu_data->label;
     int *fv_index = gpu_data->fv_index;
+    int *a_map = gpu_data->a_map;
+    int *b_map = gpu_data->b_map;
+    int *count_b = gpu_data->count_b;
     real *fv = gpu_data->fv;
 
     real *f12x = tersoff_data.f12x;
@@ -601,7 +604,7 @@ void Tersoff2::compute(Parameters *para, GPU_Data *gpu_data)
     real fe_x = para->hnemd.fe_x;
     real fe_y = para->hnemd.fe_y;
     real fe_z = para->hnemd.fe_z;
-    
+
     find_force_tersoff_step1<<<grid_size, BLOCK_SIZE_FORCE>>>
     (       
         N, N1, N2, pbc_x, pbc_y, pbc_z, 
@@ -621,7 +624,7 @@ void Tersoff2::compute(Parameters *para, GPU_Data *gpu_data)
         (
             fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, 
             f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz, 
-            sx, sy, sz, h, label, fv_index, fv
+            sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
     else if (para->hnemd.compute && !para->shc.compute)
@@ -634,9 +637,9 @@ void Tersoff2::compute(Parameters *para, GPU_Data *gpu_data)
         );
         find_force_many_body<0, 0, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
         (
-            fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, 
-            f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz, 
-            sx, sy, sz, h, label, fv_index, fv
+			fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL,
+			f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz,
+			sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
     else if (para->shc.compute && !para->hnemd.compute)
@@ -649,9 +652,9 @@ void Tersoff2::compute(Parameters *para, GPU_Data *gpu_data)
         );
         find_force_many_body<0, 1, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
         (
-            fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, 
-            f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz, 
-            sx, sy, sz, h, label, fv_index, fv
+			fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL,
+			f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz,
+			sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
     else if (para->shc.compute && para->hnemd.compute)
@@ -664,9 +667,9 @@ void Tersoff2::compute(Parameters *para, GPU_Data *gpu_data)
         );
         find_force_many_body<0, 1, 1><<<grid_size, BLOCK_SIZE_FORCE>>>
         (
-            fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, 
-            f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz, 
-            sx, sy, sz, h, label, fv_index, fv
+			fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL,
+			f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz,
+			sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
     else // no heat transport calculation
@@ -679,9 +682,9 @@ void Tersoff2::compute(Parameters *para, GPU_Data *gpu_data)
         );
         find_force_many_body<0, 0, 0><<<grid_size, BLOCK_SIZE_FORCE>>>
         (
-            fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL, 
-            f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz, 
-            sx, sy, sz, h, label, fv_index, fv
+			fe_x, fe_y, fe_z, N, N1, N2, pbc_x, pbc_y, pbc_z, NN, NL,
+			f12x, f12y, f12z, x, y, z, vx, vy, vz, box_length, fx, fy, fz,
+			sx, sy, sz, h, label, fv_index, fv, a_map, b_map, count_b
         );
     }
 

--- a/src/vashishta.cu
+++ b/src/vashishta.cu
@@ -473,12 +473,12 @@ static __global__ void gpu_find_force_vashishta_2body
 				g_fv[index_12 + 3]  += f21x;
 				g_fv[index_12 + 4]  += f21y;
 				g_fv[index_12 + 5]  += f21z;
-				g_fv[index_12 + 6]  += vx1;
-				g_fv[index_12 + 7]  += vy1;
-				g_fv[index_12 + 8]  += vz1;
-				g_fv[index_12 + 9]  += LDG(g_vx, n2);
-				g_fv[index_12 + 10] += LDG(g_vy, n2);
-				g_fv[index_12 + 11] += LDG(g_vz, n2);
+				g_fv[index_12 + 6]  = vx1;
+				g_fv[index_12 + 7]  = vy1;
+				g_fv[index_12 + 8]  = vz1;
+				g_fv[index_12 + 9]  = LDG(g_vx, n2);
+				g_fv[index_12 + 10] = LDG(g_vy, n2);
+				g_fv[index_12 + 11] = LDG(g_vz, n2);
 			}
         }
 


### PR DESCRIPTION
- Modified/added data structures, for eq. 3.114 in the GPUMD manual, to support any material. Previous code was optimized for graphene. 
- Changed 'int' to 'unsigned long long' to avoid overflow while indexing fv_all (based on previous bullet's changes).
- Updated conditions to allow for SHC + HNEMD 