### PR TITLE
Updated makefile to avoid unnecessary warnings and errors

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -1,6 +1,6 @@
 ###########################################################
 # Note: 
-# 1) You can modify -arch=sm_35 according to 
+# 1) You can modify -arch=sm_50 according to 
 #    your GPU architecture.
 # 2) For Windows systems, if you get errors like 
 #    c1xx : fatal error C1083: Cannot open source file: ...
@@ -15,9 +15,9 @@
 ###########################################################
 CC = nvcc
 ifdef OS # For Windows with the cl.exe compiler
-CFLAGS = -O3 -arch=sm_35 -Xcompiler "/wd 4819"
+CFLAGS = -O3 -arch=sm_50 -Xcompiler "/wd 4819"
 else # For linux
-CFLAGS = -std=c++11 -O3 -arch=sm_35
+CFLAGS = -std=c++14 -O3 -arch=sm_50
 endif
 INC = -I./
 LDFLAGS = 
@@ -76,7 +76,7 @@ gpumd: $(OBJ_GPUMD)
 	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
 nep: $(OBJ_NEP)
 	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
-	
+
 
 ###########################################################
 # rules for building object files
@@ -129,6 +129,6 @@ clean:
 ifdef OS
 	del /s *.obj *.exp *.lib *.exe
 else
-	rm */*.o gpumd nep
+	rm -f */*.o gpumd nep
 endif
 


### PR DESCRIPTION
This PR introduces four small changes to the makefile that prevent several warnings and errors during the compilation.
* The minimal compute capability is changed from `sm_35` (Kepler) to `sm_50` (Maxwell). This prevents a deprecation warning. The [Kepler architecture](https://en.wikipedia.org/wiki/Kepler_(microarchitecture)) is from 2012 and hence very outdated. Even the [Maxwell architecture (2014)](https://en.wikipedia.org/wiki/Maxwell_(microarchitecture)) is rather old and likely to become deprecated relatively soon. See [here](https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/) for a translation table between `sm_XX` and architecture.
* The C++ standard was switched from C++11 to C++14 (`-std=c++14`) since the former also causes a deprecation warning.
* A stray tab was removed, which caused my emacs to act up.
* The `rm` command used by `make clean` now uses the `-f` flag such that it does not throw an error when `make clean` is run without `gpumd` and `nep` present. This otherwise triggers an error preventing the rather common `make clean && make` sequence to run (i.e., `make` is run on the condition that `make clean` passes).