### PR TITLE
Fixed the error on some units

### DIFF
--- a/examples/nep_potentials/Carbon/F_DOS/DOS_results.txt
+++ b/examples/nep_potentials/Carbon/F_DOS/DOS_results.txt
@@ -1,4 +1,4 @@
-#Frequency(THz) VDOS
+#Frequency(THz) VDOS(1/THz)
 0.318310    2.688034
 0.636620    8.023230
 0.954930    20.919810

--- a/examples/nep_potentials/Carbon/F_DOS/Heat_capacity_results.txt
+++ b/examples/nep_potentials/Carbon/F_DOS/Heat_capacity_results.txt
@@ -1,4 +1,4 @@
-#Temperature(THz) Heat_Capacity(kB/atom)
+#Temperature(K) Heat_Capacity(kB/atom)
 10.000000    0.000078
 110.000000    0.130186
 210.000000    0.557350


### PR DESCRIPTION
I have fixed some errors on the units of temperature and VDOS in the NEP3 example of carbon.