### PR TITLE
Change to smooth weights A_ij = fc_ij instead of binary weights

### DIFF
--- a/src/main_nep/nep4.cu
+++ b/src/main_nep/nep4.cu
@@ -249,6 +249,9 @@ static __global__ void apply_gnn_message_passing(
   const NEP4::ParaMB paramb,
   const NEP4::ANN annmb,
   const NEP4::GNN gnnmb,
+  const float* __restrict__ g_x12,
+  const float* __restrict__ g_y12,
+  const float* __restrict__ g_z12,
   const float* __restrict__ g_messages,
   const int* g_NN,
   const int* g_NL,
@@ -261,18 +264,27 @@ static __global__ void apply_gnn_message_passing(
     // get messages for atom i and neighbors
     float q_theta_i[MAX_DIM] = {0.0f};
     float q_theta_j[MAX_NEIGHBORS * MAX_DIM] = {0.0f}; // maximum size when all atoms are neighbors
+    float fc_ij[MAX_DIM] = {0.0f};
     for (int d = 0; d < annmb.dim; ++d) {
       q_theta_i[d] = g_messages[n1 + d * N];
     }
     for (int j = 0; j < neighbor_number; ++j) {
-      int n2 = g_NL[n1 + N * j];
+      int index = n1 + N*j;
+      int n2 = g_NL[index];
       for (int d = 0; d < annmb.dim; ++d) {
         q_theta_j[j + d * neighbor_number] = g_messages[n2 + d * N];
+        // Compute weight fc_ij
+        float r12[3] = {g_x12[index], g_y12[index], g_z12[index]};
+        // Can these be saved beforehand? Or is it too memory intensive?
+        float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
+        float fc12;
+        find_fc(paramb.rc_angular, paramb.rcinv_angular, d12, fc12);
+        fc_ij[j] = fc12;
       }
     }
     // apply gnn to propagate and update descriptors
     float q_out[MAX_DIM] = {0.0f};
-    apply_gnn_A_q_theta(annmb.dim, neighbor_number, q_theta_i, q_theta_j, q_out);
+    apply_gnn_A_q_theta(annmb.dim, neighbor_number, fc_ij, q_theta_i, q_theta_j, q_out);
     // write propagated descriptor to gnn_descriptors
     for (int d = 0; d < annmb.dim; ++d) {
       // printf("n1=%d, q_out[%d]=%f\n", n1, d, q_out[d]);
@@ -534,7 +546,8 @@ void NEP4::find_force(
 
 
   apply_gnn_message_passing<<<grid_size, block_size>>>(
-    dataset.N, paramb, annmb, gnnmb, nep_data.gnn_messages.data(), nep_data.NN_angular.data(),
+    dataset.N, paramb, annmb, gnnmb, nep_data.x12_angular.data(), nep_data.y12_angular.data(),
+    nep_data.z12_angular.data(), nep_data.gnn_messages.data(), nep_data.NN_angular.data(),
     nep_data.NL_angular.data(), nep_data.gnn_descriptors.data());
   CUDA_CHECK_KERNEL
 

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -60,19 +60,19 @@ static __device__ void apply_ann_one_layer(
 }
 
 static __device__ void apply_gnn_A_q_theta(
-  const int dim, int num_neighbors, float* q_theta_i, float* q_theta_j, float* q_out)
+  const int dim, int num_neighbors, float* fc_ij, float* q_theta_i, float* q_theta_j, float* q_out)
 {
   // Note that Theta is F x dim matrix to be stored similarly
   // as other matrices in the code.
   int F = dim; // dimension of q_out, for now dim_out = dim_in.
   for (int nu = 0; nu < F; nu++) {
-    // Atom i - f_c(rii) === 1
+    // Atom i - fc(rii) == 1
     q_out[nu] += q_theta_i[nu];
 
     // neighbor atoms j
-    // TODO also add weights f_c(r_ij)
+    // TODO perhaps normalize weights? Compare Kipf, Welling et al. (2016) 
     for (int j = 0; j < num_neighbors; j++) {
-      q_out[nu] += q_theta_j[j + nu * num_neighbors];
+      q_out[nu] += fc_ij[j] * q_theta_j[j + nu * num_neighbors];
     }
     // activation function
     q_out[nu] = tanh(q_out[nu]);


### PR DESCRIPTION
Changes the graph weights A_ij = 1 to A_ij = fc(r_ij). For the PbTe system I haven't really seen an increase in performance, but I believe this will work better for more complex system (and it is more physically motivated). 

One could possibly normalize the weights fc(r_ij) such that, for instance, all rows in A sums to 1. With the current implementation, atoms with more weights will descriptors with larger magnitude, and may thus come to dominate.

This change costs a little bit of extra execution time. According to Ngsight, the execution time of the kernel `apply_gnn_message_passing` changes from ~415 µs to ~730µs, as well as a higher memory use. This translates to a total runtime of ~65s when running the PbTe example with the `nep.in` as shown below, compared to ~60s with A_ij = 1. 

Should be merged after #158

```bash
version      4
type         2 Te Pb
cutoff       6 6
n_max        12 6
neuron       40
batch        25
generation   1000
lambda_f     0
lambda_1     0.0002
lambda_2     0.0002
```