### PR TITLE
Updated HNEMD & HNEMA flags

### DIFF
--- a/src/eam.cu
+++ b/src/eam.cu
@@ -499,15 +499,15 @@ void EAM::compute(Atom *atom, Measure *measure, int potential_number)
         {
             FIND_FORCE_EAM_STEP2(0, 1, 0, 0);
         }
-        else if (compute_shc && !measure->hnemd.compute)
+        else if (compute_shc && !compute_hnemd)
         {
             FIND_FORCE_EAM_STEP2(0, 0, 1, 0);
         }
-        else if (measure->hnemd.compute && !compute_shc)
+        else if (compute_hnemd && !compute_shc)
         {
             FIND_FORCE_EAM_STEP2(0, 0, 0, 1);
         }
-        else if (measure->hnemd.compute && compute_shc)
+        else if (compute_hnemd && compute_shc)
         {
             FIND_FORCE_EAM_STEP2(0, 0, 1, 1);
         }
@@ -532,15 +532,15 @@ void EAM::compute(Atom *atom, Measure *measure, int potential_number)
         {
             FIND_FORCE_EAM_STEP2(1, 1, 0, 0);
         }
-        else if (compute_shc && !measure->hnemd.compute)
+        else if (compute_shc && !compute_hnemd)
         {
             FIND_FORCE_EAM_STEP2(1, 0, 1, 0);
         }
-        else if (measure->hnemd.compute && !compute_shc)
+        else if (compute_hnemd && !compute_shc)
         {
             FIND_FORCE_EAM_STEP2(1, 0, 0, 1);
         }
-        else if (measure->hnemd.compute && compute_shc)
+        else if (compute_hnemd && compute_shc)
         {
             FIND_FORCE_EAM_STEP2(1, 0, 1, 1);
         }

--- a/src/fcp.cu
+++ b/src/fcp.cu
@@ -681,6 +681,7 @@ static __global__ void gpu_save_pfj
 void FCP::compute(Atom *atom, Measure *measure, int potential_number)
 {
     const int block_size = 1024;
+    find_measurement_flags(atom, measure);
 
     gpu_get_uv<<<(atom->N - 1) / block_size + 1, block_size>>>
     (
@@ -693,7 +694,7 @@ void FCP::compute(Atom *atom, Measure *measure, int potential_number)
 
     gpu_find_force_fcp2<<<(number2 - 1) / block_size + 1, block_size>>>
     (
-        measure->hnemd.compute, 
+        compute_hnemd,
         measure->hnemd.fe_x, measure->hnemd.fe_y, measure->hnemd.fe_z,
         atom->N, number2, fcp_data.ia2, fcp_data.jb2, fcp_data.phi2,
         fcp_data.uv, fcp_data.xij2, fcp_data.yij2, fcp_data.zij2, fcp_data.pfj

--- a/src/force.cu
+++ b/src/force.cu
@@ -529,7 +529,7 @@ void Force::compute(Atom *atom, Measure* measure)
 
     CHECK(cudaFree(ftot));
 #else
-    if (measure->hnemd.compute)
+    if (measure->hnemd.compute || measure->hnema.compute)
     {
         real *ftot; // total force vector of the system
         CHECK(cudaMalloc((void**)&ftot, sizeof(real) * 3));

--- a/src/lj.cu
+++ b/src/lj.cu
@@ -278,15 +278,15 @@ void LJ::compute(Atom *atom, Measure *measure, int potential_number)
     {
         GPU_FIND_FORCE(1, 0, 0);
     }
-    else if (compute_shc && !measure->hnemd.compute)
+    else if (compute_shc && !compute_hnemd)
     {
         GPU_FIND_FORCE(0, 1, 0);
     }
-    else if (measure->hnemd.compute && !compute_shc)
+    else if (compute_hnemd && !compute_shc)
     {
         GPU_FIND_FORCE(0, 0, 1);
     }
-    else if (measure->hnemd.compute && compute_shc)
+    else if (compute_hnemd && compute_shc)
     {
         GPU_FIND_FORCE(0, 1, 1);
     }

--- a/src/rebo_mos2.cu
+++ b/src/rebo_mos2.cu
@@ -1001,15 +1001,15 @@ void REBO_MOS::compute(Atom *atom, Measure *measure, int potential_number)
     {
         FIND_FORCE_STEP0(1, 0, 0);
     }
-    else if (measure->hnemd.compute && !compute_shc)
+    else if (compute_hnemd && !compute_shc)
     {
         FIND_FORCE_STEP0(0, 0, 1);
     }
-    else if (compute_shc && !measure->hnemd.compute)
+    else if (compute_shc && !compute_hnemd)
     {
         FIND_FORCE_STEP0(0, 1, 0);
     }
-    else if (compute_shc && measure->hnemd.compute)
+    else if (compute_shc && compute_hnemd)
     {
         FIND_FORCE_STEP0(0, 1, 1);
     }

--- a/src/ri.cu
+++ b/src/ri.cu
@@ -299,15 +299,15 @@ void RI::compute(Atom *atom, Measure *measure, int potential_number)
     {
         GPU_FIND_FORCE(1, 0, 0);
     }
-    else if (compute_shc && !measure->hnemd.compute)
+    else if (compute_shc && !compute_hnemd)
     {
         GPU_FIND_FORCE(0, 1, 0);
     }
-    else if (measure->hnemd.compute && !compute_shc)
+    else if (compute_hnemd && !compute_shc)
     {
         GPU_FIND_FORCE(0, 0, 1);
     }
-    else if (measure->hnemd.compute && compute_shc)
+    else if (compute_hnemd && compute_shc)
     {
         GPU_FIND_FORCE(0, 1, 1);
     }

--- a/src/vashishta.cu
+++ b/src/vashishta.cu
@@ -611,7 +611,7 @@ void Vashishta::compute(Atom *atom, Measure *measure, int potential_number)
         }
         CUDA_CHECK_KERNEL
     }
-    else if (compute_shc && !measure->hnemd.compute)
+    else if (compute_shc && !compute_hnemd)
     {
         if (use_table == 0)
         {
@@ -623,7 +623,7 @@ void Vashishta::compute(Atom *atom, Measure *measure, int potential_number)
         }
         CUDA_CHECK_KERNEL
     }
-    else if (measure->hnemd.compute && !compute_shc)
+    else if (compute_hnemd && !compute_shc)
     {
         if (use_table == 0)
         {
@@ -635,7 +635,7 @@ void Vashishta::compute(Atom *atom, Measure *measure, int potential_number)
         }
         CUDA_CHECK_KERNEL
     }
-    else if (measure->hnemd.compute && compute_shc)
+    else if (compute_hnemd && compute_shc)
     {
         if (use_table == 0)
         {


### PR DESCRIPTION
Since either HNEMA or HNEMD methods apply a driving force, a common flag needs to be used for both methods. This was implemented in #43, but I only used it in many body calculations instead of all potentials. This should hopefully fix that issue. 

Note: I changed the flag in fcp.cu for consistency. I don't think the fcp potential will work with HNEMA since it doesn't use the virial tensor. If this isn't a good change, I can revert it back to the original before the pull request is merged.