### PR TITLE
Bug Fix: Modal Analysis Binning by Modes Initialization

### DIFF
--- a/src/measure/measure.cu
+++ b/src/measure/measure.cu
@@ -199,12 +199,9 @@ void Measure::parse_compute_gkma(char** param, int num_param, const int number_o
     if (g->bin_size < 1) {
       PRINT_INPUT_ERROR("compute_gkma parameters must be positive integers.\n");
     }
-    int num_modes = g->last_mode - g->first_mode + 1;
-    if (num_modes % g->bin_size != 0)
-      PRINT_INPUT_ERROR("number of modes must be divisible by bin_size.\n");
     printf(
       "    Bin by modes.\n"
-      "    bin_size is %d THz.\n",
+      "    bin_size is %d bins.\n",
       g->bin_size);
   }
 

--- a/src/measure/modal_analysis.cu
+++ b/src/measure/modal_analysis.cu
@@ -392,27 +392,22 @@ void MODAL_ANALYSIS::preprocess(
     for (int i = 0; i < num_modes; i++)
       bin_count[int(abs(f[i] / f_bin_size)) - shift]++;
 
-    bin_sum.resize(num_bins, 0, Memory_Type::managed);
-    for (int i = 1; i < num_bins; i++)
-      bin_sum[i] = bin_sum[i - 1] + bin_count[i - 1];
   } else {
     num_bins = (int)ceil((double)num_modes / (double)bin_size);
     bin_count.resize(num_bins, Memory_Type::managed);
-    if (num_modes % bin_size != 0) {
-      for (int i_ = 0; i_ < num_bins - 1; i_++) {
-        bin_count[i_] = (int)bin_size;
-      }
-      bin_count[num_bins - 1] = num_modes % bin_size;
-    } else {
-      bin_count[0] = (int)bin_size;
+    for (int i_ = 0; i_ < num_bins; i_++) {
+      bin_count[i_] = (int)bin_size;
     }
-
-    bin_sum.resize(num_bins, 0, Memory_Type::managed);
-    for (int i = 1; i < num_bins; i++)
-      bin_sum[i] = bin_sum[i - 1] + bin_count[i - 1];
+    if (num_modes % bin_size != 0) {
+      bin_count[num_bins - 1] = num_modes % bin_size;
+    }
 
     getline(eigfile, val);
   }
+
+  bin_sum.resize(num_bins, 0, Memory_Type::managed);
+  for (int i = 1; i < num_bins; i++)
+    bin_sum[i] = bin_sum[i - 1] + bin_count[i - 1];
 
   // skips modes up to first_mode
   for (int i = 1; i < first_mode; i++) {


### PR DESCRIPTION
## Purpose 
Fix a bug that incorrectly initialized the bins for compute_hnema & compute_gkma keywords when using the bin_size option. 

## Additional Details
- The f_bin_size option was not affected by this bug. 
- An additional small change was made so that (number of bins)/(bin size) is not required for GKMA, now matching the behavior of the HNEMA method.

## Validation
Step-by-step tests of:
- bin_size = 1
- num_modes % bin_size =/= 0
- bin_size > num_modes
with the correct initialization behavior observed. The rest of the code is assumed to be correct as it has been validated for the f_bin_size option which shares the same code. 
