### PR TITLE
allow for longer systems for NEP with small box

### DIFF
--- a/src/force/nep3.cu
+++ b/src/force/nep3.cu
@@ -986,11 +986,11 @@ static bool get_expanded_box(const double rc, const Box& box, NEP3::ExpandedBox&
   }
 
   if (is_small_box) {
-    if (thickness_x > 5 * rc || thickness_y > 5 * rc || thickness_z > 5 * rc) {
+    if (thickness_x > 10 * rc || thickness_y > 10 * rc || thickness_z > 10 * rc) {
       std::cout << "Error:\n"
                 << "    The box has\n"
                 << "        a thickness < 2.5 radial cutoffs in a periodic direction.\n"
-                << "        and a thickness > 5 radial cutoffs in another direction.\n"
+                << "        and a thickness > 10 radial cutoffs in another direction.\n"
                 << "    Please increase the periodic direction(s).\n";
       exit(1);
     }


### PR DESCRIPTION
Previously, it was not allowed to have a thickness < 2.5 radial cutoffs in a periodic direction and simultaneously a thickness > 5 radial cutoffs in another direction. The purpose of this is to prevent the user from using a non-optimal box (because in this case the "small-box algorithm" will be used and there are still many atoms, which can make the code slow), but Erik hoped to have more freedom for the box dimensions, for the active-learning purpose. Now I relax it a lot.