### PR TITLE
multiple GPUs for NEP

### DIFF
--- a/src/force/.vscode/settings.json
+++ b/src/force/.vscode/settings.json
@@ -4,6 +4,7 @@
         "*.cuh": "cpp",
         "vector": "cpp",
         "xutility": "cpp",
-        "memory": "cpp"
+        "memory": "cpp",
+        "xstring": "cpp"
     }
 }

--- a/src/force/nep3.cu
+++ b/src/force/nep3.cu
@@ -942,6 +942,76 @@ void NEP3::compute_large_box_single_gpu(
   }
 }
 
+void NEP3::compute_large_box_multi_gpu(
+  const int* num_bins,
+  const int type_shift,
+  Box& box,
+  const GPU_Vector<int>& type,
+  const GPU_Vector<double>& position_per_atom,
+  GPU_Vector<double>& potential_per_atom,
+  GPU_Vector<double>& force_per_atom,
+  GPU_Vector<double>& virial_per_atom)
+{
+  const int BLOCK_SIZE = 64;
+  const int N = type.size();
+  const int grid_size = (N2 - N1 - 1) / BLOCK_SIZE + 1;
+
+  allocate_memory(N);
+
+  find_cell_list(
+    rc_cell_list, num_bins, box, position_per_atom, nep_data.cell_count, nep_data.cell_count_sum,
+    nep_data.cell_contents);
+
+  find_neighbor_list_large_box<<<grid_size, BLOCK_SIZE>>>(
+    paramb, N, N1, N2, num_bins[0], num_bins[1], num_bins[2], box, nep_data.cell_count.data(),
+    nep_data.cell_count_sum.data(), nep_data.cell_contents.data(), position_per_atom.data(),
+    position_per_atom.data() + N, position_per_atom.data() + N * 2, nep_data.NN_radial.data(),
+    nep_data.NL_radial.data(), nep_data.NN_angular.data(), nep_data.NL_angular.data());
+  CUDA_CHECK_KERNEL
+
+  gpu_sort_neighbor_list<<<N, paramb.MN_radial, paramb.MN_radial * sizeof(int)>>>(
+    N, nep_data.NN_radial.data(), nep_data.NL_radial.data());
+  CUDA_CHECK_KERNEL
+
+  gpu_sort_neighbor_list<<<N, paramb.MN_angular, paramb.MN_angular * sizeof(int)>>>(
+    N, nep_data.NN_angular.data(), nep_data.NL_angular.data());
+  CUDA_CHECK_KERNEL
+
+  find_descriptor<<<grid_size, BLOCK_SIZE>>>(
+    paramb, annmb, N, N1, N2, box, nep_data.NN_radial.data(), nep_data.NL_radial.data(),
+    nep_data.NN_angular.data(), nep_data.NL_angular.data(), type.data(), position_per_atom.data(),
+    position_per_atom.data() + N, position_per_atom.data() + N * 2, potential_per_atom.data(),
+    nep_data.Fp.data(), nep_data.sum_fxyz.data());
+  CUDA_CHECK_KERNEL
+
+  find_force_radial<<<grid_size, BLOCK_SIZE>>>(
+    paramb, annmb, N, N1, N2, box, nep_data.NN_radial.data(), nep_data.NL_radial.data(),
+    type.data(), position_per_atom.data(), position_per_atom.data() + N,
+    position_per_atom.data() + N * 2, nep_data.Fp.data(), force_per_atom.data(),
+    force_per_atom.data() + N, force_per_atom.data() + N * 2, virial_per_atom.data());
+  CUDA_CHECK_KERNEL
+
+  find_partial_force_angular<<<grid_size, BLOCK_SIZE>>>(
+    paramb, annmb, N, N1, N2, box, nep_data.NN_angular.data(), nep_data.NL_angular.data(),
+    type.data(), position_per_atom.data(), position_per_atom.data() + N,
+    position_per_atom.data() + N * 2, nep_data.Fp.data(), nep_data.sum_fxyz.data(),
+    nep_data.f12x.data(), nep_data.f12y.data(), nep_data.f12z.data());
+  CUDA_CHECK_KERNEL
+  find_properties_many_body(
+    box, nep_data.NN_angular.data(), nep_data.NL_angular.data(), nep_data.f12x.data(),
+    nep_data.f12y.data(), nep_data.f12z.data(), position_per_atom, force_per_atom, virial_per_atom);
+  CUDA_CHECK_KERNEL
+
+  if (zbl.enabled) {
+    find_force_ZBL<<<grid_size, BLOCK_SIZE>>>(
+      N, zbl, N1, N2, box, nep_data.NN_angular.data(), nep_data.NL_angular.data(), type.data(),
+      position_per_atom.data(), position_per_atom.data() + N, position_per_atom.data() + N * 2,
+      force_per_atom.data(), force_per_atom.data() + N, force_per_atom.data() + N * 2,
+      virial_per_atom.data(), potential_per_atom.data());
+    CUDA_CHECK_KERNEL
+  }
+}
+
 // small box possibly used for active learning:
 void NEP3::compute_small_box(
   const int type_shift,
@@ -1086,9 +1156,9 @@ void NEP3::compute(
     box.get_num_bins(rc_cell_list, num_bins);
     check_gpus(num_bins);
     if (num_gpus > 1) {
-      // compute_large_box_multi_gpu(
-      //   num_bins, type_shift, box, type, position_per_atom, potential_per_atom, force_per_atom,
-      //   virial_per_atom);
+      compute_large_box_multi_gpu(
+        num_bins, type_shift, box, type, position_per_atom, potential_per_atom, force_per_atom,
+        virial_per_atom);
     } else {
       compute_large_box_single_gpu(
         num_bins, type_shift, box, type, position_per_atom, potential_per_atom, force_per_atom,

--- a/src/force/nep3.cu
+++ b/src/force/nep3.cu
@@ -40,6 +40,13 @@ const std::string ELEMENTS[NUM_ELEMENTS] = {
   "Os", "Ir", "Pt", "Au", "Hg", "Tl", "Pb", "Bi", "Po", "At", "Rn", "Fr", "Ra", "Ac", "Th",
   "Pa", "U",  "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr"};
 
+void NEP3::check_gpus()
+{
+  int num_gpus;
+  CHECK(cudaGetDeviceCount(&num_gpus));
+  printf("    using %d GPU(s).\n", num_gpus);
+}
+
 NEP3::NEP3(char* file_potential, const int num_atoms)
 {
 
@@ -88,6 +95,8 @@ NEP3::NEP3(char* file_potential, const int num_atoms)
       printf("Use the NEP3 potential with %d atom types.\n", paramb.num_types);
     }
   }
+
+  check_gpus();
 
   for (int n = 0; n < paramb.num_types; ++n) {
     int atomic_number = 0;

--- a/src/force/nep3.cu
+++ b/src/force/nep3.cu
@@ -40,26 +40,10 @@ const std::string ELEMENTS[NUM_ELEMENTS] = {
   "Os", "Ir", "Pt", "Au", "Hg", "Tl", "Pb", "Bi", "Po", "At", "Rn", "Fr", "Ra", "Ac", "Th",
   "Pa", "U",  "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr"};
 
-void NEP3::check_gpus(const int* num_bins)
+void NEP3::check_gpus(const int num_domains)
 {
   CHECK(cudaGetDeviceCount(&num_gpus));
-  if (num_gpus > 1) {
-    int num_domains[3] = {num_bins[0] / 100 + 1, num_bins[1] / 100 + 1, num_bins[2] / 100 + 1};
-    domain_decomposition_direction = 0;
-    if (num_domains[1] > num_domains[0]) {
-      domain_decomposition_direction = 1;
-      if (num_domains[2] > num_domains[1]) {
-        domain_decomposition_direction = 2;
-      }
-    } else {
-      if (num_domains[2] > num_domains[0]) {
-        domain_decomposition_direction = 2;
-      }
-    }
-    if (num_domains[domain_decomposition_direction] < num_gpus) {
-      num_gpus = num_domains[domain_decomposition_direction];
-    }
-  }
+  num_gpus = (num_domains < num_gpus) ? num_domains : num_gpus;
 }
 
 void NEP3::read_nep(std::ifstream& input)
@@ -1200,7 +1184,7 @@ void NEP3::compute(
   } else {
     int num_bins[3];
     box.get_num_bins(rc_cell_list, num_bins);
-    check_gpus(num_bins);
+    check_gpus(num_bins[2] / 100 + 1);
     if (num_gpus > 1) {
       compute_large_box_multi_gpu(
         num_bins, type_shift, box, type, position_per_atom, potential_per_atom, force_per_atom,

--- a/src/force/nep3.cuh
+++ b/src/force/nep3.cuh
@@ -105,10 +105,9 @@ private:
   NEP3_Data nep_data[MAX_NUM_GPU];
   ExpandedBox ebox;
   int num_gpus = 1;
-  int domain_decomposition_direction = 0;
   double rc_cell_list = 0;
 
-  void check_gpus(const int* num_bins);
+  void check_gpus(const int num_domains);
   void read_nep(std::ifstream& input);
   void read_zbl(std::ifstream& input);
   void read_cutoff(std::ifstream& input);

--- a/src/force/nep3.cuh
+++ b/src/force/nep3.cuh
@@ -17,6 +17,8 @@
 #include "potential.cuh"
 #include "utilities/gpu_vector.cuh"
 
+const int MAX_NUM_GPU = 16;
+
 struct NEP3_Data {
   GPU_Vector<float> f12x; // 3-body or manybody partial forces
   GPU_Vector<float> f12y; // 3-body or manybody partial forces
@@ -97,9 +99,9 @@ public:
 
 private:
   ParaMB paramb;
-  ANN annmb;
+  ANN annmb[MAX_NUM_GPU];
   ZBL zbl;
-  NEP3_Data nep_data;
+  NEP3_Data nep_data[MAX_NUM_GPU];
   ExpandedBox ebox;
   int num_gpus = 1;
   int domain_decomposition_direction = 0;

--- a/src/force/nep3.cuh
+++ b/src/force/nep3.cuh
@@ -104,6 +104,13 @@ private:
   int num_gpus;
 
   void check_gpus();
+  void read_nep(std::ifstream& input);
+  void read_zbl(std::ifstream& input);
+  void read_cutoff(std::ifstream& input);
+  void read_n_max(std::ifstream& input);
+  void read_basis_size(std::ifstream& input);
+  void read_l_max(std::ifstream& input);
+  void read_ann(std::ifstream& input);
 
   void update_potential(const float* parameters, ANN& ann);
 

--- a/src/force/nep3.cuh
+++ b/src/force/nep3.cuh
@@ -101,9 +101,11 @@ private:
   ZBL zbl;
   NEP3_Data nep_data;
   ExpandedBox ebox;
-  int num_gpus;
+  int num_gpus = 1;
+  int domain_decomposition_direction = 0;
+  double rc_cell_list = 0;
 
-  void check_gpus();
+  void check_gpus(const int* num_bins);
   void read_nep(std::ifstream& input);
   void read_zbl(std::ifstream& input);
   void read_cutoff(std::ifstream& input);
@@ -111,6 +113,7 @@ private:
   void read_basis_size(std::ifstream& input);
   void read_l_max(std::ifstream& input);
   void read_ann(std::ifstream& input);
+  void allocate_memory(const int num_atoms);
 
   void update_potential(const float* parameters, ANN& ann);
 
@@ -123,7 +126,8 @@ private:
     GPU_Vector<double>& force,
     GPU_Vector<double>& virial);
 
-  void compute_large_box(
+  void compute_large_box_single_gpu(
+    const int* num_bins,
     const int type_shift,
     Box& box,
     const GPU_Vector<int>& type,

--- a/src/force/nep3.cuh
+++ b/src/force/nep3.cuh
@@ -33,6 +33,7 @@ struct NEP3_Data {
   GPU_Vector<int> cell_count;
   GPU_Vector<int> cell_count_sum;
   GPU_Vector<int> cell_contents;
+  GPU_Vector<float> r12;
 };
 
 class NEP3 : public Potential
@@ -116,6 +117,7 @@ private:
   void read_l_max(std::ifstream& input);
   void read_ann(std::ifstream& input);
   void allocate_memory(const int num_atoms);
+  void allocate_memory_small_box(const int num_atoms);
 
   void update_potential(const float* parameters, ANN& ann);
 

--- a/src/force/nep3.cuh
+++ b/src/force/nep3.cuh
@@ -135,4 +135,14 @@ private:
     GPU_Vector<double>& potential,
     GPU_Vector<double>& force,
     GPU_Vector<double>& virial);
+
+  void compute_large_box_multi_gpu(
+    const int* num_bins,
+    const int type_shift,
+    Box& box,
+    const GPU_Vector<int>& type,
+    const GPU_Vector<double>& position,
+    GPU_Vector<double>& potential,
+    GPU_Vector<double>& force,
+    GPU_Vector<double>& virial);
 };

--- a/src/force/nep3.cuh
+++ b/src/force/nep3.cuh
@@ -101,6 +101,9 @@ private:
   ZBL zbl;
   NEP3_Data nep_data;
   ExpandedBox ebox;
+  int num_gpus;
+
+  void check_gpus();
 
   void update_potential(const float* parameters, ANN& ann);
 


### PR DESCRIPTION
* Aim: add multi-GPU support for the NEP part, aiming for the following performance with eight 80-GB A100 within one node:
  - size: about 2e8 atoms 
  - speed: about 1e8 atom-step/second

* Related issue: #5 
  - I will not consider `MPI`, and I think it is better to restrict to a single node.