### PR TITLE
add #include <cctype> in model/read_xyz.cu and main_nep/structure.cu

### DIFF
--- a/src/main_nep/structure.cu
+++ b/src/main_nep/structure.cu
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <cctype>
 
 static float get_area(const float* a, const float* b)
 {

--- a/src/model/read_xyz.cu
+++ b/src/model/read_xyz.cu
@@ -28,6 +28,7 @@ The class defining the simulation model.
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <cctype>
 
 static bool need_triclinic()
 {


### PR DESCRIPTION
Under the environment of the VS2017 version, I encounter the compile errors, which can be well fixed by adding "#include <cctype>" in two files: "model/read_xyz.cu" and "main_nep/structure.cu".