### PR TITLE
Fixed syntax error in the documentation of lambda_shear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ src/nep*
 local
 public*
 \#*
+
+nep
+gpumd

--- a/doc/nep/input_parameters/lambda_shear.rst
+++ b/doc/nep/input_parameters/lambda_shear.rst
@@ -3,13 +3,13 @@
    single: lambda_shear (keyword in nep.in)
 
 :attr:`lambda_shear`
-================
+====================
 
-This keyword sets the extra weight :math:`\lambda_s` of the loss term associated with the **shear virials** in the :ref:`loss function <nep_loss_function>`.
+This keyword sets the extra weight :math:`\lambda_s` of the loss term associated with the *shear* virials in the :ref:`loss function <nep_loss_function>`.
 The syntax is::
 
   lambda_shear <weight>
 
 Here, :attr:`<weight>` represents :math:`\lambda_s`, which must satisfy :math:`\lambda_s \geq 0` and defaults to :math:`\lambda_s = 1`.
 The weight for the shear virials is thus :math:`\lambda_v \lambda_s`, where :math:`\lambda_v` is set by the :ref:`lambda_v keyword <kw_lambda_v>`.
-We have tested that a vlaue of :math:`\lambda_s=5` is sometimes helpful to make the prediction of shear modulus more accurate.
+We have tested that a value of :math:`\lambda_s=5` is sometimes helpful to make the prediction of shear moduli more accurate.


### PR DESCRIPTION
This fixes a syntax error in the documentation of the `lambda_shear` keyword that caused the compilation of the user guide to fail.
It also includes the addition of `gpumd` and `nep` to `.gitignore` to avoid these executable files being shown under "untracked files".