### PR TITLE
allow for enabling/disabling 4-body

### DIFF
--- a/src/force/nep3_small_box.cuh
+++ b/src/force/nep3_small_box.cuh
@@ -214,7 +214,11 @@ static __global__ void find_descriptor_small_box(
         }
         accumulate_s(d12, r12[0], r12[1], r12[2], gn12, s);
       }
-      find_q_nep3(paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
+      if (paramb.num_L > paramb.L_max) {
+        find_q_with_4body(paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
+      } else {
+        find_q(paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
+      }
       for (int abc = 0; abc < NUM_OF_ABC; ++abc) {
         g_sum_fxyz[(n * NUM_OF_ABC + abc) * N + n1] = s[abc];
       }
@@ -389,7 +393,12 @@ static __global__ void find_force_angular_small_box(
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
-        accumulate_f12_nep3(n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
+        if (paramb.num_L > paramb.L_max) {
+          accumulate_f12_with_4body(
+            n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
+        } else {
+          accumulate_f12(n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
+        }
       }
       f12[0] *= 2.0f;
       f12[1] *= 2.0f;

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -192,7 +192,7 @@ void Fitness::report_error(
     }
     fprintf(fid_nep, "cutoff %g %g\n", para.rc_radial, para.rc_angular);
     fprintf(fid_nep, "n_max %d %d\n", para.n_max_radial, para.n_max_angular);
-    fprintf(fid_nep, "l_max %d\n", para.L_max, para.L_max_4body);
+    fprintf(fid_nep, "l_max %d %d\n", para.L_max, para.L_max_4body);
     fprintf(fid_nep, "ANN %d %d\n", para.num_neurons1, 0);
     for (int m = 0; m < para.number_of_variables; ++m) {
       fprintf(fid_nep, "%15.7e\n", elite[m]);

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -192,7 +192,7 @@ void Fitness::report_error(
     }
     fprintf(fid_nep, "cutoff %g %g\n", para.rc_radial, para.rc_angular);
     fprintf(fid_nep, "n_max %d %d\n", para.n_max_radial, para.n_max_angular);
-    fprintf(fid_nep, "l_max %d\n", para.L_max);
+    fprintf(fid_nep, "l_max %d\n", para.L_max, para.L_max_4body);
     fprintf(fid_nep, "ANN %d %d\n", para.num_neurons1, 0);
     for (int m = 0; m < para.number_of_variables; ++m) {
       fprintf(fid_nep, "%15.7e\n", elite[m]);

--- a/src/main_nep/nep3.cu
+++ b/src/main_nep/nep3.cu
@@ -187,7 +187,11 @@ static __global__ void find_descriptors_angular(
         }
         accumulate_s(d12, x12, y12, z12, gn12, s);
       }
-      find_q_nep3(paramb.n_max_angular + 1, n, s, q);
+      if (paramb.num_L > paramb.L_max) {
+        find_q_with_4body(paramb.n_max_angular + 1, n, s, q);
+      } else {
+        find_q(paramb.n_max_angular + 1, n, s, q);
+      }
       for (int abc = 0; abc < NUM_OF_ABC; ++abc) {
         g_sum_fxyz[(n * NUM_OF_ABC + abc) * N + n1] = s[abc];
       }
@@ -216,7 +220,7 @@ NEP3::NEP3(
   paramb.n_max_radial = para.n_max_radial;
   paramb.n_max_angular = para.n_max_angular;
   paramb.L_max = para.L_max;
-  paramb.num_L = paramb.L_max + 1;
+  paramb.num_L = (para.L_max_4body == 2) ? paramb.L_max + 1 : paramb.L_max;
   paramb.dim_angular = (para.n_max_angular + 1) * paramb.num_L;
 
   // new parameters for nep3
@@ -467,7 +471,12 @@ static __global__ void find_force_angular(
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
-        accumulate_f12_nep3(n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
+        if (paramb.num_L > paramb.L_max) {
+          accumulate_f12_with_4body(
+            n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
+        } else {
+          accumulate_f12(n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
+        }
       }
       f12[0] *= 2.0f;
       f12[1] *= 2.0f;

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -475,14 +475,23 @@ void Parameters::parse_l_max(char** param, int num_param)
 {
   is_l_max_set = true;
 
-  if (num_param != 2) {
-    PRINT_INPUT_ERROR("l_max should have 1 parameter.\n");
+  if (num_param != 2 && num_param != 3) {
+    PRINT_INPUT_ERROR("l_max should have 1 or 2 parameters.\n");
   }
   if (!is_valid_int(param[1], &L_max)) {
-    PRINT_INPUT_ERROR("l_max should be an integer.\n");
+    PRINT_INPUT_ERROR("l_max for 3-body descriptors should be an integer.\n");
   }
   if (L_max != 4) {
-    PRINT_INPUT_ERROR("l_max should = 4.");
+    PRINT_INPUT_ERROR("l_max for 3-body descriptors should = 4.");
+  }
+
+  if (num_param == 3) {
+    if (!is_valid_int(param[2], &L_max_4body)) {
+      PRINT_INPUT_ERROR("l_max for 4-body descriptors should be an integer.\n");
+    }
+    if (L_max_4body != 0 && L_max_4body != 2) {
+      PRINT_INPUT_ERROR("l_max for 4-body descriptors should = 0 or 2.");
+    }
   }
 }
 

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -110,11 +110,10 @@ void Parameters::read_nep_in(char* input_dir)
 
 void Parameters::calculate_parameters()
 {
-  dim_radial = (n_max_radial + 1);
-  if (version == 3) {
-    dim_angular = (n_max_angular + 1) * (L_max + 1);
-  } else {
-    dim_angular = (n_max_angular + 1) * L_max;
+  dim_radial = (n_max_radial + 1);           // 2-body descriptors q^i_n
+  dim_angular = (n_max_angular + 1) * L_max; // 3-body descriptors q^i_nl
+  if (version == 3 && L_max_4body == 2) {    // 4-body descriptors q^i_n222
+    dim_angular += n_max_angular + 1;
   }
   dim = dim_radial + dim_angular;
   q_scaler_cpu.resize(dim, 1.0e10f);

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -71,6 +71,7 @@ void Parameters::set_default_parameters()
   n_max_radial = 15;             // large enough in most cases
   n_max_angular = 10;            // large enough in most cases
   L_max = 4;                     // the only supported value
+  L_max_4body = 0;               // default is not to include 4body
   num_neurons1 = 50;             // large enough in most cases
   lambda_1 = lambda_2 = 5.0e-2f; // good default based on our tests
   lambda_e = lambda_f = 1.0f;    // energy and force are more important

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -187,9 +187,9 @@ void Parameters::report_inputs()
   }
 
   if (is_l_max_set) {
-    printf("    (input)   l_max = %d.\n", L_max);
+    printf("    (input)   l_max_3body = %d, l_max_4body = %d.\n", L_max, L_max_4body);
   } else {
-    printf("    (default) l_max = %d.\n", L_max);
+    printf("    (default) l_max_3body = %d, l_max_4body = %d.\n", L_max, L_max_4body);
   }
 
   if (is_neuron_set) {

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -35,7 +35,8 @@ public:
   int basis_size_radial;  // for nep3
   int n_max_radial;       // maximum order of the radial Chebyshev polynomials
   int n_max_angular;      // maximum order of the angular Chebyshev polynomials
-  int L_max;              // maximum order of the angular Legendre polynomials
+  int L_max;              // maximum order of the 3body spherical harmonics
+  int L_max_4body;        // maximum order of the 4body spherical harmonics
   float rc_radial;        // radial cutoff distance
   float rc_angular;       // angular cutoff distance
   float lambda_1;         // weight parameter for L1 regularization loss

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -531,7 +531,7 @@ static __device__ __forceinline__ void accumulate_f12(
     r12[0], r12[1], r12[2], d12, d12inv, fn, fnp, Fp[3 * n_max_angular_plus_1 + n], s4, f12);
 }
 
-static __device__ __forceinline__ void accumulate_f12_nep3(
+static __device__ __forceinline__ void accumulate_f12_with_4body(
   const int n,
   const int n_max_angular_plus_1,
   const float d12,
@@ -639,7 +639,7 @@ find_q(const int n_max_angular_plus_1, const int n, const float* s, float* q)
 }
 
 static __device__ __forceinline__ void
-find_q_nep3(const int n_max_angular_plus_1, const int n, const float* s, float* q)
+find_q_with_4body(const int n_max_angular_plus_1, const int n, const float* s, float* q)
 {
   // 3-body
   find_q(n_max_angular_plus_1, n, s, q);


### PR DESCRIPTION
In `nep.in`, one will be able to enable/disable 4-body descriptors in the following way:
```
l_max 4 # only use 3-body
l_max 4 0 # only use 3-body
l_max 4 2 # use both 3-body and 4-body
```
