### PR TITLE
remove the triclinic keyword in model.xyz

### DIFF
--- a/src/model/box.cu
+++ b/src/model/box.cu
@@ -123,3 +123,14 @@ bool Box::get_num_bins(const double rc, int num_bins[])
   }
   return use_ON2;
 }
+
+void Box::update_triclinic()
+{
+  if (
+    (cpu_h[1] == 0.0) && (cpu_h[2] == 0.0) && (cpu_h[3] == 0.0) && (cpu_h[5] == 0.0) &&
+    (cpu_h[6] == 0.0) && (cpu_h[7] == 0.0)) {
+    triclinic = 0;
+  } else {
+    triclinic = 1;
+  }
+}

--- a/src/model/box.cuh
+++ b/src/model/box.cuh
@@ -26,6 +26,7 @@ public:
   double thickness_x = 0.0;           // thickness perpendicular to (b x c)
   double thickness_y = 0.0;           // thickness perpendicular to (c x a)
   double thickness_z = 0.0;           // thickness perpendicular to (a x b)
+  void update_triclinic();            // update the triclinic member
   double get_area(const int d) const; // get the area of one face
   double get_volume(void) const;      // get the volume of the box
   void get_inverse(void);             // get the inverse box matrix

--- a/src/model/box.cuh
+++ b/src/model/box.cuh
@@ -22,7 +22,8 @@ public:
   int pbc_y = 1;                      // pbc_y = 1 means periodic in the y-direction
   int pbc_z = 1;                      // pbc_z = 1 means periodic in the z-direction
   int triclinic = 0;                  // triclinic = 1 means the box is non-orthogonal
-  double cpu_h[18];                   // the box data
+  double cpu_h[18];                   // data for triclinic box
+  double box_length[6];               // data for orthogonal box
   double thickness_x = 0.0;           // thickness perpendicular to (b x c)
   double thickness_y = 0.0;           // thickness perpendicular to (c x a)
   double thickness_z = 0.0;           // thickness perpendicular to (a x b)


### PR DESCRIPTION
* Let the code to check the box shape automatically at any time.
* Not finished yet. Many files need to be updated as the code needs to check if the box is triclinic before using it many in functions.
* Also need to modify the data structure, as currently box.cpu_h[] is used for both trilinic and orthogonal box. Need to use two arrays if we want to check the box shape automatically at any time.
* This is an update after PR #225, where I used a `triclinic` keyword in the second line of the extended XYZ file `model.xyz`. This seems to be not very conventional and I think it is better to remove it.