### PR TITLE
HNEMA - Modal Analysis for HNEMD

### DIFF
--- a/src/hnema.cu
+++ b/src/hnema.cu
@@ -602,7 +602,7 @@ void HNEMA::process(int step, Atom *atom, Integrate *integrate, real fe)
     FILE *fid = fopen(hnema_file_position, "a");
     for (int i = 0; i < num_bins; i++)
     {
-        fprintf(fid, "%25.15f %25.15f %25.15f %25.15f %25.15f\n",
+        fprintf(fid, "%g %g %g %g %g\n",
                 bin_out[i], bin_out[i+num_bins], bin_out[i+2*num_bins],
                          bin_out[i+3*num_bins], bin_out[i+4*num_bins]);
     }

--- a/src/hnema.cu
+++ b/src/hnema.cu
@@ -1,0 +1,546 @@
+/*
+    Copyright 2017 Zheyong Fan, Ville Vierimaa, Mikko Ervasti, and Ari Harju
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*----------------------------------------------------------------------------80
+Homogeneous Non-Equilibrium Modal Analysis (HNEMA)
+An extension of the HNEMD method to decompose thermal conductivity into
+modal contributions
+
+GPUMD Contributing author: Alexander Gabourie (Stanford University)
+------------------------------------------------------------------------------*/
+
+#include "hnema.cuh"
+#include "atom.cuh"
+#include <fstream>
+#include <string>
+#include <iostream>
+#include <sstream>
+
+#define BLOCK_SIZE 128
+#define ACCUM_BLOCK 1024
+#define BIN_BLOCK 128
+#define BLOCK_SIZE_FORCE 64
+#define BLOCK_SIZE_GK 16
+
+static __global__ void gpu_reset_data
+(
+        int num_elements, real* data
+)
+{
+    int n = blockIdx.x * blockDim.x + threadIdx.x;
+    if (n < num_elements)
+    {
+        data[n] = ZERO;
+    }
+}
+
+static __global__ void gpu_average_jm
+(
+        int num_elements, int samples_per_output, real* jm
+)
+{
+    int n = blockIdx.x * blockDim.x + threadIdx.x;
+    if (n < num_elements)
+    {
+        jm[n]/=(float)samples_per_output;
+    }
+}
+
+static __global__ void gpu_hnema_reduce
+(
+        int num_participating, int num_modes,
+        const real* __restrict__ data_n,
+        real* data
+)
+{
+    int tid = threadIdx.x;
+    int bid = blockIdx.x;
+    int number_of_patches = (num_participating - 1) / ACCUM_BLOCK + 1;
+
+    __shared__ real s_data_x[ACCUM_BLOCK];
+    __shared__ real s_data_y[ACCUM_BLOCK];
+    __shared__ real s_data_z[ACCUM_BLOCK];
+    s_data_x[tid] = ZERO;
+    s_data_y[tid] = ZERO;
+    s_data_z[tid] = ZERO;
+
+    for (int patch = 0; patch < number_of_patches; ++patch)
+    {
+        int n = tid + patch * ACCUM_BLOCK;
+        if (n < num_participating)
+        {
+            s_data_x[tid] += data_n[n + bid*num_participating ];
+            s_data_y[tid] += data_n[n + (bid + num_modes)*num_participating];
+            s_data_z[tid] += data_n[n + (bid + 2*num_modes)*num_participating];
+        }
+    }
+
+    __syncthreads();
+    #pragma unroll
+    for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1)
+    {
+        if (tid < offset)
+        {
+            s_data_x[tid] += s_data_x[tid + offset];
+            s_data_y[tid] += s_data_y[tid + offset];
+            s_data_z[tid] += s_data_z[tid + offset];
+        }
+        __syncthreads();
+    }
+    if (tid == 0)
+    {
+        data[bid] = s_data_x[0];
+        data[bid + num_modes] = s_data_y[0];
+        data[bid + 2*num_modes] = s_data_z[0];
+    }
+
+}
+
+static __global__ void gpu_calc_xdotn
+(
+        int num_participating, int N1, int N2, int num_modes,
+        const real* __restrict__ g_vx,
+        const real* __restrict__ g_vy,
+        const real* __restrict__ g_vz,
+        const real* __restrict__ g_mass,
+        const real* __restrict__ g_eig,
+        real* g_xdotn
+)
+{
+    int neig = blockIdx.x * blockDim.x + threadIdx.x;
+    int nglobal = neig + N1;
+    int nm = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (nglobal >= N1 && nglobal < N2 && nm < num_modes)
+    {
+
+        real vx1, vy1, vz1;
+        vx1 = LDG(g_vx, nglobal);
+        vy1 = LDG(g_vy, nglobal);
+        vz1 = LDG(g_vz, nglobal);
+
+        real sqrtmass = sqrt(LDG(g_mass, nglobal));
+        g_xdotn[neig + nm*num_participating] =
+                sqrtmass*g_eig[neig + nm*3*num_participating]*vx1;
+        g_xdotn[neig + (nm + num_modes)*num_participating] =
+                sqrtmass*g_eig[neig + (1 + nm*3)*num_participating]*vy1;
+        g_xdotn[neig + (nm + 2*num_modes)*num_participating] =
+                sqrtmass*g_eig[neig + (2 + nm*3)*num_participating]*vz1;
+    }
+}
+
+
+static __device__ void gpu_bin_reduce
+(
+       int num_modes, int bin_size, int shift, int num_bins,
+       int tid, int bid, int number_of_patches,
+       const real* __restrict__ g_jm,
+       real* bin_out
+)
+{
+    __shared__ real s_data_x[BIN_BLOCK];
+    __shared__ real s_data_y[BIN_BLOCK];
+    __shared__ real s_data_z[BIN_BLOCK];
+    s_data_x[tid] = ZERO;
+    s_data_y[tid] = ZERO;
+    s_data_z[tid] = ZERO;
+
+    for (int patch = 0; patch < number_of_patches; ++patch)
+    {
+        int n = tid + patch * BIN_BLOCK;
+        if (n < bin_size)
+        {
+            s_data_x[tid] += g_jm[n + shift];
+            s_data_y[tid] += g_jm[n + shift + num_modes];
+            s_data_z[tid] += g_jm[n + shift + 2*num_modes];
+        }
+    }
+
+    __syncthreads();
+    #pragma unroll
+    for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1)
+    {
+        if (tid < offset)
+        {
+            s_data_x[tid] += s_data_x[tid + offset];
+            s_data_y[tid] += s_data_y[tid + offset];
+            s_data_z[tid] += s_data_z[tid + offset];
+        }
+        __syncthreads();
+    }
+    if (tid == 0)
+    {
+        bin_out[bid] = s_data_x[0];
+        bin_out[bid + num_bins] = s_data_y[0];
+        bin_out[bid + 2*num_bins] = s_data_z[0];
+    }
+}
+
+static __global__ void gpu_bin_modes
+(
+       int num_modes, int bin_size, int num_bins,
+       const real* __restrict__ g_jm,
+       real* bin_out
+)
+{
+    int tid = threadIdx.x;
+    int bid = blockIdx.x;
+    int number_of_patches = (bin_size - 1) / BIN_BLOCK + 1;
+    int shift = bid*bin_size;
+
+    gpu_bin_reduce
+    (
+           num_modes, bin_size, shift, num_bins,
+           tid, bid, number_of_patches, g_jm, bin_out
+    );
+
+}
+
+static __global__ void gpu_bin_frequencies
+(
+       int num_modes,
+       const int* __restrict__ bin_count,
+       const int* __restrict__ bin_sum,
+       int num_bins,
+       const real* __restrict__ g_jm,
+       real* bin_out
+)
+{
+    int tid = threadIdx.x;
+    int bid = blockIdx.x;
+    int bin_size = bin_count[bid];
+    int shift = bin_sum[bid];
+    int number_of_patches = (bin_size - 1) / BIN_BLOCK + 1;
+
+    gpu_bin_reduce
+    (
+           num_modes, bin_size, shift, num_bins,
+           tid, bid, number_of_patches, g_jm, bin_out
+    );
+
+}
+
+static __global__ void gpu_find_hnema_jmn
+(
+    int num_participating, int N1, int N2,
+    const real* __restrict__ sxx,
+    const real* __restrict__ sxy,
+    const real* __restrict__ sxz,
+    const real* __restrict__ syx,
+    const real* __restrict__ syy,
+    const real* __restrict__ syz,
+    const real* __restrict__ szx,
+    const real* __restrict__ szy,
+    const real* __restrict__ szz,
+    const real* __restrict__ g_mass,
+    const real* __restrict__ g_eig,
+    const real* __restrict__ g_xdot,
+    real* g_jmn,
+    int num_modes
+)
+{
+    int neig = blockIdx.x * blockDim.x + threadIdx.x;
+    int nglobal = neig + N1;
+    int nm = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (nglobal >= N1 && nglobal < N2 && nm < num_modes)
+    {
+        real vx_gk, vy_gk, vz_gk;
+        real rsqrtmass = rsqrt(LDG(g_mass, nglobal));
+
+        vx_gk=rsqrtmass*g_eig[neig + nm*3*num_participating]*g_xdot[nm];
+        vy_gk=rsqrtmass*g_eig[neig + (1 + nm*3)*num_participating]
+                              *g_xdot[nm + num_modes];
+        vz_gk=rsqrtmass*g_eig[neig + (2 + nm*3)*num_participating]
+                              *g_xdot[nm + 2*num_modes];
+
+        g_jmn[neig + nm*num_participating] =
+                sxx[nglobal] * vx_gk + sxy[nglobal] * vy_gk + sxz[nglobal] * vz_gk; // x-all
+        g_jmn[neig + (nm+num_modes)*num_participating] =
+                syx[nglobal] * vx_gk + syy[nglobal] * vy_gk + syz[nglobal] * vz_gk; // y-all
+        g_jmn[neig + (nm+2*num_modes)*num_participating] =
+                szx[nglobal] * vx_gk + szy[nglobal] * vy_gk + szz[nglobal] * vz_gk; // z-all
+
+    }
+}
+
+void HNEMA::compute_hnema_heat(Atom *atom)
+{
+    dim3 grid, block;
+    int gk_grid_size = (num_modes - 1)/BLOCK_SIZE_GK + 1;
+    int grid_size = (N2 - N1 - 1) / BLOCK_SIZE_FORCE + 1;
+    block.x = BLOCK_SIZE_FORCE; grid.x = grid_size;
+    block.y = BLOCK_SIZE_GK;    grid.y = gk_grid_size;
+    block.z = 1;                grid.z = 1;
+    gpu_calc_xdotn<<<grid, block>>>
+    (
+        num_participating, N1, N2, num_modes,
+        atom->vx, atom->vy, atom->vz,
+        atom->mass, eig, xdotn
+    );
+    CUDA_CHECK_KERNEL
+
+    gpu_hnema_reduce<<<num_modes, ACCUM_BLOCK>>>
+    (
+        num_participating, num_modes, xdotn, xdot
+    );
+    CUDA_CHECK_KERNEL
+
+
+    gpu_find_hnema_jmn<<<grid, block>>>
+    (
+        num_participating, N1, N2,
+        atom->virial_per_atom,
+        atom->virial_per_atom + atom->N * 3,
+        atom->virial_per_atom + atom->N * 4,
+        atom->virial_per_atom + atom->N * 6,
+        atom->virial_per_atom + atom->N * 1,
+        atom->virial_per_atom + atom->N * 5,
+        atom->virial_per_atom + atom->N * 7,
+        atom->virial_per_atom + atom->N * 8,
+        atom->virial_per_atom + atom->N * 2,
+        atom->mass, eig, xdot, jmn, num_modes
+    );
+    CUDA_CHECK_KERNEL
+}
+
+void HNEMA::setN(Atom *atom)
+{
+    N1 = 0;
+    N2 = 0;
+    for (int n = 0; n < atom_begin; ++n)
+    {
+        N1 += atom->cpu_type_size[n];
+    }
+    for (int n = atom_begin; n <= atom_end; ++n)
+    {
+        N2 += atom->cpu_type_size[n];
+    }
+
+    num_participating = N2 - N1;
+}
+
+void HNEMA::preprocess(char *input_dir, Atom *atom)
+{
+    if (!compute) return;
+        num_modes = last_mode-first_mode+1;
+        samples_per_output = output_interval/sample_interval;
+        setN(atom);
+
+        strcpy(hnema_file_position, input_dir);
+        strcat(hnema_file_position, "/kappamode.out");
+
+        CHECK(cudaMallocManaged((void **)&eig,
+                sizeof(real) * num_participating * num_modes * 3));
+
+        // initialize eigenvector data structures
+        strcpy(eig_file_position, input_dir);
+        strcat(eig_file_position, "/eigenvector.out");
+        std::ifstream eigfile;
+        eigfile.open(eig_file_position);
+        if (!eigfile)
+        {
+            print_error("Cannot open eigenvector.out file.\n");
+        }
+
+        // GPU phonon code output format
+        std::string val;
+        double doubleval;
+
+        // Setup binning
+        if (f_flag)
+        {
+            real *f;
+            CHECK(cudaMallocManaged((void **)&f, sizeof(real)*num_modes));
+            getline(eigfile, val);
+            std::stringstream ss(val);
+            for (int i=0; i<first_mode-1; i++) { ss >> f[0]; }
+            real temp;
+            for (int i=0; i<num_modes; i++)
+            {
+                ss >> temp;
+                f[i] = copysign(sqrt(abs(temp))/(2.0*PI), temp);
+            }
+            real fmax, fmin; // freq are in ascending order in file
+            int shift;
+            fmax = (floor(abs(f[num_modes-1])/f_bin_size)+1)*f_bin_size;
+            fmin = floor(abs(f[0])/f_bin_size)*f_bin_size;
+            shift = floor(abs(fmin)/f_bin_size);
+            num_bins = floor((fmax-fmin)/f_bin_size);
+
+            CHECK(cudaMallocManaged((void **)&bin_count, sizeof(int)*num_bins));
+            for(int i_=0; i_<num_bins;i_++){bin_count[i_]=(int)0;}
+
+            for (int i = 0; i< num_modes; i++)
+            {
+                bin_count[int(abs(f[i]/f_bin_size))-shift]++;
+            }
+            ZEROS(bin_sum, int, num_bins);
+
+            CHECK(cudaMallocManaged((void **)&bin_sum, sizeof(int)*num_bins));
+            for(int i_=0; i_<num_bins;i_++){bin_sum[i_]=(int)0;}
+
+            for (int i = 1; i < num_bins; i++)
+            {
+                bin_sum[i] = bin_sum[i-1] + bin_count[i-1];
+            }
+
+            CHECK(cudaFree(f));
+        }
+        else
+        {
+            num_bins = num_modes/bin_size;
+            getline(eigfile,val);
+        }
+
+        // skips modes up to first_mode
+        for (int i=1; i<first_mode; i++) { getline(eigfile,val); }
+        for (int j=0; j<num_modes; j++) //modes
+        {
+            for (int i=0; i<3*num_participating; i++) // xyz of eigvec
+            {
+                eigfile >> doubleval;
+                eig[i + 3*num_participating*j] = doubleval;
+            }
+        }
+        eigfile.close();
+
+        // Allocate modal velocities
+        CHECK(cudaMallocManaged
+        (
+            (void **)&xdot,
+            sizeof(real) * num_modes * 3
+        ));
+
+        CHECK(cudaMallocManaged
+        (
+            (void **)&xdotn,
+            sizeof(real) * num_modes * 3 * num_participating
+        ));
+
+        // Allocate modal measured quantities
+        CHECK(cudaMallocManaged
+        (
+            (void **)&jm,
+            sizeof(real) * num_modes * NUM_OF_HEAT_COMPONENTS
+        ));
+        CHECK(cudaMallocManaged
+        (
+            (void **)&jmn,
+            sizeof(real) * num_modes * NUM_OF_HEAT_COMPONENTS * num_participating
+        ));
+        CHECK(cudaMallocManaged
+        (
+            (void **)&bin_out,
+            sizeof(real) * num_bins * NUM_OF_HEAT_COMPONENTS
+        ));
+
+        // Initialize modal measured quantities
+        int num_elements = num_modes*NUM_OF_HEAT_COMPONENTS;
+        gpu_reset_data<<<(num_elements-1)/BLOCK_SIZE+1, BLOCK_SIZE>>>
+        (
+                num_elements, jm
+        );
+        CUDA_CHECK_KERNEL
+
+        gpu_reset_data
+        <<<(num_elements*num_participating-1)/BLOCK_SIZE+1, BLOCK_SIZE>>>
+        (
+                num_elements*num_participating, jmn
+        );
+        CUDA_CHECK_KERNEL
+
+        gpu_reset_data
+        <<<(num_bins * NUM_OF_HEAT_COMPONENTS - 1)/BLOCK_SIZE+1, BLOCK_SIZE>>>
+        (
+                num_bins*NUM_OF_HEAT_COMPONENTS, bin_out
+        );
+}
+
+void HNEMA::process(int step, Atom *atom)
+{
+    if (!compute) return;
+    if (!((step+1) % sample_interval == 0)) return;
+
+    compute_hnema_heat(atom);
+
+    if (!((step+1) % output_interval == 0)) return;
+
+    gpu_hnema_reduce<<<num_modes, ACCUM_BLOCK>>>
+    (
+        num_participating, num_modes, jmn, jm
+    );
+    CUDA_CHECK_KERNEL
+
+
+    int num_elements = num_modes*3;
+    gpu_average_jm<<<(num_elements-1)/BLOCK_SIZE+1, BLOCK_SIZE>>>
+    (
+            num_elements, samples_per_output, jm
+    );
+    CUDA_CHECK_KERNEL
+
+    if (f_flag)
+    {
+        gpu_bin_frequencies<<<num_bins, BIN_BLOCK>>>
+        (
+               num_modes, bin_count, bin_sum, num_bins,
+               jm, bin_out
+        );
+        CUDA_CHECK_KERNEL
+    }
+    else
+    {
+        gpu_bin_modes<<<num_bins, BIN_BLOCK>>>
+        (
+               num_modes, bin_size, num_bins,
+               jm, bin_out
+        );
+        CUDA_CHECK_KERNEL
+    }
+
+    cudaDeviceSynchronize(); // ensure GPU ready to move data to CPU
+    FILE *fid = fopen(hnema_file_position, "a");
+    for (int i = 0; i < num_bins; i++)
+    {
+        fprintf(fid, "%25.15e %25.15e %25.15e\n",
+         bin_out[i], bin_out[i+num_bins], bin_out[i+2*num_bins]);
+    }
+    fflush(fid);
+    fclose(fid);
+
+    gpu_reset_data<<<(num_elements*num_participating-1)/BLOCK_SIZE+1, BLOCK_SIZE>>>
+    (
+            num_elements*num_participating, jmn
+    );
+    CUDA_CHECK_KERNEL
+
+}
+
+void HNEMA::postprocess()
+{
+    if (!compute) return;
+    CHECK(cudaFree(eig));
+    CHECK(cudaFree(xdot));
+    CHECK(cudaFree(xdotn));
+    CHECK(cudaFree(jm));
+    CHECK(cudaFree(jmn));
+    CHECK(cudaFree(bin_out));
+    if (f_flag)
+    {
+        CHECK(cudaFree(bin_count));
+        CHECK(cudaFree(bin_sum));
+    }
+}

