### PR TITLE
make nep much faster for small cells

### DIFF
--- a/src/main_nep/dataset.cuh
+++ b/src/main_nep/dataset.cuh
@@ -34,9 +34,11 @@ public:
   std::vector<int> Na_cpu;     // number of atoms in each configuration
   std::vector<int> Na_sum_cpu; // prefix sum of Na_cpu
 
-  GPU_Vector<int> type; // atom type (0, 1, 2, 3, ...)
-  GPU_Vector<float> r;  // position
-  GPU_Vector<float> h;  // box and inverse box
+  GPU_Vector<int> type;           // atom type (0, 1, 2, 3, ...)
+  GPU_Vector<float> r;            // position
+  GPU_Vector<float> box;          // (expanded) box and inverse box (18 components)
+  GPU_Vector<float> box_original; // (original) box (9 components)
+  GPU_Vector<int> num_cell;       // number of cells in the expanded box (3 components)
 
   GPU_Vector<float> energy;      // calculated energy in GPU
   GPU_Vector<float> virial;      // calculated virial in GPU

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -218,7 +218,7 @@ void Fitness::update_energy_force_virial(
   // update force.out
   for (int nc = 0; nc < dataset.Nc; ++nc) {
     int offset = dataset.Na_sum_cpu[nc];
-    for (int m = 0; m < dataset.structures[nc].num_atom_original; ++m) {
+    for (int m = 0; m < dataset.structures[nc].num_atom; ++m) {
       int n = offset + m;
       fprintf(
         fid_force, "%g %g %g %g %g %g\n", dataset.force_cpu[n], dataset.force_cpu[n + dataset.N],

--- a/src/main_nep/nep.cuh
+++ b/src/main_nep/nep.cuh
@@ -30,9 +30,6 @@ struct NEP2_Data {
   GPU_Vector<float> x12_angular;
   GPU_Vector<float> y12_angular;
   GPU_Vector<float> z12_angular;
-  GPU_Vector<float> f12x;        // partial forces
-  GPU_Vector<float> f12y;        // partial forces
-  GPU_Vector<float> f12z;        // partial forces
   GPU_Vector<float> descriptors; // descriptors
   GPU_Vector<float> Fp;          // gradient of descriptors
   GPU_Vector<float> sum_fxyz;

--- a/src/main_nep/structure.cu
+++ b/src/main_nep/structure.cu
@@ -282,7 +282,8 @@ void read_structures(
 
   fclose(fid);
 
-  if (is_train) { // TODO: only reorder if using mini-batch
+  // only reorder if not using full batch
+  if (is_train && (para.batch_size < structures.size())) {
     reorder(structures);
   }
 }

--- a/src/main_nep/structure.cuh
+++ b/src/main_nep/structure.cuh
@@ -19,11 +19,8 @@
 class Parameters;
 
 struct Structure {
-  int num_cell_a;
-  int num_cell_b;
-  int num_cell_c;
+  int num_cell[3];
   int num_atom;
-  int num_atom_original;
   int has_virial;
   float energy;
   float virial[6];


### PR DESCRIPTION
This is important when there are many small-cell structures in the training/testing set.

It also confirmed the correctness of my formulas: two differnet implementations (one with `atomicAdd()` and one without) give consistent results.