### PR TITLE
Modal Analysis Optimization

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -11,7 +11,7 @@ CFLAGS = -std=c++11 -O3 -arch=sm_35 -DDEBUG
 
 INC =
 LDFLAGS = 
-LIBS = 
+LIBS = -lcublas
 
 SOURCES = main.cu gpumd.cu read_file.cu run.cu error.cu validate.cu \
 	mic.cu atom.cu velocity.cu neighbor.cu neighbor_ON1.cu neighbor_ON2.cu \

--- a/src/measure.cu
+++ b/src/measure.cu
@@ -817,11 +817,8 @@ void Measure::parse_compute_hnema(char **param, int num_param, Atom* atom)
         {
             PRINT_INPUT_ERROR("compute_hnema parameters must be positive integers.\n");
         }
-        int num_modes = h->last_mode - h->first_mode + 1;
-        if (num_modes % h->bin_size != 0)
-            PRINT_INPUT_ERROR("number of modes must be divisible by bin_size.\n");
         printf("    Bin by modes.\n"
-               "    bin_size is %d THz.\n", h->bin_size);
+               "    bin_size is %d modes.\n", h->bin_size);
     }
 
     // Hidden feature implementation

--- a/src/modal_analysis.cu
+++ b/src/modal_analysis.cu
@@ -334,17 +334,6 @@ void MODAL_ANALYSIS::compute_heat(Atom *atom)
 
     cublasDestroy(handle);
 
-//    cudaDeviceSynchronize();
-//    float jxi = 0;
-//    float jxo = 0;
-//    for (int i = 0; i < num_modes; i++)
-//    {
-//        jxi += jmx[i] + jmy[i];
-//        jxo += jmz[i];
-//    }
-//    printf("jxi = %g, jxo = %g\n", jxi, jxo);
-
-
     grid_size = (num_modes - 1) / BLOCK_SIZE + 1;
     if (method == GKMA_METHOD)
     {
@@ -415,12 +404,12 @@ void MODAL_ANALYSIS::preprocess(char *input_dir, Atom *atom)
 
         // initialize eigenvector data structures
         strcpy(eig_file_position, input_dir);
-        strcat(eig_file_position, "/eigenvector.out"); //TODO change to .in
+        strcat(eig_file_position, "/eigenvector.in");
         std::ifstream eigfile;
         eigfile.open(eig_file_position);
         if (!eigfile)
         {
-            PRINT_INPUT_ERROR("Cannot open eigenvector.out file.");
+            PRINT_INPUT_ERROR("Cannot open eigenvector.in file.");
         }
 
         // GPU phonon code output format
@@ -465,7 +454,6 @@ void MODAL_ANALYSIS::preprocess(char *input_dir, Atom *atom)
         }
         else
         {
-            // TODO validate this section
             num_bins = (int)ceil((double)num_modes/(double)bin_size);
             size_t bin_count_size = sizeof(int)*num_bins;
             CHECK(cudaMallocManaged((void **)&bin_count, bin_count_size));
@@ -593,7 +581,6 @@ void MODAL_ANALYSIS::process(int step, Atom *atom, Integrate *integrate, double 
     }
 
 }