--- a/src/hnema.cu
+++ b/src/hnema.cu
@@ -344,15 +344,15 @@ static __global__ void gpu_find_hnema_jmn
         vz_gk=rsqrtmass*g_eig[neig + (2 + nm*3)*num_participating]
                               *g_xdot[nm + 2*num_modes];
 
-        g_jmn[neig + nm*num_participating] =
+        g_jmn[neig + nm*num_participating] +=
                 sxx[nglobal] * vx_gk + sxy[nglobal] * vy_gk; // x-in
-        g_jmn[neig + (nm+num_modes)*num_participating] =
+        g_jmn[neig + (nm+num_modes)*num_participating] +=
                 sxz[nglobal] * vz_gk; // x-out
-        g_jmn[neig + (nm+2*num_modes)*num_participating] =
+        g_jmn[neig + (nm+2*num_modes)*num_participating] +=
                 syx[nglobal] * vx_gk + syy[nglobal] * vy_gk; // y-in
-        g_jmn[neig + (nm+3*num_modes)*num_participating] =
+        g_jmn[neig + (nm+3*num_modes)*num_participating] +=
                 syz[nglobal] * vz_gk; // y-out
-        g_jmn[neig + (nm+4*num_modes)*num_participating] =
+        g_jmn[neig + (nm+4*num_modes)*num_participating] +=
                 szx[nglobal] * vx_gk + szy[nglobal] * vy_gk + szz[nglobal] * vz_gk; // z-all
 
     }
