### PR TITLE
One node multi gpu

### DIFF
--- a/src/force/force.cu
+++ b/src/force/force.cu
@@ -140,14 +140,17 @@ void Force::initialize_potential(
   } else if (
     strcmp(potential_name, "nep") == 0 || strcmp(potential_name, "nep_zbl") == 0 ||
     strcmp(potential_name, "nep3") == 0 || strcmp(potential_name, "nep3_zbl") == 0) {
+#ifdef USE_MULTI_GPU
     int num_gpus;
     CHECK(cudaGetDeviceCount(&num_gpus));
-    printf("num_GPUs=%d\n", num_gpus);
     if (num_gpus == 1) {
-      potential[m].reset(new NEP3_MULTIGPU(num_gpus, file_potential[m], number_of_atoms));
+      potential[m].reset(new NEP3(file_potential[m], number_of_atoms));
     } else {
       potential[m].reset(new NEP3_MULTIGPU(num_gpus, file_potential[m], number_of_atoms));
     }
+#else
+    potential[m].reset(new NEP3(file_potential[m], number_of_atoms));
+#endif
   } else if (strcmp(potential_name, "lj") == 0) {
     potential[m].reset(new LJ(fid_potential, num_types, number_of_atoms));
   } else {

--- a/src/force/force.cu
+++ b/src/force/force.cu
@@ -22,6 +22,7 @@ The driver class calculating force and related quantities.
 #include "force.cuh"
 #include "lj.cuh"
 #include "nep3.cuh"
+#include "nep3_multigpu.cuh"
 #include "potential.cuh"
 #include "tersoff1988.cuh"
 #include "tersoff1989.cuh"
@@ -136,14 +137,17 @@ void Force::initialize_potential(
     potential[m].reset(new EAM(fid_potential, potential_name, num_types, number_of_atoms));
   } else if (strcmp(potential_name, "fcp") == 0) {
     potential[m].reset(new FCP(fid_potential, input_dir, number_of_atoms, box));
-  } else if (strcmp(potential_name, "nep") == 0) {
-    potential[m].reset(new NEP3(file_potential[m], number_of_atoms));
-  } else if (strcmp(potential_name, "nep_zbl") == 0) {
-    potential[m].reset(new NEP3(file_potential[m], number_of_atoms));
-  } else if (strcmp(potential_name, "nep3") == 0) {
-    potential[m].reset(new NEP3(file_potential[m], number_of_atoms));
-  } else if (strcmp(potential_name, "nep3_zbl") == 0) {
-    potential[m].reset(new NEP3(file_potential[m], number_of_atoms));
+  } else if (
+    strcmp(potential_name, "nep") == 0 || strcmp(potential_name, "nep_zbl") == 0 ||
+    strcmp(potential_name, "nep3") == 0 || strcmp(potential_name, "nep3_zbl") == 0) {
+    int num_GPUs;
+    CHECK(cudaGetDeviceCount(&num_GPUs));
+    printf("num_GPUs=%d\n", num_GPUs);
+    if (num_GPUs == 1) {
+      potential[m].reset(new NEP3(file_potential[m], number_of_atoms));
+    } else {
+      potential[m].reset(new NEP3_MULTIGPU(file_potential[m], number_of_atoms));
+    }
   } else if (strcmp(potential_name, "lj") == 0) {
     potential[m].reset(new LJ(fid_potential, num_types, number_of_atoms));
   } else {

--- a/src/force/force.cu
+++ b/src/force/force.cu
@@ -140,13 +140,13 @@ void Force::initialize_potential(
   } else if (
     strcmp(potential_name, "nep") == 0 || strcmp(potential_name, "nep_zbl") == 0 ||
     strcmp(potential_name, "nep3") == 0 || strcmp(potential_name, "nep3_zbl") == 0) {
-    int num_GPUs;
-    CHECK(cudaGetDeviceCount(&num_GPUs));
-    printf("num_GPUs=%d\n", num_GPUs);
-    if (num_GPUs == 1) {
-      potential[m].reset(new NEP3(file_potential[m], number_of_atoms));
+    int num_gpus;
+    CHECK(cudaGetDeviceCount(&num_gpus));
+    printf("num_GPUs=%d\n", num_gpus);
+    if (num_gpus == 1) {
+      potential[m].reset(new NEP3_MULTIGPU(num_gpus, file_potential[m], number_of_atoms));
     } else {
-      potential[m].reset(new NEP3_MULTIGPU(file_potential[m], number_of_atoms));
+      potential[m].reset(new NEP3_MULTIGPU(num_gpus, file_potential[m], number_of_atoms));
     }
   } else if (strcmp(potential_name, "lj") == 0) {
     potential[m].reset(new LJ(fid_potential, num_types, number_of_atoms));

--- a/src/force/neighbor.cu
+++ b/src/force/neighbor.cu
@@ -251,10 +251,11 @@ void find_cell_list(
     cell_count_sum.resize(N_cells);
   }
 
-  set_to_zero<<<(N_cells - 1) / 64 + 1, 64, 0, stream>>>(cell_count.size(), cell_count.data());
-  set_to_zero<<<(N_cells - 1) / 64 + 1, 64, 0, stream>>>(
+  set_to_zero<<<(cell_count.size() - 1) / 64 + 1, 64, 0, stream>>>(
+    cell_count.size(), cell_count.data());
+  set_to_zero<<<(cell_count_sum.size() - 1) / 64 + 1, 64, 0, stream>>>(
     cell_count_sum.size(), cell_count_sum.data());
-  set_to_zero<<<(N_cells - 1) / 64 + 1, 64, 0, stream>>>(
+  set_to_zero<<<(cell_contents.size() - 1) / 64 + 1, 64, 0, stream>>>(
     cell_contents.size(), cell_contents.data());
 
   find_cell_counts<<<grid_size, block_size, 0, stream>>>(
@@ -265,7 +266,8 @@ void find_cell_list(
     thrust::cuda::par.on(stream), cell_count.data(), cell_count.data() + N_cells,
     cell_count_sum.data());
 
-  set_to_zero<<<(N_cells - 1) / 64 + 1, 64, 0, stream>>>(cell_count.size(), cell_count.data());
+  set_to_zero<<<(cell_count.size() - 1) / 64 + 1, 64, 0, stream>>>(
+    cell_count.size(), cell_count.data());
 
   find_cell_contents<<<grid_size, block_size, 0, stream>>>(
     box, N, cell_count.data(), cell_count_sum.data(), cell_contents.data(), x, y, z, num_bins[0],

--- a/src/force/neighbor.cuh
+++ b/src/force/neighbor.cuh
@@ -32,6 +32,7 @@ void find_cell_list(
   const double rc,
   const int* num_bins,
   Box& box,
+  const int N,
   const GPU_Vector<double>& position_per_atom,
   GPU_Vector<int>& cell_count,
   GPU_Vector<int>& cell_count_sum,

--- a/src/force/neighbor.cuh
+++ b/src/force/neighbor.cuh
@@ -26,6 +26,17 @@ void find_cell_list(
   GPU_Vector<int>& cell_count,
   GPU_Vector<int>& cell_count_sum,
   GPU_Vector<int>& cell_contents);
+
+void find_cell_list(
+  cudaStream_t& stream,
+  const double rc,
+  const int* num_bins,
+  Box& box,
+  const GPU_Vector<double>& position_per_atom,
+  GPU_Vector<int>& cell_count,
+  GPU_Vector<int>& cell_count_sum,
+  GPU_Vector<int>& cell_contents);
+
 void find_neighbor(
   const int N1,
   const int N2,

--- a/src/force/nep3_multigpu.cu
+++ b/src/force/nep3_multigpu.cu
@@ -882,10 +882,10 @@ void NEP3_MULTIGPU::compute(
   const int type_shift,
   Box& box,
   const GPU_Vector<int>& type,
-  const GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& potential_per_atom,
-  GPU_Vector<double>& force_per_atom,
-  GPU_Vector<double>& virial_per_atom)
+  const GPU_Vector<double>& position,
+  GPU_Vector<double>& potential,
+  GPU_Vector<double>& force,
+  GPU_Vector<double>& virial)
 {
   const int BLOCK_SIZE = 64;
   const int N = type.size();
@@ -897,7 +897,7 @@ void NEP3_MULTIGPU::compute(
   box.get_num_bins(rc_cell_list, num_bins);
 
   for (int gpu = 0; gpu < paramb.num_gpus; ++gpu) {
-    nep_temp_data.position.copy_from_device(position_per_atom.data());
+    nep_temp_data.position.copy_from_device(position.data());
     nep_temp_data.position.copy_to_device(nep_data[gpu].position.data());
   }
 
@@ -981,7 +981,7 @@ void NEP3_MULTIGPU::compute(
 
     collect_properties<<<grid_size, BLOCK_SIZE, 0, nep_data[gpu].stream>>>(
       N, nep_temp_data.force.data(), nep_temp_data.potential.data(), nep_temp_data.virial.data(),
-      force_per_atom.data(), potential_per_atom.data(), virial_per_atom.data());
+      force.data(), potential.data(), virial.data());
     CUDA_CHECK_KERNEL
   }
 }

--- a/src/force/nep3_multigpu.cu
+++ b/src/force/nep3_multigpu.cu
@@ -275,6 +275,9 @@ NEP3_MULTIGPU::NEP3_MULTIGPU(const int num_gpus, char* file_potential, const int
     CHECK(cudaStreamCreate(&nep_data[gpu].stream));
   }
 
+  nep_temp_data.cell_count.resize(num_atoms_per_gpu);
+  nep_temp_data.cell_count_sum.resize(num_atoms_per_gpu);
+  nep_temp_data.cell_contents.resize(num_atoms_per_gpu);
   nep_temp_data.position.resize(num_atoms_per_gpu * 3);
   nep_temp_data.potential.resize(num_atoms_per_gpu);
   nep_temp_data.force.resize(num_atoms_per_gpu * 3);
@@ -907,6 +910,10 @@ void NEP3_MULTIGPU::compute(
 
   int num_bins[3];
   box.get_num_bins(rc_cell_list, num_bins);
+
+  find_cell_list(
+    rc_cell_list, num_bins, box, position, nep_temp_data.cell_count, nep_temp_data.cell_count_sum,
+    nep_temp_data.cell_contents);
 
   for (int gpu = 0; gpu < paramb.num_gpus; ++gpu) {
     distribute_position<<<grid_size, BLOCK_SIZE, 0, nep_data[gpu].stream>>>(

--- a/src/force/nep3_multigpu.cu
+++ b/src/force/nep3_multigpu.cu
@@ -1,0 +1,873 @@
+/*
+    Copyright 2017 Zheyong Fan, Ville Vierimaa, Mikko Ervasti, and Ari Harju
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*----------------------------------------------------------------------------80
+The neuroevolution potential (NEP)
+Ref: Zheyong Fan et al., Neuroevolution machine learning potentials:
+Combining high accuracy and low cost in atomistic simulations and application to
+heat transport, Phys. Rev. B. 104, 104309 (2021).
+------------------------------------------------------------------------------*/
+
+#include "neighbor.cuh"
+#include "nep3_multigpu.cuh"
+#include "utilities/common.cuh"
+#include "utilities/error.cuh"
+#include "utilities/nep_utilities.cuh"
+#include <iostream>
+#include <string>
+#include <vector>
+
+const int NUM_ELEMENTS = 103;
+const std::string ELEMENTS[NUM_ELEMENTS] = {
+  "H",  "He", "Li", "Be", "B",  "C",  "N",  "O",  "F",  "Ne", "Na", "Mg", "Al", "Si", "P",
+  "S",  "Cl", "Ar", "K",  "Ca", "Sc", "Ti", "V",  "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn",
+  "Ga", "Ge", "As", "Se", "Br", "Kr", "Rb", "Sr", "Y",  "Zr", "Nb", "Mo", "Tc", "Ru", "Rh",
+  "Pd", "Ag", "Cd", "In", "Sn", "Sb", "Te", "I",  "Xe", "Cs", "Ba", "La", "Ce", "Pr", "Nd",
+  "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu", "Hf", "Ta", "W",  "Re",
+  "Os", "Ir", "Pt", "Au", "Hg", "Tl", "Pb", "Bi", "Po", "At", "Rn", "Fr", "Ra", "Ac", "Th",
+  "Pa", "U",  "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr"};
+
+NEP3_MULTIGPU::NEP3_MULTIGPU(char* file_potential, const int num_atoms)
+{
+
+  std::ifstream input(file_potential);
+  if (!input.is_open()) {
+    std::cout << "Failed to open " << file_potential << std::endl;
+    exit(1);
+  }
+
+  // nep3 1 C
+  std::vector<std::string> tokens = get_tokens(input);
+  if (tokens.size() < 3) {
+    std::cout << "The first line of nep.txt should have at least 3 items." << std::endl;
+    exit(1);
+  }
+  if (tokens[0] == "nep") {
+    paramb.version = 2;
+    zbl.enabled = false;
+  } else if (tokens[0] == "nep3") {
+    paramb.version = 3;
+    zbl.enabled = false;
+  } else if (tokens[0] == "nep_zbl") {
+    paramb.version = 2;
+    zbl.enabled = true;
+  } else if (tokens[0] == "nep3_zbl") {
+    paramb.version = 3;
+    zbl.enabled = true;
+  }
+  paramb.num_types = get_int_from_token(tokens[1], __FILE__, __LINE__);
+  if (tokens.size() != 2 + paramb.num_types) {
+    std::cout << "The first line of nep.txt should have " << paramb.num_types << " atom symbols."
+              << std::endl;
+    exit(1);
+  }
+
+  if (paramb.version == 2) {
+    if (paramb.num_types == 1) {
+      printf("Use the NEP2 potential with %d atom type.\n", paramb.num_types);
+    } else {
+      printf("Use the NEP2 potential with %d atom types.\n", paramb.num_types);
+    }
+  } else {
+    if (paramb.num_types == 1) {
+      printf("Use the NEP3 potential with %d atom type.\n", paramb.num_types);
+    } else {
+      printf("Use the NEP3 potential with %d atom types.\n", paramb.num_types);
+    }
+  }
+
+  for (int n = 0; n < paramb.num_types; ++n) {
+    int atomic_number = 0;
+    for (int m = 0; m < NUM_ELEMENTS; ++m) {
+      if (tokens[2 + n] == ELEMENTS[m]) {
+        atomic_number = m + 1;
+        break;
+      }
+    }
+    zbl.atomic_numbers[n] = atomic_number;
+    printf("    type %d (%s with Z = %g).\n", n, tokens[2 + n].c_str(), zbl.atomic_numbers[n]);
+  }
+
+  // zbl 0.7 1.4
+  if (zbl.enabled) {
+    tokens = get_tokens(input);
+    if (tokens.size() != 3) {
+      std::cout << "This line should be zbl rc_inner rc_outer." << std::endl;
+      exit(1);
+    }
+    zbl.rc_inner = get_float_from_token(tokens[1], __FILE__, __LINE__);
+    zbl.rc_outer = get_float_from_token(tokens[2], __FILE__, __LINE__);
+    printf(
+      "    has ZBL with inner cutoff %g A and outer cutoff %g A.\n", zbl.rc_inner, zbl.rc_outer);
+  }
+
+  // cutoff 4.2 3.7 80 47
+  tokens = get_tokens(input);
+  if (tokens.size() != 5) {
+    std::cout << "This line should be cutoff rc_radial rc_angular MN_radial MN_angular.\n"
+              << "You might have used a NEP model trained by GPUMD-v3.3.1 or older." << std::endl;
+    exit(1);
+  }
+  paramb.rc_radial = get_float_from_token(tokens[1], __FILE__, __LINE__);
+  paramb.rc_angular = get_float_from_token(tokens[2], __FILE__, __LINE__);
+  printf("    radial cutoff = %g A.\n", paramb.rc_radial);
+  printf("    angular cutoff = %g A.\n", paramb.rc_angular);
+
+  int MN_radial = get_int_from_token(tokens[3], __FILE__, __LINE__);
+  int MN_angular = get_int_from_token(tokens[4], __FILE__, __LINE__);
+  printf("    MN_radial = %d.\n", MN_radial);
+  printf("    MN_angular = %d.\n", MN_angular);
+  paramb.MN_radial = int(ceil(MN_radial * 1.25));
+  paramb.MN_angular = int(ceil(MN_angular * 1.25));
+  printf("    enlarged MN_radial = %d.\n", paramb.MN_radial);
+  printf("    enlarged MN_angular = %d.\n", paramb.MN_angular);
+
+  // n_max 10 8
+  tokens = get_tokens(input);
+  if (tokens.size() != 3) {
+    std::cout << "This line should be n_max n_max_radial n_max_angular." << std::endl;
+    exit(1);
+  }
+  paramb.n_max_radial = get_int_from_token(tokens[1], __FILE__, __LINE__);
+  paramb.n_max_angular = get_int_from_token(tokens[2], __FILE__, __LINE__);
+  printf("    n_max_radial = %d.\n", paramb.n_max_radial);
+  printf("    n_max_angular = %d.\n", paramb.n_max_angular);
+
+  // basis_size 10 8
+  if (paramb.version == 3) {
+    tokens = get_tokens(input);
+    if (tokens.size() != 3) {
+      std::cout << "This line should be basis_size basis_size_radial basis_size_angular."
+                << std::endl;
+      exit(1);
+    }
+    paramb.basis_size_radial = get_int_from_token(tokens[1], __FILE__, __LINE__);
+    paramb.basis_size_angular = get_int_from_token(tokens[2], __FILE__, __LINE__);
+    printf("    basis_size_radial = %d.\n", paramb.basis_size_radial);
+    printf("    basis_size_angular = %d.\n", paramb.basis_size_angular);
+  }
+
+  // l_max
+  tokens = get_tokens(input);
+  if (paramb.version == 2) {
+    if (tokens.size() != 2) {
+      std::cout << "This line should be l_max l_max_3body." << std::endl;
+      exit(1);
+    }
+  } else if (paramb.version == 3) {
+    if (tokens.size() != 4) {
+      std::cout << "This line should be l_max l_max_3body l_max_4body l_max_5body." << std::endl;
+      exit(1);
+    }
+  }
+
+  paramb.L_max = get_int_from_token(tokens[1], __FILE__, __LINE__);
+  printf("    l_max_3body = %d.\n", paramb.L_max);
+  paramb.num_L = paramb.L_max;
+
+  if (paramb.version == 3) {
+    int L_max_4body = get_int_from_token(tokens[2], __FILE__, __LINE__);
+    int L_max_5body = get_int_from_token(tokens[3], __FILE__, __LINE__);
+    printf("    l_max_4body = %d.\n", L_max_4body);
+    printf("    l_max_5body = %d.\n", L_max_5body);
+    if (L_max_4body == 2) {
+      paramb.num_L += 1;
+    }
+    if (L_max_5body == 1) {
+      paramb.num_L += 1;
+    }
+  }
+
+  paramb.dim_angular = (paramb.n_max_angular + 1) * paramb.num_L;
+
+  // ANN
+  tokens = get_tokens(input);
+  if (tokens.size() != 3) {
+    std::cout << "This line should be ANN num_neurons 0." << std::endl;
+    exit(1);
+  }
+  annmb.num_neurons1 = get_int_from_token(tokens[1], __FILE__, __LINE__);
+  annmb.dim = (paramb.n_max_radial + 1) + paramb.dim_angular;
+  printf("    ANN = %d-%d-1.\n", annmb.dim, annmb.num_neurons1);
+
+  // calculated parameters:
+  rc = paramb.rc_radial; // largest cutoff
+  paramb.rcinv_radial = 1.0f / paramb.rc_radial;
+  paramb.rcinv_angular = 1.0f / paramb.rc_angular;
+  paramb.num_types_sq = paramb.num_types * paramb.num_types;
+
+  annmb.num_para = (annmb.dim + 2) * annmb.num_neurons1 + 1;
+  printf("    number of neural network parameters = %d.\n", annmb.num_para);
+  int num_para_descriptor =
+    paramb.num_types_sq * ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1) +
+                           (paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
+  if (paramb.version == 2) {
+    num_para_descriptor =
+      (paramb.num_types == 1)
+        ? 0
+        : paramb.num_types_sq * (paramb.n_max_radial + paramb.n_max_angular + 2);
+  }
+  printf("    number of descriptor parameters = %d.\n", num_para_descriptor);
+  annmb.num_para += num_para_descriptor;
+  printf("    total number of parameters = %d\n", annmb.num_para);
+
+  paramb.num_c_radial =
+    paramb.num_types_sq * (paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1);
+
+  // NN and descriptor parameters
+  std::vector<float> parameters(annmb.num_para);
+  for (int n = 0; n < annmb.num_para; ++n) {
+    tokens = get_tokens(input);
+    parameters[n] = get_float_from_token(tokens[0], __FILE__, __LINE__);
+  }
+  nep_data.parameters.resize(annmb.num_para);
+  nep_data.parameters.copy_from_host(parameters.data());
+  update_potential(nep_data.parameters.data(), annmb);
+  for (int d = 0; d < annmb.dim; ++d) {
+    tokens = get_tokens(input);
+    paramb.q_scaler[d] = get_float_from_token(tokens[0], __FILE__, __LINE__);
+  }
+
+  nep_data.f12x.resize(num_atoms * paramb.MN_angular);
+  nep_data.f12y.resize(num_atoms * paramb.MN_angular);
+  nep_data.f12z.resize(num_atoms * paramb.MN_angular);
+  nep_data.NN_radial.resize(num_atoms);
+  nep_data.NL_radial.resize(num_atoms * paramb.MN_radial);
+  nep_data.NN_angular.resize(num_atoms);
+  nep_data.NL_angular.resize(num_atoms * paramb.MN_angular);
+  nep_data.Fp.resize(num_atoms * annmb.dim);
+  nep_data.sum_fxyz.resize(num_atoms * (paramb.n_max_angular + 1) * NUM_OF_ABC);
+  nep_data.cell_count.resize(num_atoms);
+  nep_data.cell_count_sum.resize(num_atoms);
+  nep_data.cell_contents.resize(num_atoms);
+}
+
+NEP3_MULTIGPU::~NEP3_MULTIGPU(void)
+{
+  // nothing
+}
+
+void NEP3_MULTIGPU::update_potential(const float* parameters, ANN& ann)
+{
+  ann.w0 = parameters;
+  ann.b0 = ann.w0 + ann.num_neurons1 * ann.dim;
+  ann.w1 = ann.b0 + ann.num_neurons1;
+  ann.b1 = ann.w1 + ann.num_neurons1;
+  ann.c = ann.b1 + 1;
+}
+
+static __global__ void find_neighbor_list_large_box(
+  NEP3_MULTIGPU::ParaMB paramb,
+  const int N,
+  const int N1,
+  const int N2,
+  const int nx,
+  const int ny,
+  const int nz,
+  const Box box,
+  const int* __restrict__ g_cell_count,
+  const int* __restrict__ g_cell_count_sum,
+  const int* __restrict__ g_cell_contents,
+  const double* __restrict__ g_x,
+  const double* __restrict__ g_y,
+  const double* __restrict__ g_z,
+  int* g_NN_radial,
+  int* g_NL_radial,
+  int* g_NN_angular,
+  int* g_NL_angular)
+{
+  int n1 = blockIdx.x * blockDim.x + threadIdx.x + N1;
+  if (n1 >= N2) {
+    return;
+  }
+
+  double x1 = g_x[n1];
+  double y1 = g_y[n1];
+  double z1 = g_z[n1];
+  int count_radial = 0;
+  int count_angular = 0;
+
+  int cell_id;
+  int cell_id_x;
+  int cell_id_y;
+  int cell_id_z;
+  find_cell_id(
+    box, x1, y1, z1, 2.0f * paramb.rcinv_radial, nx, ny, nz, cell_id_x, cell_id_y, cell_id_z,
+    cell_id);
+
+  const int z_lim = box.pbc_z ? 2 : 0;
+  const int y_lim = box.pbc_y ? 2 : 0;
+  const int x_lim = box.pbc_x ? 2 : 0;
+
+  for (int zz = -z_lim; zz <= z_lim; ++zz) {
+    for (int yy = -y_lim; yy <= y_lim; ++yy) {
+      for (int xx = -x_lim; xx <= x_lim; ++xx) {
+        int neighbor_cell = cell_id + zz * nx * ny + yy * nx + xx;
+        if (cell_id_x + xx < 0)
+          neighbor_cell += nx;
+        if (cell_id_x + xx >= nx)
+          neighbor_cell -= nx;
+        if (cell_id_y + yy < 0)
+          neighbor_cell += ny * nx;
+        if (cell_id_y + yy >= ny)
+          neighbor_cell -= ny * nx;
+        if (cell_id_z + zz < 0)
+          neighbor_cell += nz * ny * nx;
+        if (cell_id_z + zz >= nz)
+          neighbor_cell -= nz * ny * nx;
+
+        const int num_atoms_neighbor_cell = g_cell_count[neighbor_cell];
+        const int num_atoms_previous_cells = g_cell_count_sum[neighbor_cell];
+
+        for (int m = 0; m < num_atoms_neighbor_cell; ++m) {
+          const int n2 = g_cell_contents[num_atoms_previous_cells + m];
+
+          if (n2 < N1 || n2 >= N2 || n1 == n2) {
+            continue;
+          }
+
+          double x12double = g_x[n2] - x1;
+          double y12double = g_y[n2] - y1;
+          double z12double = g_z[n2] - z1;
+          apply_mic(box, x12double, y12double, z12double);
+          float x12 = float(x12double), y12 = float(y12double), z12 = float(z12double);
+          float d12_square = x12 * x12 + y12 * y12 + z12 * z12;
+
+          if (d12_square >= paramb.rc_radial * paramb.rc_radial) {
+            continue;
+          }
+
+          g_NL_radial[count_radial++ * N + n1] = n2;
+
+          if (d12_square < paramb.rc_angular * paramb.rc_angular) {
+            g_NL_angular[count_angular++ * N + n1] = n2;
+          }
+        }
+      }
+    }
+  }
+
+  g_NN_radial[n1] = count_radial;
+  g_NN_angular[n1] = count_angular;
+}
+
+static __global__ void find_descriptor(
+  NEP3_MULTIGPU::ParaMB paramb,
+  NEP3_MULTIGPU::ANN annmb,
+  const int N,
+  const int N1,
+  const int N2,
+  const Box box,
+  const int* g_NN,
+  const int* g_NL,
+  const int* g_NN_angular,
+  const int* g_NL_angular,
+  const int* __restrict__ g_type,
+  const double* __restrict__ g_x,
+  const double* __restrict__ g_y,
+  const double* __restrict__ g_z,
+  double* g_pe,
+  float* g_Fp,
+  float* g_sum_fxyz)
+{
+  int n1 = blockIdx.x * blockDim.x + threadIdx.x + N1;
+  if (n1 < N2) {
+    int t1 = g_type[n1];
+    double x1 = g_x[n1];
+    double y1 = g_y[n1];
+    double z1 = g_z[n1];
+    float q[MAX_DIM] = {0.0f};
+
+    // get radial descriptors
+    for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
+      int n2 = g_NL[n1 + N * i1];
+      double x12double = g_x[n2] - x1;
+      double y12double = g_y[n2] - y1;
+      double z12double = g_z[n2] - z1;
+      apply_mic(box, x12double, y12double, z12double);
+      float x12 = float(x12double), y12 = float(y12double), z12 = float(z12double);
+      float d12 = sqrt(x12 * x12 + y12 * y12 + z12 * z12);
+      float fc12;
+      find_fc(paramb.rc_radial, paramb.rcinv_radial, d12, fc12);
+      int t2 = g_type[n2];
+      float fn12[MAX_NUM_N];
+      if (paramb.version == 2) {
+        find_fn(paramb.n_max_radial, paramb.rcinv_radial, d12, fc12, fn12);
+        for (int n = 0; n <= paramb.n_max_radial; ++n) {
+          float c = (paramb.num_types == 1)
+                      ? 1.0f
+                      : annmb.c[(n * paramb.num_types + t1) * paramb.num_types + t2];
+          q[n] += fn12[n] * c;
+        }
+      } else {
+        find_fn(paramb.basis_size_radial, paramb.rcinv_radial, d12, fc12, fn12);
+        for (int n = 0; n <= paramb.n_max_radial; ++n) {
+          float gn12 = 0.0f;
+          for (int k = 0; k <= paramb.basis_size_radial; ++k) {
+            int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
+            c_index += t1 * paramb.num_types + t2;
+            gn12 += fn12[k] * annmb.c[c_index];
+          }
+          q[n] += gn12;
+        }
+      }
+    }
+
+    // get angular descriptors
+    for (int n = 0; n <= paramb.n_max_angular; ++n) {
+      float s[NUM_OF_ABC] = {0.0f};
+      for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
+        int n2 = g_NL_angular[n1 + N * i1];
+        double x12double = g_x[n2] - x1;
+        double y12double = g_y[n2] - y1;
+        double z12double = g_z[n2] - z1;
+        apply_mic(box, x12double, y12double, z12double);
+        float x12 = float(x12double), y12 = float(y12double), z12 = float(z12double);
+        float d12 = sqrt(x12 * x12 + y12 * y12 + z12 * z12);
+        float fc12;
+        find_fc(paramb.rc_angular, paramb.rcinv_angular, d12, fc12);
+        int t2 = g_type[n2];
+        if (paramb.version == 2) {
+          float fn;
+          find_fn(n, paramb.rcinv_angular, d12, fc12, fn);
+          fn *=
+            (paramb.num_types == 1)
+              ? 1.0f
+              : annmb.c
+                  [((paramb.n_max_radial + 1 + n) * paramb.num_types + t1) * paramb.num_types + t2];
+          accumulate_s(d12, x12, y12, z12, fn, s);
+        } else {
+          float fn12[MAX_NUM_N];
+          find_fn(paramb.basis_size_angular, paramb.rcinv_angular, d12, fc12, fn12);
+          float gn12 = 0.0f;
+          for (int k = 0; k <= paramb.basis_size_angular; ++k) {
+            int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
+            c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+            gn12 += fn12[k] * annmb.c[c_index];
+          }
+          accumulate_s(d12, x12, y12, z12, gn12, s);
+        }
+      }
+      if (paramb.num_L == paramb.L_max) {
+        find_q(paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
+      } else if (paramb.num_L == paramb.L_max + 1) {
+        find_q_with_4body(paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
+      } else {
+        find_q_with_5body(paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
+      }
+      for (int abc = 0; abc < NUM_OF_ABC; ++abc) {
+        g_sum_fxyz[(n * NUM_OF_ABC + abc) * N + n1] = s[abc];
+      }
+    }
+
+    // nomalize descriptor
+    for (int d = 0; d < annmb.dim; ++d) {
+      q[d] = q[d] * paramb.q_scaler[d];
+    }
+
+    // get energy and energy gradient
+    float F = 0.0f, Fp[MAX_DIM] = {0.0f};
+    apply_ann_one_layer(
+      annmb.dim, annmb.num_neurons1, annmb.w0, annmb.b0, annmb.w1, annmb.b1, q, F, Fp);
+    g_pe[n1] += F;
+
+    for (int d = 0; d < annmb.dim; ++d) {
+      g_Fp[d * N + n1] = Fp[d] * paramb.q_scaler[d];
+    }
+  }
+}
+
+static __global__ void find_force_radial(
+  NEP3_MULTIGPU::ParaMB paramb,
+  NEP3_MULTIGPU::ANN annmb,
+  const int N,
+  const int N1,
+  const int N2,
+  const Box box,
+  const int* g_NN,
+  const int* g_NL,
+  const int* __restrict__ g_type,
+  const double* __restrict__ g_x,
+  const double* __restrict__ g_y,
+  const double* __restrict__ g_z,
+  const float* __restrict__ g_Fp,
+  double* g_fx,
+  double* g_fy,
+  double* g_fz,
+  double* g_virial)
+{
+  int n1 = blockIdx.x * blockDim.x + threadIdx.x + N1;
+  if (n1 < N2) {
+    int t1 = g_type[n1];
+    float s_fx = 0.0f;
+    float s_fy = 0.0f;
+    float s_fz = 0.0f;
+    float s_sxx = 0.0f;
+    float s_sxy = 0.0f;
+    float s_sxz = 0.0f;
+    float s_syx = 0.0f;
+    float s_syy = 0.0f;
+    float s_syz = 0.0f;
+    float s_szx = 0.0f;
+    float s_szy = 0.0f;
+    float s_szz = 0.0f;
+    double x1 = g_x[n1];
+    double y1 = g_y[n1];
+    double z1 = g_z[n1];
+    for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
+      int n2 = g_NL[n1 + N * i1];
+      int t2 = g_type[n2];
+      double x12double = g_x[n2] - x1;
+      double y12double = g_y[n2] - y1;
+      double z12double = g_z[n2] - z1;
+      apply_mic(box, x12double, y12double, z12double);
+      float r12[3] = {float(x12double), float(y12double), float(z12double)};
+      float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
+      float d12inv = 1.0f / d12;
+      float fc12, fcp12;
+      find_fc_and_fcp(paramb.rc_radial, paramb.rcinv_radial, d12, fc12, fcp12);
+      float fn12[MAX_NUM_N];
+      float fnp12[MAX_NUM_N];
+
+      float f12[3] = {0.0f};
+      float f21[3] = {0.0f};
+      if (paramb.version == 2) {
+        find_fn_and_fnp(paramb.n_max_radial, paramb.rcinv_radial, d12, fc12, fcp12, fn12, fnp12);
+        for (int n = 0; n <= paramb.n_max_radial; ++n) {
+          float tmp12 = g_Fp[n1 + n * N] * fnp12[n] * d12inv;
+          float tmp21 = g_Fp[n2 + n * N] * fnp12[n] * d12inv;
+          tmp12 *= (paramb.num_types == 1)
+                     ? 1.0f
+                     : annmb.c[(n * paramb.num_types + t1) * paramb.num_types + t2];
+          tmp21 *= (paramb.num_types == 1)
+                     ? 1.0f
+                     : annmb.c[(n * paramb.num_types + t2) * paramb.num_types + t1];
+          for (int d = 0; d < 3; ++d) {
+            f12[d] += tmp12 * r12[d];
+            f21[d] -= tmp21 * r12[d];
+          }
+        }
+      } else {
+        find_fn_and_fnp(
+          paramb.basis_size_radial, paramb.rcinv_radial, d12, fc12, fcp12, fn12, fnp12);
+        for (int n = 0; n <= paramb.n_max_radial; ++n) {
+          float gnp12 = 0.0f;
+          float gnp21 = 0.0f;
+          for (int k = 0; k <= paramb.basis_size_radial; ++k) {
+            int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
+            gnp12 += fnp12[k] * annmb.c[c_index + t1 * paramb.num_types + t2];
+            gnp21 += fnp12[k] * annmb.c[c_index + t2 * paramb.num_types + t1];
+          }
+          float tmp12 = g_Fp[n1 + n * N] * gnp12 * d12inv;
+          float tmp21 = g_Fp[n2 + n * N] * gnp21 * d12inv;
+          for (int d = 0; d < 3; ++d) {
+            f12[d] += tmp12 * r12[d];
+            f21[d] -= tmp21 * r12[d];
+          }
+        }
+      }
+      s_fx += f12[0] - f21[0];
+      s_fy += f12[1] - f21[1];
+      s_fz += f12[2] - f21[2];
+      s_sxx += r12[0] * f21[0];
+      s_sxy += r12[0] * f21[1];
+      s_sxz += r12[0] * f21[2];
+      s_syx += r12[1] * f21[0];
+      s_syy += r12[1] * f21[1];
+      s_syz += r12[1] * f21[2];
+      s_szx += r12[2] * f21[0];
+      s_szy += r12[2] * f21[1];
+      s_szz += r12[2] * f21[2];
+    }
+    g_fx[n1] += s_fx;
+    g_fy[n1] += s_fy;
+    g_fz[n1] += s_fz;
+    // save virial
+    // xx xy xz    0 3 4
+    // yx yy yz    6 1 5
+    // zx zy zz    7 8 2
+    g_virial[n1 + 0 * N] += s_sxx;
+    g_virial[n1 + 1 * N] += s_syy;
+    g_virial[n1 + 2 * N] += s_szz;
+    g_virial[n1 + 3 * N] += s_sxy;
+    g_virial[n1 + 4 * N] += s_sxz;
+    g_virial[n1 + 5 * N] += s_syz;
+    g_virial[n1 + 6 * N] += s_syx;
+    g_virial[n1 + 7 * N] += s_szx;
+    g_virial[n1 + 8 * N] += s_szy;
+  }
+}
+
+static __global__ void find_partial_force_angular(
+  NEP3_MULTIGPU::ParaMB paramb,
+  NEP3_MULTIGPU::ANN annmb,
+  const int N,
+  const int N1,
+  const int N2,
+  const Box box,
+  const int* g_NN_angular,
+  const int* g_NL_angular,
+  const int* __restrict__ g_type,
+  const double* __restrict__ g_x,
+  const double* __restrict__ g_y,
+  const double* __restrict__ g_z,
+  const float* __restrict__ g_Fp,
+  const float* __restrict__ g_sum_fxyz,
+  float* g_f12x,
+  float* g_f12y,
+  float* g_f12z)
+{
+  int n1 = blockIdx.x * blockDim.x + threadIdx.x + N1;
+  if (n1 < N2) {
+
+    float Fp[MAX_DIM_ANGULAR] = {0.0f};
+    float sum_fxyz[NUM_OF_ABC * MAX_NUM_N];
+    for (int d = 0; d < paramb.dim_angular; ++d) {
+      Fp[d] = g_Fp[(paramb.n_max_radial + 1 + d) * N + n1];
+    }
+    for (int d = 0; d < (paramb.n_max_angular + 1) * NUM_OF_ABC; ++d) {
+      sum_fxyz[d] = g_sum_fxyz[d * N + n1];
+    }
+
+    int t1 = g_type[n1];
+    double x1 = g_x[n1];
+    double y1 = g_y[n1];
+    double z1 = g_z[n1];
+    for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
+      int index = i1 * N + n1;
+      int n2 = g_NL_angular[n1 + N * i1];
+      double x12double = g_x[n2] - x1;
+      double y12double = g_y[n2] - y1;
+      double z12double = g_z[n2] - z1;
+      apply_mic(box, x12double, y12double, z12double);
+      float r12[3] = {float(x12double), float(y12double), float(z12double)};
+      float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
+      float fc12, fcp12;
+      find_fc_and_fcp(paramb.rc_angular, paramb.rcinv_angular, d12, fc12, fcp12);
+      int t2 = g_type[n2];
+      float f12[3] = {0.0f};
+
+      if (paramb.version == 2) {
+        for (int n = 0; n <= paramb.n_max_angular; ++n) {
+          float fn;
+          float fnp;
+          find_fn_and_fnp(n, paramb.rcinv_angular, d12, fc12, fcp12, fn, fnp);
+          const float c =
+            (paramb.num_types == 1)
+              ? 1.0f
+              : annmb.c
+                  [((paramb.n_max_radial + 1 + n) * paramb.num_types + t1) * paramb.num_types + t2];
+          fn *= c;
+          fnp *= c;
+          accumulate_f12(n, paramb.n_max_angular + 1, d12, r12, fn, fnp, Fp, sum_fxyz, f12);
+        }
+      } else {
+        float fn12[MAX_NUM_N];
+        float fnp12[MAX_NUM_N];
+        find_fn_and_fnp(
+          paramb.basis_size_angular, paramb.rcinv_angular, d12, fc12, fcp12, fn12, fnp12);
+        for (int n = 0; n <= paramb.n_max_angular; ++n) {
+          float gn12 = 0.0f;
+          float gnp12 = 0.0f;
+          for (int k = 0; k <= paramb.basis_size_angular; ++k) {
+            int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
+            c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+            gn12 += fn12[k] * annmb.c[c_index];
+            gnp12 += fnp12[k] * annmb.c[c_index];
+          }
+          if (paramb.num_L == paramb.L_max) {
+            accumulate_f12(n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
+          } else if (paramb.num_L == paramb.L_max + 1) {
+            accumulate_f12_with_4body(
+              n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
+          } else {
+            accumulate_f12_with_5body(
+              n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
+          }
+        }
+      }
+      g_f12x[index] = f12[0];
+      g_f12y[index] = f12[1];
+      g_f12z[index] = f12[2];
+    }
+  }
+}
+
+static __global__ void find_force_ZBL(
+  const int N,
+  const NEP3_MULTIGPU::ZBL zbl,
+  const int N1,
+  const int N2,
+  const Box box,
+  const int* g_NN,
+  const int* g_NL,
+  const int* __restrict__ g_type,
+  const double* __restrict__ g_x,
+  const double* __restrict__ g_y,
+  const double* __restrict__ g_z,
+  double* g_fx,
+  double* g_fy,
+  double* g_fz,
+  double* g_virial,
+  double* g_pe)
+{
+  int n1 = blockIdx.x * blockDim.x + threadIdx.x + N1;
+  if (n1 < N2) {
+    float s_pe = 0.0f;
+    float s_fx = 0.0f;
+    float s_fy = 0.0f;
+    float s_fz = 0.0f;
+    float s_sxx = 0.0f;
+    float s_sxy = 0.0f;
+    float s_sxz = 0.0f;
+    float s_syx = 0.0f;
+    float s_syy = 0.0f;
+    float s_syz = 0.0f;
+    float s_szx = 0.0f;
+    float s_szy = 0.0f;
+    float s_szz = 0.0f;
+    double x1 = g_x[n1];
+    double y1 = g_y[n1];
+    double z1 = g_z[n1];
+    int type1 = g_type[n1];
+    float zi = zbl.atomic_numbers[type1];
+    float pow_zi = pow(zi, 0.23f);
+    for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
+      int n2 = g_NL[n1 + N * i1];
+      double x12double = g_x[n2] - x1;
+      double y12double = g_y[n2] - y1;
+      double z12double = g_z[n2] - z1;
+      apply_mic(box, x12double, y12double, z12double);
+      float r12[3] = {float(x12double), float(y12double), float(z12double)};
+      float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
+      float d12inv = 1.0f / d12;
+      float f, fp;
+      int type2 = g_type[n2];
+      float zj = zbl.atomic_numbers[type2];
+      float a_inv = (pow_zi + pow(zj, 0.23f)) * 2.134563f;
+      float zizj = K_C_SP * zi * zj;
+#ifdef USE_JESPER_HEA
+      find_f_and_fp_zbl(type1, type2, zizj, a_inv, zbl.rc_inner, zbl.rc_outer, d12, d12inv, f, fp);
+#else
+      find_f_and_fp_zbl(zizj, a_inv, zbl.rc_inner, zbl.rc_outer, d12, d12inv, f, fp);
+#endif
+      float f2 = fp * d12inv * 0.5f;
+      float f12[3] = {r12[0] * f2, r12[1] * f2, r12[2] * f2};
+      float f21[3] = {-r12[0] * f2, -r12[1] * f2, -r12[2] * f2};
+      s_fx += f12[0] - f21[0];
+      s_fy += f12[1] - f21[1];
+      s_fz += f12[2] - f21[2];
+      s_sxx -= r12[0] * f12[0];
+      s_sxy -= r12[0] * f12[1];
+      s_sxz -= r12[0] * f12[2];
+      s_syx -= r12[1] * f12[0];
+      s_syy -= r12[1] * f12[1];
+      s_syz -= r12[1] * f12[2];
+      s_szx -= r12[2] * f12[0];
+      s_szy -= r12[2] * f12[1];
+      s_szz -= r12[2] * f12[2];
+      s_pe += f * 0.5f;
+    }
+    g_fx[n1] += s_fx;
+    g_fy[n1] += s_fy;
+    g_fz[n1] += s_fz;
+    g_virial[n1 + 0 * N] += s_sxx;
+    g_virial[n1 + 1 * N] += s_syy;
+    g_virial[n1 + 2 * N] += s_szz;
+    g_virial[n1 + 3 * N] += s_sxy;
+    g_virial[n1 + 4 * N] += s_sxz;
+    g_virial[n1 + 5 * N] += s_syz;
+    g_virial[n1 + 6 * N] += s_syx;
+    g_virial[n1 + 7 * N] += s_szx;
+    g_virial[n1 + 8 * N] += s_szy;
+    g_pe[n1] += s_pe;
+  }
+}
+
+void NEP3_MULTIGPU::compute(
+  const int group_method,
+  std::vector<Group>& group,
+  const int type_begin,
+  const int type_end,
+  const int type_shift,
+  Box& box,
+  const GPU_Vector<int>& type,
+  const GPU_Vector<double>& position_per_atom,
+  GPU_Vector<double>& potential_per_atom,
+  GPU_Vector<double>& force_per_atom,
+  GPU_Vector<double>& virial_per_atom)
+{
+  const int BLOCK_SIZE = 64;
+  const int N = type.size();
+  const int grid_size = (N2 - N1 - 1) / BLOCK_SIZE + 1;
+
+  const double rc_cell_list = 0.5 * rc;
+
+  int num_bins[3];
+  box.get_num_bins(rc_cell_list, num_bins);
+
+  find_cell_list(
+    rc_cell_list, num_bins, box, position_per_atom, nep_data.cell_count, nep_data.cell_count_sum,
+    nep_data.cell_contents);
+
+  find_neighbor_list_large_box<<<grid_size, BLOCK_SIZE>>>(
+    paramb, N, N1, N2, num_bins[0], num_bins[1], num_bins[2], box, nep_data.cell_count.data(),
+    nep_data.cell_count_sum.data(), nep_data.cell_contents.data(), position_per_atom.data(),
+    position_per_atom.data() + N, position_per_atom.data() + N * 2, nep_data.NN_radial.data(),
+    nep_data.NL_radial.data(), nep_data.NN_angular.data(), nep_data.NL_angular.data());
+  CUDA_CHECK_KERNEL
+
+  gpu_sort_neighbor_list<<<N, paramb.MN_radial, paramb.MN_radial * sizeof(int)>>>(
+    N, nep_data.NN_radial.data(), nep_data.NL_radial.data());
+  CUDA_CHECK_KERNEL
+
+  gpu_sort_neighbor_list<<<N, paramb.MN_angular, paramb.MN_angular * sizeof(int)>>>(
+    N, nep_data.NN_angular.data(), nep_data.NL_angular.data());
+  CUDA_CHECK_KERNEL
+
+  find_descriptor<<<grid_size, BLOCK_SIZE>>>(
+    paramb, annmb, N, N1, N2, box, nep_data.NN_radial.data(), nep_data.NL_radial.data(),
+    nep_data.NN_angular.data(), nep_data.NL_angular.data(), type.data(), position_per_atom.data(),
+    position_per_atom.data() + N, position_per_atom.data() + N * 2, potential_per_atom.data(),
+    nep_data.Fp.data(), nep_data.sum_fxyz.data());
+  CUDA_CHECK_KERNEL
+
+  find_force_radial<<<grid_size, BLOCK_SIZE>>>(
+    paramb, annmb, N, N1, N2, box, nep_data.NN_radial.data(), nep_data.NL_radial.data(),
+    type.data(), position_per_atom.data(), position_per_atom.data() + N,
+    position_per_atom.data() + N * 2, nep_data.Fp.data(), force_per_atom.data(),
+    force_per_atom.data() + N, force_per_atom.data() + N * 2, virial_per_atom.data());
+  CUDA_CHECK_KERNEL
+
+  find_partial_force_angular<<<grid_size, BLOCK_SIZE>>>(
+    paramb, annmb, N, N1, N2, box, nep_data.NN_angular.data(), nep_data.NL_angular.data(),
+    type.data(), position_per_atom.data(), position_per_atom.data() + N,
+    position_per_atom.data() + N * 2, nep_data.Fp.data(), nep_data.sum_fxyz.data(),
+    nep_data.f12x.data(), nep_data.f12y.data(), nep_data.f12z.data());
+  CUDA_CHECK_KERNEL
+  find_properties_many_body(
+    box, nep_data.NN_angular.data(), nep_data.NL_angular.data(), nep_data.f12x.data(),
+    nep_data.f12y.data(), nep_data.f12z.data(), position_per_atom, force_per_atom, virial_per_atom);
+  CUDA_CHECK_KERNEL
+
+  if (zbl.enabled) {
+    find_force_ZBL<<<grid_size, BLOCK_SIZE>>>(
+      N, zbl, N1, N2, box, nep_data.NN_angular.data(), nep_data.NL_angular.data(), type.data(),
+      position_per_atom.data(), position_per_atom.data() + N, position_per_atom.data() + N * 2,
+      force_per_atom.data(), force_per_atom.data() + N, force_per_atom.data() + N * 2,
+      virial_per_atom.data(), potential_per_atom.data());
+    CUDA_CHECK_KERNEL
+  }
+}

--- a/src/force/nep3_multigpu.cu
+++ b/src/force/nep3_multigpu.cu
@@ -1029,10 +1029,10 @@ void NEP3_MULTIGPU::compute(
   find_cell_list(
     rc_cell_list, num_bins, box, position, nep_temp_data.cell_count, nep_temp_data.cell_count_sum,
     nep_temp_data.cell_contents);
+  nep_temp_data.cell_count_sum.copy_to_host(
+    nep_temp_data.cell_count_sum_cpu.data(), num_bins[0] * num_bins[1] * num_bins[2]);
 
   for (int gpu = 0; gpu < paramb.num_gpus; ++gpu) {
-    nep_temp_data.cell_count_sum.copy_to_host(
-      nep_temp_data.cell_count_sum_cpu.data(), num_bins[0] * num_bins[1] * num_bins[2]);
     const int num_bins_z = num_bins[2] / paramb.num_gpus;
     const int num_bins_xy = num_bins[0] * num_bins[1];
     if (paramb.num_gpus == 1) {
@@ -1048,8 +1048,9 @@ void NEP3_MULTIGPU::compute(
         nep_data[gpu].M1 = 0;
         nep_data[gpu].M2 = nep_temp_data.cell_count_sum_cpu[num_bins_z * num_bins_xy];
         nep_data[gpu].N1 = N - nep_data[gpu].M0;
-        nep_data[gpu].N2 = N1 + nep_data[gpu].M2;
-        nep_data[gpu].N3 = N1 + nep_temp_data.cell_count_sum_cpu[(num_bins_z + 4) * num_bins_xy];
+        nep_data[gpu].N2 = nep_data[gpu].N1 + nep_data[gpu].M2;
+        nep_data[gpu].N3 =
+          nep_data[gpu].N1 + nep_temp_data.cell_count_sum_cpu[(num_bins_z + 4) * num_bins_xy];
       } else if (gpu == paramb.num_gpus - 1) {
         nep_data[gpu].M0 = nep_temp_data.cell_count_sum_cpu[(gpu * num_bins_z - 4) * num_bins_xy];
         nep_data[gpu].M1 = nep_temp_data.cell_count_sum_cpu[(gpu * num_bins_z) * num_bins_xy];

--- a/src/force/nep3_multigpu.cuh
+++ b/src/force/nep3_multigpu.cuh
@@ -41,6 +41,9 @@ struct NEP3_MULTIGPU_Data {
 };
 
 struct NEP3_TEMP_Data {
+  GPU_Vector<int> cell_count;
+  GPU_Vector<int> cell_count_sum;
+  GPU_Vector<int> cell_contents;
   GPU_Vector<double> position;
   GPU_Vector<double> force;
   GPU_Vector<double> potential;

--- a/src/force/nep3_multigpu.cuh
+++ b/src/force/nep3_multigpu.cuh
@@ -37,11 +37,14 @@ struct NEP3_MULTIGPU_Data {
   GPU_Vector<double> potential;
   GPU_Vector<double> virial;
 
+  int N1, N2, N3; // ending indices in local system
+  int M0, M1, M2; // starting indices in global system
   cudaStream_t stream;
 };
 
 struct NEP3_TEMP_Data {
   int num_atoms_per_gpu;
+  std::vector<int> cell_count_sum_cpu;
   GPU_Vector<int> cell_count;
   GPU_Vector<int> cell_count_sum;
   GPU_Vector<int> cell_contents;
@@ -117,5 +120,4 @@ private:
   NEP3_TEMP_Data nep_temp_data;
 
   void update_potential(const float* parameters, ANN& ann);
-  void copy_position(GPU_Vector<double>& potential_per_atom);
 };

--- a/src/force/nep3_multigpu.cuh
+++ b/src/force/nep3_multigpu.cuh
@@ -37,6 +37,7 @@ class NEP3_MULTIGPU : public Potential
 {
 public:
   struct ParaMB {
+    int num_gpus = 1;
     int version = 2;            // NEP version, 2 for NEP2 and 3 for NEP3
     float rc_radial = 0.0f;     // radial cutoff
     float rc_angular = 0.0f;    // angular cutoff
@@ -75,7 +76,7 @@ public:
     float atomic_numbers[10];
   };
 
-  NEP3_MULTIGPU(char* file_potential, const int num_atoms);
+  NEP3_MULTIGPU(const int num_gpus, char* file_potential, const int num_atoms);
   virtual ~NEP3_MULTIGPU(void);
   virtual void compute(
     const int group_method,
@@ -92,9 +93,9 @@ public:
 
 private:
   ParaMB paramb;
-  ANN annmb;
+  ANN annmb[16];
   ZBL zbl;
-  NEP3_MULTIGPU_Data nep_data;
+  NEP3_MULTIGPU_Data nep_data[16];
 
   void update_potential(const float* parameters, ANN& ann);
 };

--- a/src/force/nep3_multigpu.cuh
+++ b/src/force/nep3_multigpu.cuh
@@ -32,6 +32,7 @@ struct NEP3_MULTIGPU_Data {
   GPU_Vector<int> cell_count_sum;
   GPU_Vector<int> cell_contents;
 
+  GPU_Vector<int> type;
   GPU_Vector<double> position;
   GPU_Vector<double> force;
   GPU_Vector<double> potential;
@@ -48,6 +49,7 @@ struct NEP3_TEMP_Data {
   GPU_Vector<int> cell_count;
   GPU_Vector<int> cell_count_sum;
   GPU_Vector<int> cell_contents;
+  GPU_Vector<int> type;
   GPU_Vector<double> position;
   GPU_Vector<double> force;
   GPU_Vector<double> potential;

--- a/src/force/nep3_multigpu.cuh
+++ b/src/force/nep3_multigpu.cuh
@@ -31,6 +31,18 @@ struct NEP3_MULTIGPU_Data {
   GPU_Vector<int> cell_count;
   GPU_Vector<int> cell_count_sum;
   GPU_Vector<int> cell_contents;
+
+  GPU_Vector<double> position;
+  GPU_Vector<double> force;
+  GPU_Vector<double> potential;
+  GPU_Vector<double> virial;
+};
+
+struct NEP3_TEMP_Data {
+  GPU_Vector<double> position;
+  GPU_Vector<double> force;
+  GPU_Vector<double> potential;
+  GPU_Vector<double> virial;
 };
 
 class NEP3_MULTIGPU : public Potential
@@ -96,6 +108,8 @@ private:
   ANN annmb[16];
   ZBL zbl;
   NEP3_MULTIGPU_Data nep_data[16];
+  NEP3_TEMP_Data nep_temp_data;
 
   void update_potential(const float* parameters, ANN& ann);
+  void copy_position(GPU_Vector<double>& potential_per_atom);
 };

--- a/src/force/nep3_multigpu.cuh
+++ b/src/force/nep3_multigpu.cuh
@@ -36,6 +36,8 @@ struct NEP3_MULTIGPU_Data {
   GPU_Vector<double> force;
   GPU_Vector<double> potential;
   GPU_Vector<double> virial;
+
+  cudaStream_t stream;
 };
 
 struct NEP3_TEMP_Data {

--- a/src/force/nep3_multigpu.cuh
+++ b/src/force/nep3_multigpu.cuh
@@ -41,6 +41,7 @@ struct NEP3_MULTIGPU_Data {
 };
 
 struct NEP3_TEMP_Data {
+  int num_atoms_per_gpu;
   GPU_Vector<int> cell_count;
   GPU_Vector<int> cell_count_sum;
   GPU_Vector<int> cell_contents;

--- a/src/force/nep3_multigpu.cuh
+++ b/src/force/nep3_multigpu.cuh
@@ -1,0 +1,100 @@
+/*
+    Copyright 2017 Zheyong Fan, Ville Vierimaa, Mikko Ervasti, and Ari Harju
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "potential.cuh"
+#include "utilities/gpu_vector.cuh"
+
+struct NEP3_MULTIGPU_Data {
+  GPU_Vector<float> f12x; // 3-body or manybody partial forces
+  GPU_Vector<float> f12y; // 3-body or manybody partial forces
+  GPU_Vector<float> f12z; // 3-body or manybody partial forces
+  GPU_Vector<float> Fp;
+  GPU_Vector<float> sum_fxyz;
+  GPU_Vector<int> NN_radial;    // radial neighbor list
+  GPU_Vector<int> NL_radial;    // radial neighbor list
+  GPU_Vector<int> NN_angular;   // angular neighbor list
+  GPU_Vector<int> NL_angular;   // angular neighbor list
+  GPU_Vector<float> parameters; // parameters to be optimized
+  GPU_Vector<int> cell_count;
+  GPU_Vector<int> cell_count_sum;
+  GPU_Vector<int> cell_contents;
+};
+
+class NEP3_MULTIGPU : public Potential
+{
+public:
+  struct ParaMB {
+    int version = 2;            // NEP version, 2 for NEP2 and 3 for NEP3
+    float rc_radial = 0.0f;     // radial cutoff
+    float rc_angular = 0.0f;    // angular cutoff
+    float rcinv_radial = 0.0f;  // inverse of the radial cutoff
+    float rcinv_angular = 0.0f; // inverse of the angular cutoff
+    int MN_radial = 200;
+    int MN_angular = 100;
+    int n_max_radial = 0;  // n_radial = 0, 1, 2, ..., n_max_radial
+    int n_max_angular = 0; // n_angular = 0, 1, 2, ..., n_max_angular
+    int L_max = 0;         // l = 0, 1, 2, ..., L_max
+    int dim_angular;
+    int num_L;
+    int basis_size_radial = 8;  // for nep3
+    int basis_size_angular = 8; // for nep3
+    int num_types_sq = 0;       // for nep3
+    int num_c_radial = 0;       // for nep3
+    int num_types = 0;
+    float q_scaler[140];
+  };
+
+  struct ANN {
+    int dim = 0;          // dimension of the descriptor
+    int num_neurons1 = 0; // number of neurons in the 1st hidden layer
+    int num_para = 0;     // number of parameters
+    const float* w0;      // weight from the input layer to the hidden layer
+    const float* b0;      // bias for the hidden layer
+    const float* w1;      // weight from the hidden layer to the output layer
+    const float* b1;      // bias for the output layer
+    const float* c;
+  };
+
+  struct ZBL {
+    bool enabled = false;
+    float rc_inner = 1.0f;
+    float rc_outer = 2.0f;
+    float atomic_numbers[10];
+  };
+
+  NEP3_MULTIGPU(char* file_potential, const int num_atoms);
+  virtual ~NEP3_MULTIGPU(void);
+  virtual void compute(
+    const int group_method,
+    std::vector<Group>& group,
+    const int type_begin,
+    const int type_end,
+    const int type_shift,
+    Box& box,
+    const GPU_Vector<int>& type,
+    const GPU_Vector<double>& position,
+    GPU_Vector<double>& potential,
+    GPU_Vector<double>& force,
+    GPU_Vector<double>& virial);
+
+private:
+  ParaMB paramb;
+  ANN annmb;
+  ZBL zbl;
+  NEP3_MULTIGPU_Data nep_data;
+
+  void update_potential(const float* parameters, ANN& ann);
+};

--- a/src/utilities/main_common.cu
+++ b/src/utilities/main_common.cu
@@ -57,15 +57,38 @@ void print_gpu_information(void)
   printf("GPU information:\n");
   print_line_2();
 
-  int device_id = 0;
-  cudaDeviceProp prop;
-  CHECK(cudaGetDeviceProperties(&prop, device_id));
+  int num_gpus;
+  CHECK(cudaGetDeviceCount(&num_gpus));
+  printf("number of GPUs = %d\n", num_gpus);
 
-  printf("Device id:               %d\n", device_id);
-  printf("Device name:             %s\n", prop.name);
-  printf("Compute capability:      %d.%d\n", prop.major, prop.minor);
-  printf("Amount of global memory: %g GB\n", prop.totalGlobalMem / (1024.0 * 1024 * 1024));
-  printf("Number of SMs:           %d\n", prop.multiProcessorCount);
+  for (int device_id = 0; device_id < num_gpus; ++device_id) {
+    cudaDeviceProp prop;
+    CHECK(cudaGetDeviceProperties(&prop, device_id));
+
+    printf("Device id:                   %d\n", device_id);
+    printf("    Device name:             %s\n", prop.name);
+    printf("    Compute capability:      %d.%d\n", prop.major, prop.minor);
+    printf("    Amount of global memory: %g GB\n", prop.totalGlobalMem / (1024.0 * 1024 * 1024));
+    printf("    Number of SMs:           %d\n", prop.multiProcessorCount);
+  }
+
+  for (int i = 0; i < num_gpus; i++) {
+    cudaSetDevice(i);
+    for (int j = 0; j < num_gpus; j++) {
+      int can_access;
+      if (i != j) {
+        CHECK(cudaDeviceCanAccessPeer(&can_access, i, j));
+        if (can_access) {
+          CHECK(cudaDeviceEnablePeerAccess(j, 0));
+          printf("GPU-%d can access GPU-%d.\n", i, j);
+        } else {
+          printf("GPU-%d cannot access GPU-%d.\n", i, j);
+        }
+      }
+    }
+  }
+
+  cudaSetDevice(0); // normally use GPU-0
 }
 
 int get_number_of_input_directories(void)


### PR DESCRIPTION
* Only use the multi-GPU version when all the conditions below are true:
  * There are 2 or more GPUs available in the current node (can be set by `CUDA_VISIBLE_DEVICES`)
  * `-DUSE_MULTI_GPU` is added to `makefile`
* Otherwise, the code will choose the single-GPU path
* Some improvements can be done, but I leave them for the future:
  * slice the system in the longest direction, not always in the z direction.
  * do not blindly use all the available GPUs, but check if it is necessary.