### PR TITLE
Changed pages job so that it also runs on schedule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,5 +60,4 @@ pages:
   only:
     - master
     - tags
-  except:
-   - schedules
+    - schedules


### PR DESCRIPTION
This change causes the `pages` job to be run on GitLab not only for master and `tags` but on `schedules`.
This should enable the continuous (nightly by schedule) deployment of updates to the documentation,