### PR TITLE
Update random number generator seed

### DIFF
--- a/src/main.cu
+++ b/src/main.cu
@@ -82,7 +82,9 @@ void print_compile_information(void)
 #ifdef DEBUG
     printf("DEBUG is on: Use a fixed PRNG seed for different runs.\n");
 #else
-    srand(time(NULL));
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    srand((time_t)ts.tv_nsec); // ns random number
     printf("DEBUG is off: Use different PRNG seeds for different runs.\n");
 #endif
 #ifdef ZHEN_LI


### PR DESCRIPTION
For cluster GPUMD submissions, multiple simulations were starting during the exact same second causing the random number generators to output identical numbers. This small change now makes it such that the seed is based on nanoseconds instead of seconds, greatly reducing the chance of running identical simulations.