### PR TITLE
calculate some indices correctly for multi-GPU version of NEP

### DIFF
--- a/src/force/nep3_multigpu.cu
+++ b/src/force/nep3_multigpu.cu
@@ -361,17 +361,17 @@ static __device__ void find_cell_id(
     cell_id_y = floor(sy * box.thickness_y * rc_inv);
     cell_id_z = floor(sz * box.thickness_z * rc_inv);
   }
-  if (cell_id_x < 0)
+  while (cell_id_x < 0)
     cell_id_x += nx;
-  if (cell_id_x >= nx)
+  while (cell_id_x >= nx)
     cell_id_x -= nx;
-  if (cell_id_y < 0)
+  while (cell_id_y < 0)
     cell_id_y += ny;
-  if (cell_id_y >= ny)
+  while (cell_id_y >= ny)
     cell_id_y -= ny;
-  if (cell_id_z < 0)
+  while (cell_id_z < 0)
     cell_id_z += nz;
-  if (cell_id_z >= nz)
+  while (cell_id_z >= nz)
     cell_id_z -= nz;
   if (partition_direction == 0) {
     cell_id = cell_id_y + ny * (cell_id_z + nz * cell_id_x);
@@ -1259,6 +1259,11 @@ void NEP3_MULTIGPU::compute(
   find_cell_list(
     nep_data[0].stream, partition_direction, rc_cell_list, num_bins, box, N, position,
     nep_temp_data.cell_count, nep_temp_data.cell_count_sum, nep_temp_data.cell_contents);
+
+  if (num_bins[0] * num_bins[1] * num_bins[2] > nep_temp_data.cell_count_sum_cpu.size()) {
+    nep_temp_data.cell_count_sum_cpu.resize(num_bins[0] * num_bins[1] * num_bins[2]);
+  }
+
   nep_temp_data.cell_count_sum.copy_to_host(
     nep_temp_data.cell_count_sum_cpu.data(), num_bins[0] * num_bins[1] * num_bins[2]);
 

--- a/src/force/nep3_multigpu.cu
+++ b/src/force/nep3_multigpu.cu
@@ -1275,13 +1275,15 @@ void NEP3_MULTIGPU::compute(
     } else {
       if (gpu == 0) {
         nep_data[gpu].M0 =
-          nep_temp_data.cell_count_sum_cpu[(num_bins[2] - 4) * num_bins_transverse];
+          nep_temp_data
+            .cell_count_sum_cpu[(num_bins[partition_direction] - 4) * num_bins_transverse];
         nep_data[gpu].M1 = 0;
         nep_data[gpu].M2 =
           nep_temp_data.cell_count_sum_cpu[num_bins_longitudinal * num_bins_transverse];
         nep_data[gpu].N1 = N - nep_data[gpu].M0;
         nep_data[gpu].N4 =
-          nep_temp_data.cell_count_sum_cpu[(num_bins[2] - 2) * num_bins_transverse] -
+          nep_temp_data
+            .cell_count_sum_cpu[(num_bins[partition_direction] - 2) * num_bins_transverse] -
           nep_data[gpu].M0;
         nep_data[gpu].N2 = nep_data[gpu].N1 + nep_data[gpu].M2;
         nep_data[gpu].N5 =


### PR DESCRIPTION
* Aim to resolve this issue: #232 
* For the test you sent me, I can run it now after fixing an apparent bug in the code, but I got a CPU memory issue upon the exit of the program. I am not sure if it is due to my testing environment (There are two 2080ti GPUs but one was running another calculation during my test). Could you test the code with the fix here? @AmbroseWong 
* @erhart1 @elindgren You can also test if there is any problem for the multi-GPU version. I have very limited access to multi-GPU computers.