### PR TITLE
Make sure velocities in xyz.in are properly used for initialization

### DIFF
--- a/src/model/read_xyz.cu
+++ b/src/model/read_xyz.cu
@@ -476,6 +476,7 @@ void allocate_memory_gpu(
   atom.position_per_atom.resize(N * 3);
   atom.position_per_atom.copy_from_host(atom.cpu_position_per_atom.data());
   atom.velocity_per_atom.resize(N * 3);
+  atom.velocity_per_atom.copy_from_host(atom.cpu_velocity_per_atom.data());
   atom.force_per_atom.resize(N * 3);
   atom.virial_per_atom.resize(N * 9);
   atom.potential_per_atom.resize(N);


### PR DESCRIPTION
It seems like velocities as provided in the `xyz.in` file have no effect on an MD simulation. I think this is because velocities are read into `atom.cpu_velocity_per_atom` but never copied to the "GPU version" of the same array. This PR fixes this with one line, but I'm not sure it is the proper way to do it.

Here is a minimal working example with two atoms to test this:
[velocity-bug.tar.gz](https://github.com/brucefan1983/GPUMD/files/8532059/velocity-bug.tar.gz)

One of the two atoms is given a large velocity in the x direction. In the current master branch, it is quite clear that this does not affect the system. In this branch, that atom is properly shot onto the other. 
