### PR TITLE
Minor Bug Fix: Safer floor function for modal analysis binning

### DIFF
--- a/src/measure/modal_analysis.cu
+++ b/src/measure/modal_analysis.cu
@@ -383,10 +383,11 @@ void MODAL_ANALYSIS::preprocess(
     }
     double fmax, fmin; // freq are in ascending order in file
     int shift;
+    const double epsilon = 1.e-6;
     fmax = (floor(abs(f[num_modes - 1]) / f_bin_size) + 1) * f_bin_size;
     fmin = floor(abs(f[0]) / f_bin_size) * f_bin_size;
-    shift = floor(abs(fmin) / f_bin_size);
-    num_bins = floor((fmax - fmin) / f_bin_size);
+    shift = floor(abs(fmin) / f_bin_size + epsilon);
+    num_bins = floor((fmax - fmin) / f_bin_size + epsilon);
 
     bin_count.resize(num_bins, 0, Memory_Type::managed);
     for (int i = 0; i < num_modes; i++)


### PR DESCRIPTION
Adds small value to ensure 'floor' function does not yield logically incorrect values due to double precision errors. For example: floor((43*0.05)/0.05) = floor(42.999999999) = 42. In this case, the desired and correct outcome should be 43. This type of behavior does not show up often, but should still be fixed anyways. 