### PR TITLE
Update DOS and SHC initialization on cpu

### DIFF
--- a/src/measure/dos.cu
+++ b/src/measure/dos.cu
@@ -285,9 +285,12 @@ void DOS::allocate_memory()
   vacx_.resize(num_groups_ * num_correlation_steps_, 0.0, Memory_Type::managed);
   vacy_.resize(num_groups_ * num_correlation_steps_, 0.0, Memory_Type::managed);
   vacz_.resize(num_groups_ * num_correlation_steps_, 0.0, Memory_Type::managed);
-  dosx_.resize(num_groups_ * num_dos_points_, 0.0);
-  dosy_.resize(num_groups_ * num_dos_points_, 0.0);
-  dosz_.resize(num_groups_ * num_dos_points_, 0.0);
+  dosx_.resize(num_groups_ * num_dos_points_);
+  dosy_.resize(num_groups_ * num_dos_points_);
+  dosz_.resize(num_groups_ * num_dos_points_);
+  dosx_.assign(num_groups_ * num_dos_points_, 0.0);
+  dosy_.assign(num_groups_ * num_dos_points_, 0.0);
+  dosz_.assign(num_groups_ * num_dos_points_, 0.0);
   mass_.resize(num_atoms_);
 }
 

--- a/src/measure/shc.cu
+++ b/src/measure/shc.cu
@@ -52,10 +52,14 @@ void SHC::preprocess(const int N, const std::vector<Group>& group)
   ko_negative.resize(Nc, 0.0, Memory_Type::managed);
   ki_positive.resize(Nc, 0.0, Memory_Type::managed);
   ko_positive.resize(Nc, 0.0, Memory_Type::managed);
-  ki.resize(Nc * 2 - 1, 0.0);
-  ko.resize(Nc * 2 - 1, 0.0);
-  shc_i.resize(num_omega, 0.0);
-  shc_o.resize(num_omega, 0.0);
+  ki.resize(Nc * 2 - 1);
+  ko.resize(Nc * 2 - 1);
+  ki.assign(Nc * 2 - 1, 0.0);
+  ko.assign(Nc * 2 - 1, 0.0);
+  shc_i.resize(num_omega);
+  shc_o.resize(num_omega);
+  shc_i.assign(num_omega, 0.0);
+  shc_o.assign(num_omega, 0.0);
 }
 
 static __global__ void gpu_find_k(


### PR DESCRIPTION
# Issue
The "resize" function for std::vector only initializes elements to a value for new indices beyond previous size. For GPUMD simulations with multiple runs using the compute_shc and compute_dos keywords, the "allocate" function must be used to properly initialize some data structures.

## Note
The dos.cu code has been tested, but the shc.cu code has not. The change was simple enough that I did not feel it needed testing. Also, I believe that these are the only two files that need this change.