### PR TITLE
allow for using dynamic seed for langevin when not debugging

### DIFF
--- a/src/integrate/ensemble_lan.cu
+++ b/src/integrate/ensemble_lan.cu
@@ -19,8 +19,9 @@ The Bussi-Parrinello integrator of the Langevin thermostat:
 ------------------------------------------------------------------------------*/
 
 #include "ensemble_lan.cuh"
-#include "utilities/common.cuh"
 #include "langevin_utilities.cuh"
+#include "utilities/common.cuh"
+#include <cstdlib>
 
 Ensemble_LAN::Ensemble_LAN(int t, int fg, int N, double T, double Tc)
 {
@@ -32,7 +33,7 @@ Ensemble_LAN::Ensemble_LAN(int t, int fg, int N, double T, double Tc)
   c2 = sqrt((1 - c1 * c1) * K_B * T);
   curand_states.resize(N);
   int grid_size = (N - 1) / 128 + 1;
-  initialize_curand_states<<<grid_size, 128>>>(curand_states.data(), N);
+  initialize_curand_states<<<grid_size, 128>>>(curand_states.data(), N, rand());
   CUDA_CHECK_KERNEL
 }
 
@@ -67,9 +68,10 @@ Ensemble_LAN::Ensemble_LAN(
   curand_states_sink.resize(N_sink);
   int grid_size_source = (N_source - 1) / 128 + 1;
   int grid_size_sink = (N_sink - 1) / 128 + 1;
-  initialize_curand_states<<<grid_size_source, 128>>>(curand_states_source.data(), N_source);
+  initialize_curand_states<<<grid_size_source, 128>>>(
+    curand_states_source.data(), N_source, rand());
   CUDA_CHECK_KERNEL
-  initialize_curand_states<<<grid_size_sink, 128>>>(curand_states_sink.data(), N_sink);
+  initialize_curand_states<<<grid_size_sink, 128>>>(curand_states_sink.data(), N_sink, rand());
   CUDA_CHECK_KERNEL
   energy_transferred[0] = 0.0;
   energy_transferred[1] = 0.0;

--- a/src/integrate/langevin_utilities.cuh
+++ b/src/integrate/langevin_utilities.cuh
@@ -20,12 +20,11 @@ Some CUDA kernels for Langevin thermostats.
 #define CURAND_NORMAL(a) curand_normal_double(a)
 
 // initialize curand states
-static __global__ void initialize_curand_states(curandState* state, int N)
+static __global__ void initialize_curand_states(curandState* state, int N, int seed)
 {
   int n = blockIdx.x * blockDim.x + threadIdx.x;
-  // We can use a fixed seed here.
   if (n < N) {
-    curand_init(123456, n, 0, &state[n]);
+    curand_init(seed, n, 0, &state[n]);
   }
 }
 


### PR DESCRIPTION
Before this fix, the Langevin thermost will use fixed random numbers for different runs, which can lead to strong correlation. See the figure below 

![image](https://user-images.githubusercontent.com/24891193/168476866-b7835455-823c-455e-a4a6-8e4b642d1145.png)
