### PR TITLE
Get the descriptor normalization back

### DIFF
--- a/src/main_nep/nep.cuh
+++ b/src/main_nep/nep.cuh
@@ -66,7 +66,8 @@ public:
     int N,
     int N_times_max_NN_radial,
     int N_times_max_NN_angular);
-  void find_force(Parameters& para, const float* parameters, Dataset& dataset);
+  void
+  find_force(Parameters& para, const float* parameters, Dataset& dataset, bool calculate_q_scaler);
 
 private:
   ParaMB paramb;

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -103,14 +103,7 @@ Parameters::Parameters(char* input_dir)
   }
 
   int dim = (n_max_radial + 1) + (n_max_angular + 1) * L_max;
-  q_scaler_cpu.resize(dim, 1.0f);
-  float factor_cutoff = rc_radial * rc_radial * rc_radial / (rc_angular * rc_angular * rc_angular);
-  for (int l = 1; l <= L_max; ++l) {
-    float factor = 4.0f * 3.1415927f / (2 * l + 1) * factor_cutoff;
-    for (int n = 0; n <= n_max_angular; ++n) {
-      q_scaler_cpu[(l - 1) * (n_max_angular + 1) + n + n_max_radial + 1] = factor;
-    }
-  }
+  q_scaler_cpu.resize(dim, 1.0e10f);
   q_scaler_gpu.resize(dim);
   q_scaler_gpu.copy_from_host(q_scaler_cpu.data());
 

--- a/src/main_nep/potential.cuh
+++ b/src/main_nep/potential.cuh
@@ -23,5 +23,6 @@ class Potential
 {
 public:
   virtual ~Potential() = default;
-  virtual void find_force(Parameters& para, const float* parameters, Dataset& dataset) = 0;
+  virtual void find_force(
+    Parameters& para, const float* parameters, Dataset& dataset, bool calculate_q_scaler) = 0;
 };


### PR DESCRIPTION
This should get the accuracy of NEP1 back for single-component systems. It has little effect for multi-component systems. 