### PR TITLE
Split gnn

### DIFF
--- a/src/main_nep/nep4.cu
+++ b/src/main_nep/nep4.cu
@@ -272,7 +272,7 @@ static __global__ void apply_gnn_message_passing(
     }
     // apply gnn to propagate and update descriptors
     float q_out[MAX_DIM] = {0.0f};
-    apply_gnn_A_q_theta(annmb.dim, neighbor_number, gnnmb.theta, q_theta_i, q_theta_j, q_out);
+    apply_gnn_A_q_theta(annmb.dim, neighbor_number, q_theta_i, q_theta_j, q_out);
     // write propagated descriptor to gnn_descriptors
     for (int d = 0; d < annmb.dim; ++d) {
       // printf("n1=%d, q_out[%d]=%f\n", n1, d, q_out[d]);

--- a/src/main_nep/nep4.cuh
+++ b/src/main_nep/nep4.cuh
@@ -27,6 +27,7 @@ struct NEP4_Data {
   GPU_Vector<float> z12_angular;
   GPU_Vector<float> descriptors;     // descriptors
   GPU_Vector<float> gnn_descriptors; // temporary descriptors for use in GNN
+  GPU_Vector<float> gnn_messages;    // Computed messages q * theta for all atoms, same shape as gnn_descriptors
   GPU_Vector<float> Fp;              // gradient of descriptors
   GPU_Vector<float> sum_fxyz;
   GPU_Vector<float> parameters; // parameters to be optimized

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -60,7 +60,7 @@ static __device__ void apply_ann_one_layer(
 }
 
 static __device__ void apply_gnn_A_q_theta(
-  const int dim, int num_neighbors, const float* theta, float* q_theta_i, float* q_theta_j, float* q_out)
+  const int dim, int num_neighbors, float* q_theta_i, float* q_theta_j, float* q_out)
 {
   // Note that Theta is F x dim matrix to be stored similarly
   // as other matrices in the code.
@@ -72,7 +72,7 @@ static __device__ void apply_gnn_A_q_theta(
     // neighbor atoms j
     // TODO also add weights f_c(r_ij)
     for (int j = 0; j < num_neighbors; j++) {
-      q_out[nu] += q_theta_j[nu];
+      q_out[nu] += q_theta_j[j + nu * num_neighbors];
     }
     // activation function
     q_out[nu] = tanh(q_out[nu]);
@@ -82,10 +82,8 @@ static __device__ void apply_gnn_A_q_theta(
 static __device__ void apply_gnn_q_theta(
   const int dim, int num_neighbors, const float* theta, float* q_i, float* q_theta)
 {
-
   int F = dim; // dimension of q_out, for now dim_out = dim_in.
   for (int nu = 0; nu < F; nu++) {
-    // Atom i
     for (int gamma = 0; gamma < dim; gamma++) {
       q_theta[nu] += q_i[gamma] * theta[gamma + dim * nu];
     }

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -59,26 +59,36 @@ static __device__ void apply_ann_one_layer(
   energy -= b1[0];
 }
 
-static __device__ void apply_gnn_one_layer(
-  const int dim, int num_neighbors, const float* theta, float* q_i, float* q_j, float* q_out)
+static __device__ void apply_gnn_A_q_theta(
+  const int dim, int num_neighbors, const float* theta, float* q_theta_i, float* q_theta_j, float* q_out)
 {
-  // TODO also add weights f_c(r_ij)
   // Note that Theta is F x dim matrix to be stored similarly
   // as other matrices in the code.
   int F = dim; // dimension of q_out, for now dim_out = dim_in.
   for (int nu = 0; nu < F; nu++) {
-    // Atom i
-    for (int gamma = 0; gamma < dim; gamma++) {
-      q_out[nu] += q_i[gamma] * theta[gamma + dim * nu];
-    }
+    // Atom i - f_c(rii) === 1
+    q_out[nu] += q_theta_i[nu];
+
     // neighbor atoms j
+    // TODO also add weights f_c(r_ij)
     for (int j = 0; j < num_neighbors; j++) {
-      for (int gamma = 0; gamma < dim; gamma++) {
-        q_out[nu] += q_j[j + gamma * num_neighbors] * theta[gamma + dim * nu];
-      }
+      q_out[nu] += q_theta_j[nu];
     }
     // activation function
     q_out[nu] = tanh(q_out[nu]);
+  }
+}
+
+static __device__ void apply_gnn_q_theta(
+  const int dim, int num_neighbors, const float* theta, float* q_i, float* q_theta)
+{
+
+  int F = dim; // dimension of q_out, for now dim_out = dim_in.
+  for (int nu = 0; nu < F; nu++) {
+    // Atom i
+    for (int gamma = 0; gamma < dim; gamma++) {
+      q_theta[nu] += q_i[gamma] * theta[gamma + dim * nu];
+    }
   }
 }
 


### PR DESCRIPTION
I've split `apply_gnn` into two functions, `apply_gnn_compute_messages` that calculates the messages `q_j * theta`, and `apply_gnn_message_passing` that performs the message passing, i.e., the weighted sum over  `A_ij * q_j * theta`.

This seems to speed up computation a little bit, initially I gained about 5-10% in total computation time (~46s -> ~42s), but after the second commit the new code runs a bit slower, closer to 45s. I have only done (very) crude benchmarking so far, one should probably rerun the program a few times in order to collect statistics. 
 
Checking the kernel execution time in Ngsight,  the total time of executing the two two new kernels is 430µs + 50µs ~= 480µs, which can be compared to the original kernel's execution time of ~560µs. Furthermore, with the old kernel Ngsight warns for a high memory throughput and relatively poor compute utilization. With the new kernels, the warning goes away even though the memory usage is increased. From what I can tell, compute utilization is even lower with the new kernels though. 

The output is not exactly the same as the earlier version of NEP4 though. Checking `loss.out`, the first 5 rows (timesteps 100-500) match exactly, but then the output is different for the remaining 5 rows (timestep 600-1000). @brucefan1983 do you know why that might be the case?