### PR TITLE
simplify code by removing input_dir

### DIFF
--- a/src/force/fcp.cu
+++ b/src/force/fcp.cu
@@ -21,7 +21,7 @@ The force constant potential (FCP)
 #include "utilities/error.cuh"
 #include <vector>
 
-FCP::FCP(FILE* fid, char* input_dir, const int num_types, const int N, const Box& box)
+FCP::FCP(FILE* fid, const int num_types, const int N, const Box& box)
 {
   printf("Use the %d-element force constant potential with element(s):", num_types);
   for (int n = 0; n < num_types; ++n) {

--- a/src/force/fcp.cuh
+++ b/src/force/fcp.cuh
@@ -32,7 +32,7 @@ struct FCP_Data {
 class FCP : public Potential
 {
 public:
-  FCP(FILE* fid, char* input_dir, const int num_types, const int N, const Box& box);
+  FCP(FILE* fid, const int num_types, const int N, const Box& box);
   virtual ~FCP(void);
   virtual void compute(
     Box& box,

--- a/src/force/force.cu
+++ b/src/force/force.cu
@@ -37,7 +37,7 @@ The driver class calculating force and related quantities.
 Force::Force(void) { is_fcp = false; }
 
 void Force::parse_potential(
-  const char** param, int num_param, char* input_dir, const Box& box, const int number_of_atoms)
+  const char** param, int num_param, const Box& box, const int number_of_atoms)
 {
   static int num_calls = 0;
   if (num_calls++ != 0) {
@@ -68,7 +68,7 @@ void Force::parse_potential(
   } else if (strcmp(potential_name, "eam_dai_2006") == 0) {
     potential.reset(new EAM(fid_potential, potential_name, num_types, number_of_atoms));
   } else if (strcmp(potential_name, "fcp") == 0) {
-    potential.reset(new FCP(fid_potential, input_dir, num_types, number_of_atoms, box));
+    potential.reset(new FCP(fid_potential, num_types, number_of_atoms, box));
     is_fcp = true;
   } else if (
     strcmp(potential_name, "nep") == 0 || strcmp(potential_name, "nep_zbl") == 0 ||

--- a/src/force/force.cuh
+++ b/src/force/force.cuh
@@ -27,8 +27,8 @@ class Force
 public:
   Force(void);
 
-  void parse_potential(
-    const char** param, int num_param, char* input_dir, const Box& box, const int number_of_atoms);
+  void
+  parse_potential(const char** param, int num_param, const Box& box, const int number_of_atoms);
 
   void compute(
     Box& box,

--- a/src/main_gpumd/cohesive.cu
+++ b/src/main_gpumd/cohesive.cu
@@ -192,16 +192,9 @@ void Cohesive::compute_D()
   }
 }
 
-void Cohesive::output(char* input_dir, Box& box)
+void Cohesive::output(Box& box)
 {
-  char file[200];
-  strcpy(file, input_dir);
-  if (deformation_type == 0) {
-    strcat(file, "/cohesive.out");
-  } else {
-    strcat(file, "/elastic.out");
-  }
-  FILE* fid = my_fopen(file, "w");
+  FILE* fid = my_fopen(deformation_type == 0 ? "cohesive.out" : "elastic.out", "w");
 
   if (deformation_type == 0) {
     for (int n = 0; n < num_points; ++n) {
@@ -233,7 +226,6 @@ void Cohesive::output(char* input_dir, Box& box)
 }
 
 void Cohesive::compute(
-  char* input_dir,
   Box& box,
   GPU_Vector<double>& position_per_atom,
   GPU_Vector<int>& type,
@@ -266,5 +258,5 @@ void Cohesive::compute(
     }
   }
 
-  output(input_dir, box);
+  output(box);
 }

--- a/src/main_gpumd/cohesive.cuh
+++ b/src/main_gpumd/cohesive.cuh
@@ -30,7 +30,6 @@ class Cohesive
 public:
   void parse(const char** param, int num_param, int type);
   void compute(
-    char* iput_dir,
     Box& box,
     GPU_Vector<double>& position_per_atom,
     GPU_Vector<int>& type,
@@ -45,7 +44,7 @@ private:
   void parse_elastic(const char** param, int num_param);
   void allocate_memory(const int num_atoms);
   void compute_D();
-  void output(char* input_dir, Box& box);
+  void output(Box& box);
   void deform_box(
     const int N, const D& cpu_d, Box& old_box, Box& new_box, GPU_Vector<double>& position_per_atom);
   std::vector<double> cpu_potential_total;

--- a/src/main_gpumd/main.cu
+++ b/src/main_gpumd/main.cu
@@ -29,8 +29,6 @@ int main(int argc, char* argv[])
   print_compile_information();
   print_gpu_information();
 
-  char input_directory[200] = ".";
-
   print_line_1();
   printf("Started running GPUMD.\n");
   print_line_2();
@@ -38,7 +36,7 @@ int main(int argc, char* argv[])
   CHECK(cudaDeviceSynchronize());
   clock_t time_begin = clock();
 
-  Run run(input_directory);
+  Run run;
 
   CHECK(cudaDeviceSynchronize());
   clock_t time_finish = clock();

--- a/src/main_gpumd/run.cuh
+++ b/src/main_gpumd/run.cuh
@@ -33,12 +33,12 @@ class Measure;
 class Run
 {
 public:
-  Run(char*);
+  Run();
 
 private:
-  void execute_run_in(char* input_dir);
-  void perform_a_run(char* input_dir);
-  void parse_one_keyword(std::vector<std::string>& tokens, char* input_dir);
+  void execute_run_in();
+  void perform_a_run();
+  void parse_one_keyword(std::vector<std::string>& tokens);
 
   // keyword parsing functions
   void parse_neighbor(const char** param, int num_param);
@@ -46,7 +46,7 @@ private:
   void parse_change_box(const char** param, int num_param);
   void parse_correct_velocity(const char** param, int num_param);
   void parse_time_step(const char** param, int num_param);
-  void parse_run(const char** param, int num_param, char* input_dir);
+  void parse_run(const char** param, int num_param);
 
   int N;               // number of atoms
   int number_of_types; // number of atom types

--- a/src/measure/compute.cu
+++ b/src/measure/compute.cu
@@ -25,7 +25,7 @@ Compute block (space) averages of various per-atom quantities.
 
 #define DIM 3
 
-void Compute::preprocess(const int N, const char* input_dir, const std::vector<Group>& group)
+void Compute::preprocess(const int N, const std::vector<Group>& group)
 {
   number_of_scalars = 0;
   if (compute_temperature)
@@ -54,10 +54,7 @@ void Compute::preprocess(const int N, const char* input_dir, const std::vector<G
   gpu_per_atom_y.resize(N);
   gpu_per_atom_z.resize(N);
 
-  char filename[200];
-  strcpy(filename, input_dir);
-  strcat(filename, "/compute.out");
-  fid = my_fopen(filename, "a");
+  fid = my_fopen("compute.out", "a");
 }
 
 void Compute::postprocess()

--- a/src/measure/compute.cuh
+++ b/src/measure/compute.cuh
@@ -34,7 +34,7 @@ public:
   int output_interval = 1;
   int grouping_method = 0;
 
-  void preprocess(const int N, const char* input_dir, const std::vector<Group>& group);
+  void preprocess(const int N, const std::vector<Group>& group);
 
   void postprocess();
   void process(

--- a/src/measure/dos.cu
+++ b/src/measure/dos.cu
@@ -220,7 +220,7 @@ void DOS::process(
   }
 }
 
-void DOS::postprocess(const char* input_dir)
+void DOS::postprocess()
 {
   if (!compute_)
     return;
@@ -228,9 +228,9 @@ void DOS::postprocess(const char* input_dir)
   CHECK(cudaDeviceSynchronize()); // needed for pre-Pascal GPU
 
   normalize_vac();
-  output_vac(input_dir);
+  output_vac();
   find_dos();
-  output_dos(input_dir);
+  output_dos();
 
   compute_ = false;
   grouping_method_ = -1;
@@ -387,12 +387,9 @@ void DOS::normalize_vac()
   }
 }
 
-void DOS::output_vac(const char* input_dir)
+void DOS::output_vac()
 {
-  char file_vac[200];
-  strcpy(file_vac, input_dir);
-  strcat(file_vac, "/mvac.out");
-  FILE* fid = fopen(file_vac, "a");
+  FILE* fid = fopen("mvac.out", "a");
 
   for (int n = 0; n < num_groups_; ++n) {
     const int offset = num_correlation_steps_ * n;
@@ -440,12 +437,9 @@ void DOS::find_dos()
   }
 }
 
-void DOS::output_dos(const char* input_dir)
+void DOS::output_dos()
 {
-  char file_dos[200];
-  strcpy(file_dos, input_dir);
-  strcat(file_dos, "/dos.out");
-  FILE* fid_dos = fopen(file_dos, "a");
+  FILE* fid_dos = fopen("dos.out", "a");
 
   const double d_omega = omega_max_ / num_dos_points_;
   for (int ng = 0; ng < num_groups_; ++ng) {

--- a/src/measure/dos.cuh
+++ b/src/measure/dos.cuh
@@ -34,7 +34,7 @@ public:
     const double time_step, const std::vector<Group>& group, const GPU_Vector<double>& mass);
   void process(
     const int step, const std::vector<Group>& groups, const GPU_Vector<double>& velocity_per_atom);
-  void postprocess(const char*);
+  void postprocess();
 
 private:
   int num_atoms_;
@@ -59,7 +59,7 @@ private:
   void copy_velocity(const int correlation_step, const GPU_Vector<double>& velocity_per_atom);
   void find_vac(const int correlation_step);
   void normalize_vac();
-  void output_vac(const char* input_dir);
+  void output_vac();
   void find_dos();
-  void output_dos(const char* input_dir);
+  void output_dos();
 };

--- a/src/measure/dump_exyz.cu
+++ b/src/measure/dump_exyz.cu
@@ -84,12 +84,10 @@ void Dump_EXYZ::parse(const char** param, int num_param)
   }
 }
 
-void Dump_EXYZ::preprocess(char* input_dir, const int number_of_atoms)
+void Dump_EXYZ::preprocess(const int number_of_atoms)
 {
   if (dump_) {
-    strcpy(filename_, input_dir);
-    strcat(filename_, "/dump.xyz");
-    fid_ = my_fopen(filename_, "a");
+    fid_ = my_fopen("dump.xyz", "a");
     gpu_total_virial_.resize(6);
     cpu_total_virial_.resize(6);
     if (has_force_) {

--- a/src/measure/dump_exyz.cuh
+++ b/src/measure/dump_exyz.cuh
@@ -24,7 +24,7 @@ class Dump_EXYZ
 {
 public:
   void parse(const char** param, int num_param);
-  void preprocess(char* input_dir, const int number_of_atoms);
+  void preprocess(const int number_of_atoms);
   void process(
     const int step,
     const double global_time,

--- a/src/measure/dump_force.cu
+++ b/src/measure/dump_force.cu
@@ -51,13 +51,10 @@ void Dump_Force::parse(const char** param, int num_param, const std::vector<Grou
   }
 }
 
-void Dump_Force::preprocess(
-  char* input_dir, const int number_of_atoms, const std::vector<Group>& groups)
+void Dump_Force::preprocess(const int number_of_atoms, const std::vector<Group>& groups)
 {
   if (dump_) {
-    strcpy(filename_, input_dir);
-    strcat(filename_, "/force.out");
-    fid_ = my_fopen(filename_, "a");
+    fid_ = my_fopen("force.out", "a");
 
     if (grouping_method_ < 0) {
       cpu_force_per_atom.resize(number_of_atoms * 3);

--- a/src/measure/dump_force.cuh
+++ b/src/measure/dump_force.cuh
@@ -23,7 +23,7 @@ class Dump_Force
 {
 public:
   void parse(const char** param, int num_param, const std::vector<Group>& groups);
-  void preprocess(char* input_dir, const int number_of_atoms, const std::vector<Group>& groups);
+  void preprocess(const int number_of_atoms, const std::vector<Group>& groups);
   void
   process(const int step, const std::vector<Group>& groups, GPU_Vector<double>& force_per_atom);
   void postprocess();

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -103,13 +103,12 @@ void DUMP_NETCDF::parse(const char** param, int num_param)
   }
 }
 
-void DUMP_NETCDF::preprocess(char* input_dir, const int N)
+void DUMP_NETCDF::preprocess(const int N)
 {
   if (!dump_)
     return;
 
-  strcpy(file_position, input_dir);
-  strcat(file_position, "/movie.nc");
+  strcpy(file_position, "movie.nc");
 
   // find appropriate file name
   // Append if same simulation, new file otherwise
@@ -119,10 +118,9 @@ void DUMP_NETCDF::preprocess(char* input_dir, const int N)
   while (!done) {
 
     if (access(file_position, F_OK) != -1) {
-      strcpy(file_position, input_dir);
       filenum++;
-      sprintf(filename, "/movie_%d.nc", filenum);
-      strcat(file_position, filename);
+      sprintf(filename, "movie_%d.nc", filenum);
+      strcpy(file_position, filename);
     } else {
       done = true;
     }
@@ -130,12 +128,10 @@ void DUMP_NETCDF::preprocess(char* input_dir, const int N)
 
   if (append) {
     if (filenum == 2) {
-      strcpy(file_position, input_dir);
-      strcat(file_position, "/movie.nc");
+      strcpy(file_position, "movie.nc");
     } else {
-      strcpy(file_position, input_dir);
-      sprintf(filename, "/movie_%d.nc", filenum - 1);
-      strcat(file_position, filename);
+      sprintf(filename, "movie_%d.nc", filenum - 1);
+      strcpy(file_position, filename);
     }
     return; // creation of file & other info not needed
   }

--- a/src/measure/dump_netcdf.cuh
+++ b/src/measure/dump_netcdf.cuh
@@ -25,7 +25,7 @@ class DUMP_NETCDF
 {
 public:
   void parse(const char** param, int num_param);
-  void preprocess(char* input_dir, const int N);
+  void preprocess(const int N);
   void process(
     const int step,
     const double global_time,

--- a/src/measure/dump_position.cu
+++ b/src/measure/dump_position.cu
@@ -57,12 +57,10 @@ void Dump_Position::parse(const char** param, int num_param, const std::vector<G
   }
 }
 
-void Dump_Position::preprocess(char* input_dir)
+void Dump_Position::preprocess()
 {
   if (dump_) {
-    strcpy(filename_, input_dir);
-    strcat(filename_, "/movie.xyz");
-    fid_ = my_fopen(filename_, "a");
+    fid_ = my_fopen("movie.xyz", "a");
     if (precision_ == 0)
       strcpy(precision_str_, "%s %g %g %g\n");
     else if (precision_ == 1) // single precision

--- a/src/measure/dump_position.cuh
+++ b/src/measure/dump_position.cuh
@@ -25,7 +25,7 @@ class Dump_Position
 {
 public:
   void parse(const char** param, int num_param, const std::vector<Group>& groups);
-  void preprocess(char* input_dir);
+  void preprocess();
   void process(
     const int step,
     const Box& box,

--- a/src/measure/dump_restart.cu
+++ b/src/measure/dump_restart.cu
@@ -47,11 +47,10 @@ void Dump_Restart::parse(const char** param, int num_param)
   print_line_2();
 }
 
-void Dump_Restart::preprocess(char* input_dir)
+void Dump_Restart::preprocess()
 {
   if (dump_) {
-    strcpy(filename_, input_dir);
-    strcat(filename_, "/restart.xyz");
+    // nothing
   }
 }
 
@@ -72,7 +71,7 @@ void Dump_Restart::process(
   if ((step + 1) % dump_interval_ != 0)
     return;
 
-  FILE* fid = my_fopen(filename_, "w");
+  FILE* fid = my_fopen("restart.xyz", "w");
 
   const int number_of_atoms = cpu_mass.size();
 

--- a/src/measure/dump_restart.cuh
+++ b/src/measure/dump_restart.cuh
@@ -25,7 +25,7 @@ class Dump_Restart
 {
 public:
   void parse(const char** param, int num_param);
-  void preprocess(char* input_dir);
+  void preprocess();
   void process(
     const int step,
     const Box& box,
@@ -42,5 +42,4 @@ public:
 private:
   bool dump_ = false;
   int dump_interval_ = 1;
-  char filename_[200];
 };

--- a/src/measure/dump_thermo.cu
+++ b/src/measure/dump_thermo.cu
@@ -39,12 +39,10 @@ void Dump_Thermo::parse(const char** param, int num_param)
   printf("Dump thermo every %d steps.\n", dump_interval_);
 }
 
-void Dump_Thermo::preprocess(char* input_dir)
+void Dump_Thermo::preprocess()
 {
   if (dump_) {
-    strcpy(filename_, input_dir);
-    strcat(filename_, "/thermo.out");
-    fid_ = my_fopen(filename_, "a");
+    fid_ = my_fopen("thermo.out", "a");
   }
 }
 

--- a/src/measure/dump_thermo.cuh
+++ b/src/measure/dump_thermo.cuh
@@ -22,7 +22,7 @@ class Dump_Thermo
 {
 public:
   void parse(const char** param, int num_param);
-  void preprocess(char* input_dir);
+  void preprocess();
   void process(
     const int step,
     const int number_of_atoms,

--- a/src/measure/dump_velocity.cu
+++ b/src/measure/dump_velocity.cu
@@ -60,12 +60,10 @@ void Dump_Velocity::parse(const char** param, int num_param, const std::vector<G
   print_line_2();
 }
 
-void Dump_Velocity::preprocess(char* input_dir)
+void Dump_Velocity::preprocess()
 {
   if (dump_) {
-    strcpy(filename_, input_dir);
-    strcat(filename_, "/velocity.out");
-    fid_ = my_fopen(filename_, "a");
+    fid_ = my_fopen("velocity.out", "a");
   }
 }
 

--- a/src/measure/dump_velocity.cuh
+++ b/src/measure/dump_velocity.cuh
@@ -23,7 +23,7 @@ class Dump_Velocity
 {
 public:
   void parse(const char** param, int num_param, const std::vector<Group>& groups);
-  void preprocess(char* input_dir);
+  void preprocess();
   void process(
     const int step,
     const std::vector<Group>& groups,

--- a/src/measure/hac.cu
+++ b/src/measure/hac.cu
@@ -71,7 +71,6 @@ gpu_sum_heat(const int N, const int Nd, const int nd, const double* g_heat, doub
 void HAC::process(
   const int number_of_steps,
   const int step,
-  const char* input_dir,
   const GPU_Vector<double>& velocity_per_atom,
   const GPU_Vector<double>& virial_per_atom,
   GPU_Vector<double>& heat_per_atom)
@@ -164,11 +163,7 @@ static void find_rtc(const int Nc, const double factor, const double* hac, doubl
 // Calculate HAC (heat currant auto-correlation function)
 // and RTC (running thermal conductivity)
 void HAC::postprocess(
-  const int number_of_steps,
-  const char* input_dir,
-  const double temperature,
-  const double time_step,
-  const double volume)
+  const int number_of_steps, const double temperature, const double time_step, const double volume)
 {
   if (!compute)
     return;
@@ -195,10 +190,7 @@ void HAC::postprocess(
 
   find_rtc(Nc, factor, hac_cpu.data(), rtc.data());
 
-  char file_hac[FILE_NAME_LENGTH];
-  strcpy(file_hac, input_dir);
-  strcat(file_hac, "/hac.out");
-  FILE* fid = fopen(file_hac, "a");
+  FILE* fid = fopen("hac.out", "a");
   const int number_of_output_data = Nc / output_interval;
   for (int nd = 0; nd < number_of_output_data; nd++) {
     const int nc = nd * output_interval;

--- a/src/measure/hac.cuh
+++ b/src/measure/hac.cuh
@@ -29,14 +29,12 @@ public:
   void process(
     const int number_of_steps,
     const int step,
-    const char* input_dir,
     const GPU_Vector<double>& velocity_per_atom,
     const GPU_Vector<double>& virial_per_atom,
     GPU_Vector<double>& heat_per_atom);
 
   void postprocess(
     const int number_of_steps,
-    const char* input_dir,
     const double temperature,
     const double time_step,
     const double volume);

--- a/src/measure/hnemd_kappa.cu
+++ b/src/measure/hnemd_kappa.cu
@@ -70,7 +70,6 @@ gpu_sum_heat(const int N, const int step, const double* g_heat, double* g_heat_s
 
 void HNEMD::process(
   int step,
-  const char* input_dir,
   const double temperature,
   const double volume,
   const GPU_Vector<double>& velocity_per_atom,
@@ -105,10 +104,7 @@ void HNEMD::process(
     double factor = KAPPA_UNIT_CONVERSION / output_interval;
     factor /= (volume * temperature * fe);
 
-    char file_kappa[FILE_NAME_LENGTH];
-    strcpy(file_kappa, input_dir);
-    strcat(file_kappa, "/kappa.out");
-    FILE* fid = fopen(file_kappa, "a");
+    FILE* fid = fopen("kappa.out", "a");
     for (int n = 0; n < NUM_OF_HEAT_COMPONENTS; n++) {
       fprintf(fid, "%25.15f", kappa[n] * factor);
     }

--- a/src/measure/hnemd_kappa.cuh
+++ b/src/measure/hnemd_kappa.cuh
@@ -34,7 +34,6 @@ public:
 
   void process(
     int step,
-    const char* input_dir,
     const double temperature,
     const double volume,
     const GPU_Vector<double>& velocity_per_atom,

--- a/src/measure/hnemdec_kappa.cu
+++ b/src/measure/hnemdec_kappa.cu
@@ -139,7 +139,6 @@ static __global__ void gpu_sum_heat_and_diffusion(
 
 void HNEMDEC::process(
   int step,
-  const char* input_dir,
   const double temperature,
   const double volume,
   const GPU_Vector<double>& velocity_per_atom,
@@ -199,10 +198,7 @@ void HNEMDEC::process(
       factor2 *= FACTOR / (output_interval * volume * temperature * fe);
     }
 
-    char file_onsager[FILE_NAME_LENGTH];
-    strcpy(file_onsager, input_dir);
-    strcat(file_onsager, "/onsager.out");
-    FILE* fid = fopen(file_onsager, "a");
+    FILE* fid = fopen("onsager.out", "a");
     for (int n = 0; n < NUM_OF_HEAT_COMPONENTS; n++) {
       // [Lqq/T^2](W/mK) for compute==1,  [Lq1/T^2](kg/smK) for compute==2
       fprintf(fid, "%25.15f", onsager1[n] * factor1);

--- a/src/measure/hnemdec_kappa.cuh
+++ b/src/measure/hnemdec_kappa.cuh
@@ -45,7 +45,6 @@ public:
 
   void process(
     int step,
-    const char* input_dir,
     const double temperature,
     const double volume,
     const GPU_Vector<double>& velocity_per_atom,

--- a/src/measure/measure.cu
+++ b/src/measure/measure.cu
@@ -24,7 +24,6 @@ The driver class dealing with measurement.
 #define NUM_OF_HEAT_COMPONENTS 5
 
 void Measure::initialize(
-  char* input_dir,
   const int number_of_steps,
   const double time_step,
   Box& box,
@@ -37,18 +36,18 @@ void Measure::initialize(
   sdc.preprocess(number_of_atoms, time_step, group);
   hac.preprocess(number_of_steps);
   shc.preprocess(number_of_atoms, group);
-  compute.preprocess(number_of_atoms, input_dir, group);
+  compute.preprocess(number_of_atoms, group);
   hnemd.preprocess();
   hnemdec.preprocess(atom.cpu_mass, atom.cpu_type, atom.cpu_type_size);
-  modal_analysis.preprocess(input_dir, atom.cpu_type_size, atom.mass);
-  dump_position.preprocess(input_dir);
-  dump_velocity.preprocess(input_dir);
-  dump_restart.preprocess(input_dir);
-  dump_thermo.preprocess(input_dir);
-  dump_force.preprocess(input_dir, number_of_atoms, group);
-  dump_exyz.preprocess(input_dir, number_of_atoms);
+  modal_analysis.preprocess(atom.cpu_type_size, atom.mass);
+  dump_position.preprocess();
+  dump_velocity.preprocess();
+  dump_restart.preprocess();
+  dump_thermo.preprocess();
+  dump_force.preprocess(number_of_atoms, group);
+  dump_exyz.preprocess(number_of_atoms);
 #ifdef USE_NETCDF
-  dump_netcdf.preprocess(input_dir, number_of_atoms);
+  dump_netcdf.preprocess(number_of_atoms);
 #endif
 #ifdef USE_PLUMED
   plmd.preprocess(atom.cpu_mass);
@@ -56,11 +55,7 @@ void Measure::initialize(
 }
 
 void Measure::finalize(
-  char* input_dir,
-  const int number_of_steps,
-  const double time_step,
-  const double temperature,
-  const double volume)
+  const int number_of_steps, const double time_step, const double temperature, const double volume)
 {
   dump_position.postprocess();
   dump_velocity.postprocess();
@@ -68,10 +63,10 @@ void Measure::finalize(
   dump_thermo.postprocess();
   dump_force.postprocess();
   dump_exyz.postprocess();
-  dos.postprocess(input_dir);
-  sdc.postprocess(input_dir);
-  hac.postprocess(number_of_steps, input_dir, temperature, time_step, volume);
-  shc.postprocess(input_dir, time_step);
+  dos.postprocess();
+  sdc.postprocess();
+  hac.postprocess(number_of_steps, temperature, time_step, volume);
+  shc.postprocess(time_step);
   compute.postprocess();
   hnemd.postprocess();
   hnemdec.postprocess();
@@ -89,7 +84,6 @@ void Measure::finalize(
 }
 
 void Measure::process(
-  char* input_dir,
   const int number_of_steps,
   int step,
   const int fixed_group,
@@ -123,15 +117,14 @@ void Measure::process(
   dos.process(step, group, atom.velocity_per_atom);
   sdc.process(step, group, atom.velocity_per_atom);
   hac.process(
-    number_of_steps, step, input_dir, atom.velocity_per_atom, atom.virial_per_atom,
-    atom.heat_per_atom);
+    number_of_steps, step, atom.velocity_per_atom, atom.virial_per_atom, atom.heat_per_atom);
   shc.process(step, group, atom.velocity_per_atom, atom.virial_per_atom);
   hnemd.process(
-    step, input_dir, temperature, box.get_volume(), atom.velocity_per_atom, atom.virial_per_atom,
+    step, temperature, box.get_volume(), atom.velocity_per_atom, atom.virial_per_atom,
     atom.heat_per_atom);
   hnemdec.process(
-    step, input_dir, temperature, box.get_volume(), atom.velocity_per_atom, atom.virial_per_atom,
-    atom.type, atom.mass, atom.potential_per_atom, atom.heat_per_atom);
+    step, temperature, box.get_volume(), atom.velocity_per_atom, atom.virial_per_atom, atom.type,
+    atom.mass, atom.potential_per_atom, atom.heat_per_atom);
   modal_analysis.process(
     step, temperature, box.get_volume(), hnemd.fe, atom.velocity_per_atom, atom.virial_per_atom);
 #ifdef USE_NETCDF

--- a/src/measure/measure.cuh
+++ b/src/measure/measure.cuh
@@ -45,7 +45,6 @@ class Measure
 {
 public:
   void initialize(
-    char* input_dir,
     const int number_of_steps,
     const double time_step,
     Box& box,
@@ -54,14 +53,12 @@ public:
     Atom& atom);
 
   void finalize(
-    char* input_dir,
     const int number_of_steps,
     const double time_step,
     const double temperature,
     const double volume);
 
   void process(
-    char* input_dir,
     const int number_of_steps,
     int step,
     const int fixed_group,

--- a/src/measure/modal_analysis.cu
+++ b/src/measure/modal_analysis.cu
@@ -324,7 +324,7 @@ void MODAL_ANALYSIS::setN(const std::vector<int>& cpu_type_size)
 void MODAL_ANALYSIS::set_eigmode(int mode, std::ifstream& eigfile, GPU_Vector<float>& eig)
 {
   std::vector<float> floatval(num_participating);
-  eigfile.read((char *)(&floatval[0]), num_participating * sizeof(float));
+  eigfile.read((char*)(&floatval[0]), num_participating * sizeof(float));
   for (int i = 0; i < num_participating; i++) {
     // column major ordering for cuBLAS
     eig[mode + i * num_modes] = floatval[i];
@@ -332,7 +332,7 @@ void MODAL_ANALYSIS::set_eigmode(int mode, std::ifstream& eigfile, GPU_Vector<fl
 }
 
 void MODAL_ANALYSIS::preprocess(
-  char* input_dir, const std::vector<int>& cpu_type_size, const GPU_Vector<double>& mass)
+  const std::vector<int>& cpu_type_size, const GPU_Vector<double>& mass)
 {
   if (!compute)
     return;
@@ -340,11 +340,10 @@ void MODAL_ANALYSIS::preprocess(
   samples_per_output = output_interval / sample_interval;
   setN(cpu_type_size);
 
-  strcpy(output_file_position, input_dir);
   if (method == GKMA_METHOD) {
-    strcat(output_file_position, "/heatmode.out");
+    strcpy(output_file_position, "heatmode.out");
   } else if (method == HNEMA_METHOD) {
-    strcat(output_file_position, "/kappamode.out");
+    strcpy(output_file_position, "kappamode.out");
   }
 
   size_t eig_size = num_participating * num_modes;
@@ -353,8 +352,7 @@ void MODAL_ANALYSIS::preprocess(
   eigz.resize(eig_size, Memory_Type::managed);
 
   // initialize eigenvector data structures
-  strcpy(eig_file_position, input_dir);
-  strcat(eig_file_position, "/eigenvector.in");
+  strcpy(eig_file_position, "eigenvector.in");
   std::ifstream eigfile;
   eigfile.open(eig_file_position, std::ios::in | std::ios::binary);
   if (!eigfile) {
@@ -367,9 +365,8 @@ void MODAL_ANALYSIS::preprocess(
     eigfile.seekg((first_mode - 1) * sizeof(float));
     float om2;
     for (int i = 0; i < num_modes; i++) {
-      eigfile.read((char *)(&om2), sizeof(float));
+      eigfile.read((char*)(&om2), sizeof(float));
       f[i] = copysign(sqrt(abs(om2)) / (2.0 * PI), om2);
-
     }
     double fmax, fmin; // freq are in ascending order in file
     int shift;

--- a/src/measure/modal_analysis.cuh
+++ b/src/measure/modal_analysis.cuh
@@ -77,8 +77,7 @@ public:
   char eig_file_position[200];
   char output_file_position[200];
 
-  void preprocess(
-    char* input_dir, const std::vector<int>& cpu_type_size, const GPU_Vector<double>& mass);
+  void preprocess(const std::vector<int>& cpu_type_size, const GPU_Vector<double>& mass);
 
   void process(
     const int step,

--- a/src/measure/sdc.cu
+++ b/src/measure/sdc.cu
@@ -186,7 +186,7 @@ void SDC::process(
   }
 }
 
-void SDC::postprocess(const char* input_dir)
+void SDC::postprocess()
 {
   if (!compute_)
     return;
@@ -214,10 +214,7 @@ void SDC::postprocess(const char* input_dir)
   const double sdc_unit_conversion = 1.0e3 / TIME_UNIT_CONVERSION;
   const double vac_unit_conversion = sdc_unit_conversion * sdc_unit_conversion;
 
-  char file_sdc[200];
-  strcpy(file_sdc, input_dir);
-  strcat(file_sdc, "/sdc.out");
-  FILE* fid = fopen(file_sdc, "a");
+  FILE* fid = fopen("sdc.out", "a");
   for (int nc = 0; nc < num_correlation_steps_; nc++) {
     fprintf(
       fid, "%g %g %g %g %g %g %g\n", nc * dt_in_ps_, vacx_[nc] * vac_unit_conversion,

--- a/src/measure/sdc.cuh
+++ b/src/measure/sdc.cuh
@@ -30,7 +30,7 @@ public:
   void preprocess(const int num_atoms, const double time_step, const std::vector<Group>& groups);
   void process(
     const int step, const std::vector<Group>& groups, const GPU_Vector<double>& velocity_per_atom);
-  void postprocess(const char*);
+  void postprocess();
   void parse(const char** param, const int num_param, const std::vector<Group>& groups);
 
 private:

--- a/src/measure/shc.cu
+++ b/src/measure/shc.cu
@@ -243,7 +243,7 @@ void SHC::find_shc(const double dt_in_ps, const double d_omega)
   }
 }
 
-void SHC::postprocess(const char* input_dir, const double time_step)
+void SHC::postprocess(const double time_step)
 {
   if (!compute) {
     return;
@@ -252,10 +252,7 @@ void SHC::postprocess(const char* input_dir, const double time_step)
   const double dt_in_ps = time_step * sample_interval * TIME_UNIT_CONVERSION / 1000.0;
   const double d_omega = max_omega / num_omega;
 
-  char file_shc[200];
-  strcpy(file_shc, input_dir);
-  strcat(file_shc, "/shc.out");
-  FILE* fid = my_fopen(file_shc, "a");
+  FILE* fid = my_fopen("shc.out", "a");
 
   // ki and ko are in units of A*eV/ps
   average_k();

--- a/src/measure/shc.cuh
+++ b/src/measure/shc.cuh
@@ -34,7 +34,7 @@ public:
     const std::vector<Group>& group,
     const GPU_Vector<double>& velocity_per_atom,
     const GPU_Vector<double>& virial_per_atom);
-  void postprocess(const char*, const double time_step);
+  void postprocess(const double time_step);
   void parse(const char**, int, const std::vector<Group>& group);
   void find_shc(const double dt_in_ps, const double d_omega);
   void average_k();

--- a/src/model/read_xyz.cu
+++ b/src/model/read_xyz.cu
@@ -465,9 +465,9 @@ void find_type_size(
   }
 }
 
-static std::string get_filename_potential(char* input_dir)
+static std::string get_filename_potential()
 {
-  std::ifstream input_run(input_dir + std::string("/run.in"));
+  std::ifstream input_run("run.in");
   if (!input_run.is_open()) {
     PRINT_INPUT_ERROR("No run.in.");
   }
@@ -521,7 +521,6 @@ static std::vector<std::string> get_atom_symbols(std::string& filename_potential
 }
 
 void initialize_position(
-  char* input_dir,
   int& N,
   int& has_velocity_in_xyz,
   int& number_of_types,
@@ -529,7 +528,7 @@ void initialize_position(
   std::vector<Group>& group,
   Atom& atom)
 {
-  std::string filename(input_dir + std::string("/model.xyz"));
+  std::string filename("model.xyz");
   std::ifstream input(filename);
 
   if (!input.is_open()) {
@@ -537,7 +536,7 @@ void initialize_position(
   }
 
   std::vector<std::string> atom_symbols;
-  auto filename_potential = get_filename_potential(input_dir);
+  auto filename_potential = get_filename_potential();
   atom_symbols = get_atom_symbols(filename_potential);
 
   read_xyz_line_1(input, N);

--- a/src/model/read_xyz.cuh
+++ b/src/model/read_xyz.cuh
@@ -23,7 +23,6 @@ class Atom;
 #include <vector>
 
 void initialize_position(
-  char* input_dir,
   int& N,
   int& has_velocity_in_xyz,
   int& number_of_types,

--- a/src/phonon/hessian.cuh
+++ b/src/phonon/hessian.cuh
@@ -31,7 +31,6 @@ public:
   double cutoff = 4.0;
 
   void compute(
-    char* input_dir,
     Force& force,
     Box& box,
     std::vector<double>& cpu_position_per_atom,
@@ -56,9 +55,9 @@ protected:
   std::vector<double> DR;
   std::vector<double> DI;
 
-  void read_basis(char*, size_t N);
-  void read_kpoints(char*);
-  void initialize(char*, size_t);
+  void read_basis(size_t N);
+  void read_kpoints();
+  void initialize(size_t);
   void finalize(void);
 
   void find_H(
@@ -78,13 +77,12 @@ protected:
     const size_t n1,
     const size_t n2);
 
-  void find_dispersion(
-    char* input_dir, const Box& box, const std::vector<double>& cpu_position_per_atom);
+  void find_dispersion(const Box& box, const std::vector<double>& cpu_position_per_atom);
 
   void find_D(const Box& box, std::vector<double>& cpu_position_per_atom);
 
-  void find_eigenvectors(char*);
-  void output_D(char*);
+  void find_eigenvectors();
+  void output_D();
   void find_omega(FILE*, size_t);
   void find_omega_batch(FILE*);
 };


### PR DESCRIPTION
After removing the "driver input file", we don't need to use `input_directory` any more. So we can simplify the code by removing 100+ lines.