### PR TITLE
Tersoff1988 optimization

### DIFF
--- a/src/tersoff1988.cu
+++ b/src/tersoff1988.cu
@@ -290,9 +290,17 @@ static __device__ void find_e_and_ep
 	if (LDG(ters, i + ALPHA) == 0.0){ e = ONE; ep = ZERO;}
 	else
 	{
-		e = exp(LDG(ters, i + ALPHA) * pow(d12 - d13, LDG(ters, i + M)));
-		ep = LDG(ters, i + ALPHA) * LDG(ters, i + M) *
-				pow(d12 - d13, LDG(ters, i + M) - ONE)*e;
+		real r = d12 - d13;
+		if (LDG(ters, i + M) == 3.0)
+		{
+			e = exp(LDG(ters, i + ALPHA) * r * r * r);
+			ep = LDG(ters, i + ALPHA) * THREE * r * r * e;
+		}
+		else
+		{
+			e = exp(LDG(ters, i + ALPHA) * r);
+			ep = LDG(ters, i + ALPHA) * e;
+		}
 	}
 }
 
@@ -310,7 +318,9 @@ static __device__ void find_e
 	if (LDG(ters, i + ALPHA) == 0.0){ e = ONE;}
 	else
 	{
-		e = exp(LDG(ters, i + ALPHA) * pow(d12 - d13, LDG(ters, i + M)));
+		real r = d12 - d13;
+		if (LDG(ters, i + M) == 3.0){ e = exp(LDG(ters, i + ALPHA) * r * r * r);}
+		else{e = exp(LDG(ters, i + ALPHA) * r);}
 	}
 }
 


### PR DESCRIPTION
This work is simply an optimization update to the Tersoff1988 potential. A switch to reading the Tersoff parameters from texture memory instead of global memory has been made as well as optimizations to the exponential term functions from the three-body interaction part of the potential. The potential still gives a force match to LAMMPS for four different, perturbed systems (SiC, BNC, GaN, Stanene; all used in original Tersoff1988 pull request https://github.com/brucefan1983/GPUMD/pull/15). 

A simple test script is used to gauge the performance benefit of the changes (excluding potential line):
velocity	        300
ensemble	nvt_ber 300 300 0.01
time_step	0.5
run 		10000

Performance: (system: old -> new -> % faster)
Stanene: 1.81763 Sec -> 1.23766 Sec -> ~47% faster
BNC: 2.47423 Sec -> 1.43466 Sec -> ~72% faster
SiC: 3.91685 Sec -> 1.76474 Sec -> ~122% faster
GaN: 30.0284 Sec -> 12.485 Sec -> ~140% faster

In addition to optimizations, some parameter checking has been added. This is a natural addition to the code for this pull request as we already need to ensure that the parameter _m_  is either 1 or 3 (might as well add the others).