### PR TITLE
Fixed error that prevented the succesful compilation of the documentation

### DIFF
--- a/doc/gpumd/input_parameters/ensemble.rst
+++ b/doc/gpumd/input_parameters/ensemble.rst
@@ -106,7 +106,7 @@ with three different options for specifying :attr:`<pressure_control_parameters>
 If the first parameter is :attr:`npt_scr`, it is similar to the case of :attr:`npt_ber`, but using the :ref:`stochastic cell rescaling method <stochastic_cell_rescaling>`.
 
 :attr:`heat_nhc`
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^
 If the first parameter is :attr:`heat_nhc`, it means heating a source region and simultaneously cooling a sink region using local :ref:`Nose-Hoover chain thermostats <nose_hoover_chain_thermostat>`.
 The full command is::
 


### PR DESCRIPTION
Fixed the following error
```bash
...
Warning, treated as error:
/builds/materials-theory/gpumd-fork/doc/gpumd/input_parameters/ensemble.rst:109:Title underline too short.
:attr:`heat_nhc`
^^^^^^^^^^^^^^^
sphinx-sitemap warning: No pages generated for sitemap.xml
```

This error occurred when running
```bash
sphinx-build -W doc public
```
and caused the CI on gitlab to fail.