### PR TITLE
fix a bug about sdc when num_atom*run_steps is too large

### DIFF
--- a/src/measure/sdc.cu
+++ b/src/measure/sdc.cu
@@ -194,7 +194,7 @@ void SDC::postprocess(const char* input_dir)
   CHECK(cudaDeviceSynchronize()); // needed for pre-Pascal GPU
 
   // normalize by the number of atoms and number of time origins
-  const double vac_scaler = 1.0 / (num_atoms_ * num_time_origins_);
+  const double vac_scaler = 1.0 / ((double)num_atoms_ * (double)num_time_origins_);
   for (int nc = 0; nc < num_correlation_steps_; nc++) {
     vacx_[nc] *= vac_scaler;
     vacy_[nc] *= vac_scaler;


### PR DESCRIPTION
When the product of the number of atoms and the number of time originis (almost the number of running steps) exceeds the upper bound of `int`, the VAC and SDC will not be correctly calculated. This PR fixes this problem.

Thanks @Kick-H for detecting the probem. 