-
 
 void MODAL_ANALYSIS::postprocess()
 {

--- a/src/modal_analysis.cu
+++ b/src/modal_analysis.cu
@@ -457,8 +457,15 @@ void MODAL_ANALYSIS::preprocess(char *input_dir, Atom *atom)
             num_bins = (int)ceil((double)num_modes/(double)bin_size);
             size_t bin_count_size = sizeof(int)*num_bins;
             CHECK(cudaMallocManaged((void **)&bin_count, bin_count_size));
-            for(int i_=0; i_<num_bins-1;i_++){bin_count[i_]=(int)bin_size;}
-            bin_count[num_bins-1] = num_modes%bin_size;
+            if (num_modes%bin_size != 0)
+            {
+                for(int i_=0; i_<num_bins-1;i_++){bin_count[i_]=(int)bin_size;}
+                bin_count[num_bins-1] = num_modes%bin_size;
+            }
+            else
+            {
+                bin_count[0] = (int)bin_size;
+            }
 
             size_t bin_sum_size = sizeof(int)*num_bins;
             CHECK(cudaMallocManaged((void **)&bin_sum, bin_sum_size));

--- a/src/modal_analysis.cuh
+++ b/src/modal_analysis.cuh
@@ -69,8 +69,18 @@ public:
     float* sqrtmass;         // precalculated mass values
     float* rsqrtmass;
 
-    float* jmn;              // per-atom modal heat current
-    float* jm;               // total modal heat current
+    float* jmx;
+    float* jmy;
+    float* jmz;
+
+    float* smx;               // stress by by square root mass
+    float* smy;
+    float* smz;
+
+    float* jtmp;             // placeholder for intermediate
+
+    //    float* jmn;              // per-atom modal heat current
+//    float* jm;               // total modal heat current
     float* bin_out;          // modal binning structure
     int* bin_count;          // Number of modes per bin when f_flag=1
     int* bin_sum;            // Running sum from bin_count

--- a/src/modal_analysis.cuh
+++ b/src/modal_analysis.cuh
@@ -58,29 +58,18 @@ public:
     float* xdot_y;
     float* xdot_z;
 
-    float* vim_x;            // real velocity mode projection
-    float* vim_y;
-    float* vim_z;
-
-    float* vib_x;            // real velocity binned
-    float* vib_y;
-    float* vib_z;
-
     float* sqrtmass;         // precalculated mass values
     float* rsqrtmass;
 
     float* jmx;
     float* jmy;
     float* jmz;
+    float* jm;
 
     float* smx;               // stress by by square root mass
     float* smy;
     float* smz;
 
-    float* jtmp;             // placeholder for intermediate
-
-    //    float* jmn;              // per-atom modal heat current
-//    float* jm;               // total modal heat current
     float* bin_out;          // modal binning structure
     int* bin_count;          // Number of modes per bin when f_flag=1
     int* bin_sum;            // Running sum from bin_count

--- a/src/modal_analysis.cuh
+++ b/src/modal_analysis.cuh
@@ -23,6 +23,10 @@ GPUMD Contributing author: Alexander Gabourie (Stanford University)
 #include "atom.cuh"
 #include "integrate.cuh"
 #include "ensemble.cuh"
+#include <fstream>
+#include <string>
+#include <iostream>
+#include <sstream>
 
 #define NO_METHOD -1
 #define GKMA_METHOD 0
@@ -31,6 +35,7 @@ GPUMD Contributing author: Alexander Gabourie (Stanford University)
 class MODAL_ANALYSIS
 {
 public:
+    // Bookkeeping variables
     int compute = 0;
     int method = NO_METHOD; // Method to compute
     int output_interval;    // number of times steps to output average heat current
@@ -44,14 +49,31 @@ public:
     int atom_begin;         // Beginning atom group/type
     int atom_end;           // End atom group/type
 
-    float* eig;              // eigenvectors
-    float* xdotn;            // per-atom modal velocity
-    float* xdot;             // modal velocities
+    // Data variables
+    float* eig_x;            // eigenvectors x
+    float* eig_y;            // eigenvectors y
+    float* eig_z;            // eigenvectors z
+
+    float* xdot_x;           // modal velocities
+    float* xdot_y;
+    float* xdot_z;
+
+    float* vim_x;            // real velocity mode projection
+    float* vim_y;
+    float* vim_z;
+
+    float* vib_x;            // real velocity binned
+    float* vib_y;
+    float* vib_z;
+
+    float* sqrtmass;         // precalculated mass values
+    float* rsqrtmass;
+
     float* jmn;              // per-atom modal heat current
     float* jm;               // total modal heat current
     float* bin_out;          // modal binning structure
-    int* bin_count;         // Number of modes per bin when f_flag=1
-    int* bin_sum;           // Running sum from bin_count
+    int* bin_count;          // Number of modes per bin when f_flag=1
+    int* bin_sum;            // Running sum from bin_count
 
     char eig_file_position[FILE_NAME_LENGTH];
     char output_file_position[FILE_NAME_LENGTH];
@@ -61,15 +83,18 @@ public:
     void postprocess();
 
 private:
-    int samples_per_output; // samples to be averaged for output
-    int num_bins;           // number of bins to output
-    int N1;                 // Atom starting index
-    int N2;                 // Atom ending index
-    int num_participating;  // Number of particles participating
-    int num_heat_stored;    // Number of stored heat current elements
+    int samples_per_output;  // samples to be averaged for output
+    int num_bins;            // number of bins to output
+    int N1;                  // Atom starting index
+    int N2;                  // Atom ending index
+    int num_participating;   // Number of particles participating
+    int num_heat_stored;     // Number of stored heat current elements
+    float* mv_x;             // sqrt(mass)*velocity intermediate variable
+    float* mv_y;
+    float* mv_z;
 
     void compute_heat(Atom*);
     void setN(Atom*);
-
+    void set_eigmode(int, std::ifstream&, float*);
 
 };


### PR DESCRIPTION
This work is limited to optimizing the [GKMA](#42) and [HNEMA](#43) methods. The changes are back-end and keyword usage is unchanged. I have swapped out the original custom modal analysis kernels and replaced them cuBLAS functions. The order of calculations has also been changed to reduce the number of read/write operations. Performance improvements vary depending on the size of systems, output rates, and number of bins, but initial testing has been promising. 

To give an example, an HNEMA calculation with the following conditions:
-  3680 atom graphene sheet (11040 modes)
-  output average thermal conductivity every 100 time steps 
-  52 bin output
- 10,000 step run

shows the following improvements:

|               |  Original  | Optimized | Reduction |
| --------  | --------- | ----------- | ---------- | 
| Memory | 1930 MB |   746 MB   |   ~62%    |
|    Time    |   69.4 s   |     21.6 s     |   ~69%   |  

with memory and time referring to that used during the HNEMA run in the simulation. Since the optimized version is more memory efficient, the difference between it and the original is expected to grow as the simulations scale in size.

Next, modal analysis now requires an *eigenvector.in* file as opposed to the *eigenvector.out* file used previously. There is no change to the file format, simply a change in the naming convention.

Please let me know what you think. Also, if you would like, I can try to update this code to use the GPU vectors. Otherwise, I will add those in a future pull request.

**Author(s)**
Alexander Gabourie (Stanford)