### PR TITLE
use mt19937 rng for BDP thermostat

### DIFF
--- a/src/integrate/ensemble_bdp.cuh
+++ b/src/integrate/ensemble_bdp.cuh
@@ -15,6 +15,7 @@
 
 #pragma once
 #include "ensemble.cuh"
+#include <random>
 
 class Ensemble_BDP : public Ensemble
 {
@@ -48,6 +49,9 @@ public:
     GPU_Vector<double>& thermo);
 
 protected:
+  std::mt19937 rng;
+  void initialize_rng();
+
   void integrate_nvt_bdp_2(
     const double time_step,
     const double volume,

--- a/src/integrate/ensemble_npt_scr.cuh
+++ b/src/integrate/ensemble_npt_scr.cuh
@@ -15,6 +15,7 @@
 
 #pragma once
 #include "ensemble.cuh"
+#include <random>
 
 class Ensemble_NPT_SCR : public Ensemble
 {
@@ -45,4 +46,8 @@ public:
     GPU_Vector<double>& position_per_atom,
     GPU_Vector<double>& velocity_per_atom,
     GPU_Vector<double>& thermo);
+
+protected:
+  std::mt19937 rng;
+  void initialize_rng();
 };


### PR DESCRIPTION
The `ran1()` function in Bussi's original code seems to be too simple, leading to correlated results from differnet runs. 