### PR TITLE
prepare for NEP4 force

### DIFF
--- a/src/main_nep/nep4.cu
+++ b/src/main_nep/nep4.cu
@@ -390,7 +390,7 @@ static __global__ void find_force_angular(
   const float* __restrict__ g_x12,
   const float* __restrict__ g_y12,
   const float* __restrict__ g_z12,
-  const float* __restrict__ g_Fp,
+  const float* __restrict__ g_dU_dq,
   const float* __restrict__ g_s,
   float* g_fx,
   float* g_fy,
@@ -407,13 +407,13 @@ static __global__ void find_force_angular(
     float s_virial_yz = 0.0f;
     float s_virial_zx = 0.0f;
 
-    float Fp[MAX_DIM_ANGULAR] = {0.0f};
-    float sum_fxyz[NUM_OF_ABC * MAX_NUM_N];
+    float dU_dq[MAX_DIM_ANGULAR] = {0.0f};
+    float s[NUM_OF_ABC * MAX_NUM_N];
     for (int d = 0; d < (para.n_max_angular + 1) * para.L_max; ++d) {
-      Fp[d] = g_Fp[d * N + n1];
+      dU_dq[d] = g_dU_dq[d * N + n1];
     }
     for (int d = 0; d < (para.n_max_angular + 1) * NUM_OF_ABC; ++d) {
-      sum_fxyz[d] = g_s[d * N + n1];
+      s[d] = g_s[d * N + n1];
     }
     int neighbor_number = g_NN[n1];
     int t1 = g_type[n1];
@@ -438,7 +438,7 @@ static __global__ void find_force_angular(
           gn12 += fn12[k] * ann.c[c_index];
           gnp12 += fnp12[k] * ann.c[c_index];
         }
-        accumulate_f12(n, para.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
+        accumulate_f12(n, para.n_max_angular + 1, d12, r12, gn12, gnp12, dU_dq, s, f12);
       }
 
       atomicAdd(&g_fx[n1], f12[0]);

--- a/src/main_nep/nep4.cuh
+++ b/src/main_nep/nep4.cuh
@@ -25,11 +25,15 @@ struct NEP4_Data {
   GPU_Vector<float> x12_angular;
   GPU_Vector<float> y12_angular;
   GPU_Vector<float> z12_angular;
+  GPU_Vector<float> dq_dx;
+  GPU_Vector<float> dq_dy;
+  GPU_Vector<float> dq_dz;
   GPU_Vector<float> descriptors;     // descriptors
   GPU_Vector<float> gnn_descriptors; // temporary descriptors for use in GNN
-  GPU_Vector<float> gnn_messages;    // Computed messages q * theta for all atoms, same shape as gnn_descriptors
-  GPU_Vector<float> Fp;              // gradient of descriptors
-  GPU_Vector<float> sum_fxyz;
+  GPU_Vector<float>
+    gnn_messages;       // Computed messages q * theta for all atoms, same shape as gnn_descriptors
+  GPU_Vector<float> Fp; // derivative of ANN output (energy) wrt ANN input (descriptor)
+  GPU_Vector<float> s;  // s in the NEP3 manuscript
   GPU_Vector<float> parameters; // parameters to be optimized
 };
 

--- a/src/main_nep/nep4.cuh
+++ b/src/main_nep/nep4.cuh
@@ -28,19 +28,18 @@ struct NEP4_Data {
   GPU_Vector<float> dq_dx;
   GPU_Vector<float> dq_dy;
   GPU_Vector<float> dq_dz;
-  GPU_Vector<float> descriptors;     // descriptors
+  GPU_Vector<float> q;               // descriptors (angular only)
   GPU_Vector<float> gnn_descriptors; // temporary descriptors for use in GNN
-  GPU_Vector<float>
-    gnn_messages;       // Computed messages q * theta for all atoms, same shape as gnn_descriptors
-  GPU_Vector<float> Fp; // derivative of ANN output (energy) wrt ANN input (descriptor)
-  GPU_Vector<float> s;  // s in the NEP3 manuscript
+  GPU_Vector<float> gnn_messages; // messages q * theta for all atoms, same shape as gnn_descriptors
+  GPU_Vector<float> dU_dq;
+  GPU_Vector<float> s;          // s in the NEP3 manuscript
   GPU_Vector<float> parameters; // parameters to be optimized
 };
 
 class NEP4 : public Potential
 {
 public:
-  struct ParaMB {
+  struct Para {
     float rc_angular = 0.0f;    // angular cutoff
     float rcinv_angular = 0.0f; // inverse of the angular cutoff
     int basis_size_radial = 0;
@@ -79,9 +78,9 @@ public:
   find_force(Parameters& para, const float* parameters, Dataset& dataset, bool calculate_q_scaler);
 
 private:
-  ParaMB paramb;
-  ANN annmb;
-  GNN gnnmb;
+  Para nep_para;
+  ANN ann;
+  GNN gnn;
   NEP4_Data nep_data;
   ZBL zbl;
   void update_potential(const float* parameters, ANN& ann, GNN& gnn);

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -59,17 +59,6 @@ static __device__ void apply_ann_one_layer(
   energy -= b1[0];
 }
 
-static __device__ void
-apply_gnn_q_theta(const int dim, int num_neighbors, const float* theta, float* q_i, float* q_theta)
-{
-  int F = dim; // dimension of q_out, for now dim_out = dim_in.
-  for (int nu = 0; nu < F; nu++) {
-    for (int gamma = 0; gamma < dim; gamma++) {
-      q_theta[nu] += q_i[gamma] * theta[gamma + dim * nu];
-    }
-  }
-}
-
 static __device__ __forceinline__ void find_fc(float rc, float rcinv, float d12, float& fc)
 {
   if (d12 < rc) {

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -510,7 +510,7 @@ static __device__ __forceinline__ void find_dq_dr(
   int index = index_start;
   dq_dx[index] = dq_dr_1[0];
   dq_dy[index] = dq_dr_1[1];
-  dq_dy[index] = dq_dr_1[2];
+  dq_dz[index] = dq_dr_1[2];
   // l = 2
   fnp = fnp * d12inv - fn * d12inv * d12inv;
   fn = fn * d12inv;
@@ -522,7 +522,7 @@ static __device__ __forceinline__ void find_dq_dr(
   index += index_step;
   dq_dx[index] = dq_dr_2[0];
   dq_dy[index] = dq_dr_2[1];
-  dq_dy[index] = dq_dr_2[2];
+  dq_dz[index] = dq_dr_2[2];
   // l = 3
   fnp = fnp * d12inv - fn * d12inv * d12inv;
   fn = fn * d12inv;
@@ -535,7 +535,7 @@ static __device__ __forceinline__ void find_dq_dr(
   index += index_step;
   dq_dx[index] = dq_dr_3[0];
   dq_dy[index] = dq_dr_3[1];
-  dq_dy[index] = dq_dr_3[2];
+  dq_dz[index] = dq_dr_3[2];
   // l = 4
   fnp = fnp * d12inv - fn * d12inv * d12inv;
   fn = fn * d12inv;
@@ -549,7 +549,7 @@ static __device__ __forceinline__ void find_dq_dr(
   index += index_step;
   dq_dx[index] = dq_dr_4[0];
   dq_dy[index] = dq_dr_4[1];
-  dq_dy[index] = dq_dr_4[2];
+  dq_dz[index] = dq_dr_4[2];
 }
 
 static __device__ __forceinline__ void accumulate_f12(

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -59,28 +59,8 @@ static __device__ void apply_ann_one_layer(
   energy -= b1[0];
 }
 
-static __device__ void apply_gnn_A_q_theta(
-  const int dim, int num_neighbors, float* fc_ij, float* q_theta_i, float* q_theta_j, float* q_out)
-{
-  // Note that Theta is F x dim matrix to be stored similarly
-  // as other matrices in the code.
-  int F = dim; // dimension of q_out, for now dim_out = dim_in.
-  for (int nu = 0; nu < F; nu++) {
-    // Atom i - fc(rii) == 1
-    q_out[nu] += q_theta_i[nu];
-
-    // neighbor atoms j
-    // TODO perhaps normalize weights? Compare Kipf, Welling et al. (2016) 
-    for (int j = 0; j < num_neighbors; j++) {
-      q_out[nu] += fc_ij[j] * q_theta_j[j + nu * num_neighbors];
-    }
-    // activation function
-    q_out[nu] = tanh(q_out[nu]);
-  }
-}
-
-static __device__ void apply_gnn_q_theta(
-  const int dim, int num_neighbors, const float* theta, float* q_i, float* q_theta)
+static __device__ void
+apply_gnn_q_theta(const int dim, int num_neighbors, const float* theta, float* q_i, float* q_theta)
 {
   int F = dim; // dimension of q_out, for now dim_out = dim_in.
   for (int nu = 0; nu < F; nu++) {

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -485,6 +485,73 @@ static __device__ __forceinline__ void get_f12_4(
   f12[2] += tmp * Fp * fn * 2.0f;
 }
 
+static __device__ __forceinline__ void find_dq_dr(
+  const int index_start,
+  const int index_step,
+  const int n,
+  const int n_max_angular_plus_1,
+  const float d12,
+  const float* r12,
+  float fn,
+  float fnp,
+  const float* s,
+  float* dq_dx,
+  float* dq_dy,
+  float* dq_dz)
+{
+  const float d12inv = 1.0f / d12;
+  // l = 1
+  fnp = fnp * d12inv - fn * d12inv * d12inv;
+  fn = fn * d12inv;
+  float s1[3] = {
+    s[n * NUM_OF_ABC + 0] * C3B[0], s[n * NUM_OF_ABC + 1] * C3B[1], s[n * NUM_OF_ABC + 2] * C3B[2]};
+  float dq_dr_1[3] = {0.0f};
+  get_f12_1(d12inv, fn, fnp, 1.0f, s1, r12, dq_dr_1);
+  int index = index_start;
+  dq_dx[index] = dq_dr_1[0];
+  dq_dy[index] = dq_dr_1[1];
+  dq_dy[index] = dq_dr_1[2];
+  // l = 2
+  fnp = fnp * d12inv - fn * d12inv * d12inv;
+  fn = fn * d12inv;
+  float s2[5] = {
+    s[n * NUM_OF_ABC + 3] * C3B[3], s[n * NUM_OF_ABC + 4] * C3B[4], s[n * NUM_OF_ABC + 5] * C3B[5],
+    s[n * NUM_OF_ABC + 6] * C3B[6], s[n * NUM_OF_ABC + 7] * C3B[7]};
+  float dq_dr_2[3] = {0.0f};
+  get_f12_2(d12, d12inv, fn, fnp, 1.0f, s2, r12, dq_dr_2);
+  index += index_step;
+  dq_dx[index] = dq_dr_2[0];
+  dq_dy[index] = dq_dr_2[1];
+  dq_dy[index] = dq_dr_2[2];
+  // l = 3
+  fnp = fnp * d12inv - fn * d12inv * d12inv;
+  fn = fn * d12inv;
+  float s3[7] = {s[n * NUM_OF_ABC + 8] * C3B[8],   s[n * NUM_OF_ABC + 9] * C3B[9],
+                 s[n * NUM_OF_ABC + 10] * C3B[10], s[n * NUM_OF_ABC + 11] * C3B[11],
+                 s[n * NUM_OF_ABC + 12] * C3B[12], s[n * NUM_OF_ABC + 13] * C3B[13],
+                 s[n * NUM_OF_ABC + 14] * C3B[14]};
+  float dq_dr_3[3] = {0.0f};
+  get_f12_3(d12, d12inv, fn, fnp, 1.0f, s3, r12, dq_dr_3);
+  index += index_step;
+  dq_dx[index] = dq_dr_3[0];
+  dq_dy[index] = dq_dr_3[1];
+  dq_dy[index] = dq_dr_3[2];
+  // l = 4
+  fnp = fnp * d12inv - fn * d12inv * d12inv;
+  fn = fn * d12inv;
+  float s4[9] = {s[n * NUM_OF_ABC + 15] * C3B[15], s[n * NUM_OF_ABC + 16] * C3B[16],
+                 s[n * NUM_OF_ABC + 17] * C3B[17], s[n * NUM_OF_ABC + 18] * C3B[18],
+                 s[n * NUM_OF_ABC + 19] * C3B[19], s[n * NUM_OF_ABC + 20] * C3B[20],
+                 s[n * NUM_OF_ABC + 21] * C3B[21], s[n * NUM_OF_ABC + 22] * C3B[22],
+                 s[n * NUM_OF_ABC + 23] * C3B[23]};
+  float dq_dr_4[3] = {0.0f};
+  get_f12_4(r12[0], r12[1], r12[2], d12, d12inv, fn, fnp, 1.0f, s4, dq_dr_4);
+  index += index_step;
+  dq_dx[index] = dq_dr_4[0];
+  dq_dy[index] = dq_dr_4[1];
+  dq_dy[index] = dq_dr_4[2];
+}
+
 static __device__ __forceinline__ void accumulate_f12(
   const int n,
   const int n_max_angular_plus_1,


### PR DESCRIPTION
* speed up the kernel `apply_gnn_message_passing`
* speed up the kernel `apply_gnn_compute_message`
* make { dq^i_mu/d\vec{r}_ij } available. This array is of length `3 * num_atoms * MAX_NUM_NEIGHBORS * dim`. In NEP4, `cutoff` can be small (as the effective cutoff will be doubled by message passing), and `MAX_NUM_NEIGHBORS ` can be small, such as `~20`. In NEP4, `dim` can also be small. Anyway, NEP4 will be more time-consuming and memory consuming than NEP2/NEP3, but hope it is more accurate.


`nep.in` for the PbTe example:
```
version      4
type         2 Te Pb
cutoff       6 6 # only the second number (angular cutoff) is used for NEP4
n_max        6 6 # only the second number (angular n_max) is used for NEP4
neuron       40
batch        25
generation   100
lambda_f     0
lambda_1     0.001
lambda_2     0.001
```