### PR TITLE
Small fixes to LaTeX code in the documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,7 +64,7 @@ _PREAMBLE = r"""
 \usepackage{amsmath,amssymb}
 \renewcommand{\vec}[1]{\boldsymbol{#1}}
 \DeclareMathOperator*{\argmin}{\arg\!\min}
-\DeclareMathOperator{\argmin}{\arg\!\min}
+%\DeclareMathOperator{\argmin}{\arg\!\min}
 """
 
 latex_elements = {

--- a/doc/gpumd/output_files/heatmode_out.rst
+++ b/doc/gpumd/output_files/heatmode_out.rst
@@ -14,8 +14,8 @@ This file reads:
 
 .. math::
 
-   \begin{array}
-   .J^{x,in}_{1,1}
+   \begin{array}{ccccc}
+   J^{x,in}_{1,1}
    & J^{x,out}_{1,1}
    & J^{y,in}_{1,1}
    & J^{y,out}_{1,1}

--- a/doc/gpumd/output_files/kappamode_out.rst
+++ b/doc/gpumd/output_files/kappamode_out.rst
@@ -14,8 +14,8 @@ This file reads:
 
 .. math::
 
-   \begin{array}
-   .\kappa^{x,in}_{1,1}
+   \begin{array}{ccccc}
+   \kappa^{x,in}_{1,1}
    & \kappa^{x,out}_{1,1}
    & \kappa^{y,in}_{1,1}
    & \kappa^{y,out}_{1,1}

--- a/doc/nep/input_parameters/force_delta.rst
+++ b/doc/nep/input_parameters/force_delta.rst
@@ -16,12 +16,12 @@ When :math:`\delta = 0` eV/A, the :ref:`loss term associated with the forces <ne
 
 .. math::
    
-   \sqrt{\frac{1}{3N}\sum_{i=1}^{N}\left(\vec{F}_i^\mathrm{NEP} - \vec{F}_i^\mathrm{tar}\right)^2}
+   \sqrt{\frac{1}{3N}\sum_{i=1}^{N}\left(\boldsymbol{F}_i^\mathrm{NEP} - \boldsymbol{F}_i^\mathrm{tar}\right)^2}
 
 When :math:`\delta > 0` eV/Å, this expression is modified to read:
 
 .. math::
    
-   \sqrt{\frac{1}{3N}\sum_{i=1}^{N}\left(\vec{F}_i^\mathrm{NEP} - \vec{F}_i^\mathrm{tar}\right)^2 \frac{1}{1+\|\vec{F}_i^\mathrm{tar}\| / \delta} }
+   \sqrt{\frac{1}{3N}\sum_{i=1}^{N}\left(\boldsymbol{F}_i^\mathrm{NEP} - \boldsymbol{F}_i^\mathrm{tar}\right)^2 \frac{1}{1+\|\boldsymbol{F}_i^\mathrm{tar}\| / \delta} }
 
 In this case, a smaller :math:`\delta` implies a larger weight on smaller forces.


### PR DESCRIPTION
This PR fixes a few small LaTeX syntax errors that were not picked up by the sphinx-to-html compilation.
This reduces the number of errors when compiling the documentation with LaTeX.
The remaining issues are associated with sphinx-specific styling commands, for which I do not have a fix yet.,