@@ -531,24 +531,12 @@ void HNEMA::preprocess(char *input_dir, Atom *atom)
 
         // Initialize modal measured quantities
         int num_elements = num_modes*NUM_OF_HEAT_COMPONENTS;
-        gpu_reset_data<<<(num_elements-1)/BLOCK_SIZE+1, BLOCK_SIZE>>>
-        (
-                num_elements, jm
-        );
-        CUDA_CHECK_KERNEL
-
         gpu_reset_data
         <<<(num_elements*num_participating-1)/BLOCK_SIZE+1, BLOCK_SIZE>>>
         (
                 num_elements*num_participating, jmn
         );
         CUDA_CHECK_KERNEL
-
-        gpu_reset_data
-        <<<(num_bins * NUM_OF_HEAT_COMPONENTS - 1)/BLOCK_SIZE+1, BLOCK_SIZE>>>
-        (
-                num_bins*NUM_OF_HEAT_COMPONENTS, bin_out
-        );
 }
 
 void HNEMA::process(int step, Atom *atom, Integrate *integrate, real fe)

--- a/src/hnema.cuh
+++ b/src/hnema.cuh
@@ -1,0 +1,65 @@
+/*
+    Copyright 2017 Zheyong Fan, Ville Vierimaa, Mikko Ervasti, and Ari Harju
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "common.cuh"
+#include "error.cuh"
+#include "mic.cuh"
+
+class HNEMA
+{
+public:
+    int compute = 0;
+    int sample_interval;// steps per heat current computation
+    int output_interval;// number of time steps to output average heat current
+    int first_mode;     // first mode to consider
+    int last_mode;      // last mode to consider
+    int bin_size;       // number of modes per bin
+    real f_bin_size;    // freq. range per bin (THz)
+    int f_flag;         // 0 -> modes, 1 -> freq.
+    int num_modes;      // total number of modes to consider
+    int atom_begin;     // Beginning atom group/type
+    int atom_end;       // End atom group/type
+
+    real* eig;          // eigenvectors
+    real* xdotn;        // per-atom modal velocity
+    real* xdot;         // modal velocities
+    real* jmn;          // per-atom modal heat current
+    real* jm;           // total modal heat current
+    real* bin_out;      // modal binning structure
+    int* bin_count;     // Number of modes per bin when f_flag=1
+    int* bin_sum;       // Running sum from bin_count
+
+
+    char eig_file_position[FILE_NAME_LENGTH];
+    char hnema_file_position[FILE_NAME_LENGTH];
+
+    void preprocess(char*, Atom*);
+    void process(int, Atom*);
+    void postprocess();
+
+private:
+    int samples_per_output;// samples to be averaged for output
+    int num_bins;          // number of bins to output
+    int N1;                // Atom starting index
+    int N2;                // Atom ending index
+    int num_participating; // Number of particles participating
+
+    void compute_hnema_heat(Atom*);
+    void setN(Atom*);
+
+};
+
+

--- a/src/hnema.cuh
+++ b/src/hnema.cuh
@@ -47,7 +47,7 @@ public:
     char hnema_file_position[FILE_NAME_LENGTH];
 
     void preprocess(char*, Atom*);
-    void process(int, Atom*);
+    void process(int, Atom*, Integrate*, real);
     void postprocess();
 
 private:

--- a/src/makefile
+++ b/src/makefile
@@ -12,7 +12,7 @@ SOURCES = main.cu gpumd.cu parse.cu read_file.cu run.cu error.cu validate.cu \
 	integrate.cu ensemble.cu ensemble_nve.cu ensemble_ber.cu \
 	ensemble_nhc.cu ensemble_lan.cu ensemble_bdp.cu \
 	measure.cu compute.cu shc.cu vac.cu hac.cu hnemd_kappa.cu box.cu \
-	dos.cu sdc.cu dump_netcdf.cu dump_xyz.cu gkma.cu
+	dos.cu sdc.cu dump_netcdf.cu dump_xyz.cu gkma.cu hnema.cu
 
 _OBJ = main.o gpumd.o parse.o read_file.o run.o error.o validate.o \
 	mic.o atom.o velocity.o neighbor.o neighbor_ON1.o neighbor_ON2.o \
@@ -21,7 +21,7 @@ _OBJ = main.o gpumd.o parse.o read_file.o run.o error.o validate.o \
 	integrate.o ensemble.o ensemble_nve.o ensemble_ber.o \
 	ensemble_nhc.o ensemble_lan.o ensemble_bdp.o \
 	measure.o compute.o shc.o vac.o hac.o hnemd_kappa.o box.o \
-	dos.o sdc.o dump_netcdf.o dump_xyz.o gkma.o
+	dos.o sdc.o dump_netcdf.o dump_xyz.o gkma.o hnema.o
 
 HEADERS = gpumd.cuh parse.cuh read_file.cuh run.cuh error.cuh validate.cuh \
 	mic.cuh common.cuh atom.cuh \
@@ -30,7 +30,7 @@ HEADERS = gpumd.cuh parse.cuh read_file.cuh run.cuh error.cuh validate.cuh \
 	integrate.cuh ensemble.cuh ensemble_nve.cuh ensemble_ber.cuh \
 	ensemble_nhc.cuh ensemble_lan.cuh ensemble_bdp.cuh \
 	measure.cuh compute.cuh shc.cuh vac.cuh hac.cuh hnemd_kappa.cuh box.cuh \
-	dos.cuh sdc.cuh dump_pos.cuh dump_netcdf.cuh dump_xyz.cuh gkma.cuh
+	dos.cuh sdc.cuh dump_pos.cuh dump_netcdf.cuh dump_xyz.cuh gkma.cuh hnema.cuh
 
 ODIR = obj
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))

--- a/src/makefile.phonon
+++ b/src/makefile.phonon
@@ -7,21 +7,21 @@ SOURCES = main_phonon.cu phonon.cu parse.cu read_file.cu error.cu \
 	force.cu potential.cu lj.cu ri.cu eam.cu sw.cu vashishta.cu fcp.cu \
 	tersoff1988.cu tersoff1989.cu tersoff_modc.cu rebo_mos2.cu tersoff_mini.cu hessian.cu \
 	measure.cu compute.cu shc.cu vac.cu hac.cu hnemd_kappa.cu box.cu \
-	cusolver_wrapper.cu mic.cu dos.cu sdc.cu dump_xyz.cu gkma.cu
+	cusolver_wrapper.cu mic.cu dos.cu sdc.cu dump_xyz.cu gkma.cu hnema.cu
 
 _OBJ = main_phonon.o phonon.o parse.o read_file.o error.o \
 	atom.o velocity.o neighbor.o neighbor_ON1.o neighbor_ON2.o \
 	force.o potential.o lj.o ri.o eam.o sw.o vashishta.o fcp.o \
 	tersoff1988.o tersoff1989.o tersoff_modc.o rebo_mos2.o tersoff_mini.o hessian.o \
 	measure.o compute.o shc.o vac.o hac.o hnemd_kappa.o box.o \
-	cusolver_wrapper.o mic.o dos.o sdc.o dump_xyz.o gkma.o
+	cusolver_wrapper.o mic.o dos.o sdc.o dump_xyz.o gkma.o hnema.o
 
 HEADERS = phonon.cuh parse.cuh read_file.cuh error.cuh mic.cuh \
 	common.cuh atom.cuh \
 	force.cuh potential.cuh lj.cuh ri.cuh eam.cuh sw.cuh vashishta.cuh fcp.cuh \
 	tersoff1988.cuh tersoff1989.cuh tersoff_modc.cuh rebo_mos2.cuh tersoff_mini.cuh hessian.cuh \
 	measure.cuh compute.cuh shc.cuh vac.cuh hac.cuh hnemd_kappa.cuh box.cuh \
-	cusolver_wrapper.cuh dos.cuh sdc.cuh dump_xyz.cuh gkma.cuh
+	cusolver_wrapper.cuh dos.cuh sdc.cuh dump_xyz.cuh gkma.cuh hnema.cuh
 
 ODIR = obj_phonon
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))

--- a/src/measure.cu
+++ b/src/measure.cu
@@ -79,6 +79,7 @@ void Measure::initialize(char* input_dir, Atom *atom)
     compute.preprocess(input_dir, atom);
     hnemd.preprocess(atom);
     gkma.preprocess(input_dir, atom);
+    hnema.preprocess(input_dir, atom);
 }
 
 
@@ -99,6 +100,7 @@ void Measure::finalize
     compute.postprocess(atom, integrate);
     hnemd.postprocess(atom);
     gkma.postprocess();
+    hnema.postprocess();
 }
 
 
@@ -309,6 +311,7 @@ void Measure::process
     shc.process(step, input_dir, atom);
     hnemd.process(step, input_dir, atom, integrate);
     gkma.process(step, atom);
+    hnema.process(step, atom);
     if (dump_pos) dump_pos->dump(atom, step);
 
 }

--- a/src/measure.cu
+++ b/src/measure.cu
@@ -311,7 +311,7 @@ void Measure::process
     shc.process(step, input_dir, atom);
     hnemd.process(step, input_dir, atom, integrate);
     gkma.process(step, atom);
-    hnema.process(step, atom);
+    hnema.process(step, atom, integrate, hnemd.fe);
     if (dump_pos) dump_pos->dump(atom, step);
 
 }

--- a/src/measure.cuh
+++ b/src/measure.cuh
@@ -22,6 +22,7 @@
 #include "hac.cuh"
 #include "shc.cuh"
 #include "gkma.cuh"
+#include "hnema.cuh"
 #include "dump_pos.cuh"
 #include "hnemd_kappa.cuh"
 #include "compute.cuh"
@@ -71,6 +72,7 @@ public:
     HNEMD hnemd;
     Compute compute;
     GKMA gkma;
+    HNEMA hnema;
     DUMP_POS* dump_pos;
 protected:
     void dump_thermos(FILE*, Atom*, int);

--- a/src/parse.cu
+++ b/src/parse.cu
@@ -1031,6 +1031,11 @@ void parse_compute_hnema(char **param, int num_param, Measure* measure, Atom* at
         print_error("fe_z for HNEMD should be a real number.\n");
     }
     printf("    fe_z = %g /A\n", measure->hnemd.fe_z);
+    // magnitude of the vector
+    measure->hnemd.fe  = measure->hnemd.fe_x * measure->hnemd.fe_x;
+    measure->hnemd.fe += measure->hnemd.fe_y * measure->hnemd.fe_y;
+    measure->hnemd.fe += measure->hnemd.fe_z * measure->hnemd.fe_z;
+    measure->hnemd.fe  = sqrt(measure->hnemd.fe);
 
 
     if (strcmp(param[8], "bin_size") == 0)
@@ -1078,7 +1083,7 @@ void parse_compute_hnema(char **param, int num_param, Measure* measure, Atom* at
             print_error("bin_size must be greater than zero.\n");
         }
         printf("    Bin by frequency.\n"
-               "    f_bin_size is %f THz.\n", g->f_bin_size);
+               "    f_bin_size is %f THz.\n", h->f_bin_size);
     }
     else
     {

--- a/src/parse.cuh
+++ b/src/parse.cuh
@@ -39,6 +39,7 @@ void parse_num_dos_points(char **param, Measure *measure, int *k);
 void parse_compute_dos(char**, int , Measure*, Group *group);
 void parse_compute_sdc(char**, int , Measure*, Group *group);
 void parse_compute_gkma(char**, int, Measure*, Atom*);
+void parse_compute_hnema(char **, int, Measure*, Atom*);
 void parse_compute_hac(char**, int , Measure*);
 void parse_compute_hnemd(char**, int, Measure*);
 void parse_compute_shc(char**,  int, Measure*);

--- a/src/potential.cu
+++ b/src/potential.cu
@@ -204,7 +204,7 @@ void Potential::find_properties_many_body
     int grid_size = (N2 - N1 - 1) / BLOCK_SIZE_FORCE + 1;
     gpu_find_force_many_body<<<grid_size, BLOCK_SIZE_FORCE>>>
     (
-        compute_shc, measure->hnemd.compute,
+        compute_shc, compute_hnemd,
         measure->hnemd.fe_x, measure->hnemd.fe_y, measure->hnemd.fe_z,
         atom->N, N1, N2, atom->box.triclinic,
         atom->box.pbc_x, atom->box.pbc_y, atom->box.pbc_z, NN,
@@ -235,6 +235,11 @@ void Potential::find_measurement_flags(Atom* atom, Measure* measure)
     if (measure->shc.compute)
     {
         compute_shc = (atom->step + 1) % measure->shc.sample_interval == 0;
+    }
+    compute_hnemd = 0;
+    if (measure->hnemd.compute == 1 || measure->hnema.compute == 1)
+    {
+        compute_hnemd = 1;
     }
 }
 

--- a/src/potential.cuh
+++ b/src/potential.cuh
@@ -31,6 +31,7 @@ protected:
     int compute_j   = 0; // 1 for computing heat current
     int compute_shc = 0; // 1 for computing shc
     int compute_gkma = 0; // 1 for computing gkma
+    int compute_hnemd = 0; // 1 for computing hnemd or hnema
     void find_properties_many_body
     (Atom*, Measure*, int*, int*, real*, real*, real*);
     void find_measurement_flags(Atom*, Measure*);

--- a/src/run.cu
+++ b/src/run.cu
@@ -386,6 +386,10 @@ void Run::parse
     {
         parse_compute_gkma(param, num_param, measure, atom);
     }
+    else if (strcmp(param[0], "compute_hnema")   == 0)
+    {
+        parse_compute_hnema(param, num_param, measure, atom);
+    }
     else if (strcmp(param[0], "deform")         == 0)
     {
         parse_deform(param, num_param, integrate);

--- a/src/run.cu
+++ b/src/run.cu
@@ -78,6 +78,7 @@ void Run::initialize_run(Atom* atom, Integrate* integrate, Measure* measure)
     measure->vac.compute_dos= 0;
     measure->vac.compute_sdc= 0;
     measure->gkma.compute   = 0;
+    measure->hnema.compute  = 0;
     measure->vac.grouping_method = -1;
     measure->vac.group		= -1;
     measure->dos.num_dos_points = -1;


### PR DESCRIPTION
This is an extension of the modal analysis technique to HNEMD. It uses many of the same techniques used in the GKMA code. 

The command will have the following format:

**compute_hnema** *sample_interval* *output_interval* *Fe_x* *Fe_y* *Fe_z* *first_mode* *last_mode* *bin_option* *bin_size*

with argument definitions of:
- *sample_interval* = interval (in number of steps) used to compute the heat modal heat flux.
- *output_interval* = interval (in number of steps) to output modal thermal conductivity. Thermal conductivity is averaged over all samples per output interval.
- *Fe_x*, *Fe_y*, *Fe_z* = x, y, z components of external driving force F_e in units of 1/Angstrom
- *first_mode* = First mode to include in calculation based on the eigenvector.out file.
- *last_mode* = Last mode to include in calculation based on the eigenvector.out file.
- *bin_option* = Which binning technique to use: 'bin_size' or 'f_bin_size' are current option.
- *bin_size* = If bin_option = 'bin_size', then this is an integer describing how many modes are included per bin. If bin_option = 'f_bin_size', then binning by frequency is used and this is a float describing the bin size in THz.

Currently, this code also requires the use of an eigenvector file (eigenvector.out) generated by this package. The modal thermal conductivity is output to the 'kappamode.out' file. For *n* bins, the output will look like (e.g. kx_output_num_mode):

kxi_1_1, kxo_1_1, kyi_1_1, kyo_1_1, kz_1_1
kxi_1_2, kxo_1_2, kyi_1_2, kyo_1_2, kz_1_2
...
kxi_1_n, kxo_1_n, kyi_1_n, kyo_1_n, kz_1_n
kxi_2_1, kxo_2_1, kyi_2_1, kyo_2_1, kz_2_1
...

This code has been confirmed to match the HNEMD output to 1e-2 if all modes are totaled. The lower matching accuracy is a symptom of lower accuracy output of the data in eigenvector.out. Agreement up to 1e-10 can be achieved if you change the output of the eigenvector.out file to %25.15e. 

**Author(s)**
Alexander Gabourie (Stanford)