### PR TITLE
GKMA - keyword syntax, heat current decomposition, output format specifier

### DIFF
--- a/src/gkma.cu
+++ b/src/gkma.cu
@@ -581,7 +581,7 @@ void GKMA::process(int step, Atom *atom)
     FILE *fid = fopen(gkma_file_position, "a");
     for (int i = 0; i < num_bins; i++)
     {
-        fprintf(fid, "%25.15e %25.15e %25.15e %25.15e %25.15e\n",
+        fprintf(fid, "%g %g %g %g %g\n",
          bin_out[i], bin_out[i+num_bins], bin_out[i+2*num_bins],
          bin_out[i+3*num_bins], bin_out[i+4*num_bins]);
     }

--- a/src/gkma.cuh
+++ b/src/gkma.cuh
@@ -22,8 +22,7 @@ class GKMA
 {
 public:
     int compute = 0;
-    int sample_interval;// number of time steps per heat current computation
-    int output_interval;// number of time steps to output average heat current
+    int sample_interval;// steps per heat current computation and output
     int first_mode;     // first mode to consider
     int last_mode;      // last mode to consider
     int bin_size;       // number of modes per bin
@@ -51,7 +50,6 @@ public:
     void postprocess();
 
 private:
-    int samples_per_output;// samples to be averaged for output
     int num_bins;          // number of bins to output
     int N1;                // Atom starting index
     int N2;                // Atom ending index

--- a/src/parse.cu
+++ b/src/parse.cu
@@ -885,30 +885,29 @@ void parse_compute_gkma(char **param, int num_param, Measure* measure, Atom* ato
      * -- Works for types only, not groups --
      */
 
-    if (num_param != 7 && num_param != 10)
+    if (num_param != 6 && num_param != 9)
     {
         print_error("compute_gkma should have 6 parameters.\n");
     }
     if (!is_valid_int(param[1], &measure->gkma.sample_interval) ||
-        !is_valid_int(param[2], &measure->gkma.output_interval) ||
-        !is_valid_int(param[3], &measure->gkma.first_mode)      ||
-        !is_valid_int(param[4], &measure->gkma.last_mode)       )
+        !is_valid_int(param[2], &measure->gkma.first_mode)      ||
+        !is_valid_int(param[3], &measure->gkma.last_mode)       )
     {
         print_error("A parameter for GKMA should be an integer.\n");
     }
 
-    if (strcmp(param[5], "bin_size") == 0)
+    if (strcmp(param[4], "bin_size") == 0)
     {
         measure->gkma.f_flag = 0;
-        if(!is_valid_int(param[6], &measure->gkma.bin_size))
+        if(!is_valid_int(param[5], &measure->gkma.bin_size))
         {
             print_error("GKMA bin_size must be an integer.\n");
         }
     }
-    else if (strcmp(param[5], "f_bin_size") == 0)
+    else if (strcmp(param[4], "f_bin_size") == 0)
     {
         measure->gkma.f_flag = 1;
-        if(!is_valid_real(param[6], &measure->gkma.f_bin_size))
+        if(!is_valid_real(param[5], &measure->gkma.f_bin_size))
         {
             print_error("GKMA f_bin_size must be a real number.\n");
         }
@@ -920,22 +919,15 @@ void parse_compute_gkma(char **param, int num_param, Measure* measure, Atom* ato
 
     GKMA *g = &measure->gkma;
     // Parameter checking
-    if (g->sample_interval < 1 || g->output_interval < 1 || g->first_mode < 1 ||
-            g->last_mode < 1)
+    if (g->sample_interval < 1  || g->first_mode < 1 || g->last_mode < 1)
         print_error("compute_gkma parameters must be positive integers.\n");
-    if (g->sample_interval > g->output_interval)
-        print_error("sample_interval <= output_interval required.\n");
     if (g->first_mode > g->last_mode)
         print_error("first_mode <= last_mode required.\n");
-    if (g->output_interval % g->sample_interval != 0)
-        print_error("sample_interval must divide output_interval an integer\n"
-                " number of times.\n");
 
     printf("    sample_interval is %d.\n"
-           "    output_interval is %d.\n"
            "    first_mode is %d.\n"
            "    last_mode is %d.\n",
-          g->sample_interval, g->output_interval, g->first_mode, g->last_mode);
+          g->sample_interval, g->first_mode, g->last_mode);
 
     if (g->f_flag)
     {
@@ -961,12 +953,12 @@ void parse_compute_gkma(char **param, int num_param, Measure* measure, Atom* ato
 
 
     // Hidden feature implementation
-    if (num_param == 10)
+    if (num_param == 9)
     {
-        if (strcmp(param[7], "atom_range") == 0)
+        if (strcmp(param[6], "atom_range") == 0)
         {
-            if(!is_valid_int(param[8], &measure->gkma.atom_begin) ||
-               !is_valid_int(param[9], &measure->gkma.atom_end))
+            if(!is_valid_int(param[7], &measure->gkma.atom_begin) ||
+               !is_valid_int(param[8], &measure->gkma.atom_end))
             {
                 print_error("GKMA atom_begin & atom_end must be integers.\n");
             }


### PR DESCRIPTION
This is a simple update to the previously merged GKMA pull request (#41). The changes to the GKMA method are:

1. Removed the *output_interval* argument from the *compute_gkma* keyword. Averaging multiple heat flux samples per output seemed like a bad idea. Now there is one output for every sample at *sample_interval*.
2. Decomposed the heat flux into the in-plane and out-of-plane contributions for the *x* and *y* directions. This is the same decomposition used in the EMD and HNEMD methods.
3. Changed the output format specifier from %25.15e to %g. The GKMA heat flux only matched the true heat flux out to 1e-7 which should be captured with the %g specifier. This change can save space and I have not seen any noticeable changes in thermal conductivity calculations.

Below are some revisions of the usage and outputs:

**compute_gkma** *sample_interval* *first_mode* *last_mode* *bin_option* *bin_size*

with argument definitions of:
-   sample_interval = interval (in number of steps) used to compute the heat modal heat flux.
-   first_mode = First mode to include in calculation based on the eigenvector.out file.
-   last_mode = Last mode to include in calculation based on the eigenvector.out file.
-   bin_option = Which binning technique to use: 'bin_size' or 'f_bin_size' are current option.
-   bin_size = If bin_option = 'bin_size', then this is an integer describing how many modes are included per bin. If bin_option = 'f_bin_size', then binning by frequency is used and this is a float describing the bin size in THz.

For n bins, the output will look like (Ex: jx_outputNum_mode):
jxin_1_1, jxout_1_1, jyin_1_1, jyout_1_1, jz_1_1
jxin_1_2, jxout_1_2, jyin_1_2, jyout_1_2, jz_1_2
...
jxin_1_n, jxout_1_n, jyin_1_n, jyout_1_n, jz_1_n
jxin_2_1, jxout_2_1, jyin_2_1, jyout_2_1, jz_2_1
jxin_2_2, jxout_2_2, jyin_2_2, jyout_2_2, jz_2_2
...

Output will be found in heatmode.out.

Please let me know what you think of these changes or if you have any problems/suggestions. 