### PR TITLE
Improve nep4

### DIFF
--- a/src/main_nep/dataset.cuh
+++ b/src/main_nep/dataset.cuh
@@ -65,7 +65,7 @@ public:
   construct(Parameters& para, std::vector<Structure>& structures, int n1, int n2, int device_id);
   float get_rmse_force(Parameters& para, const bool use_weight, int device_id);
   float get_rmse_energy(
-    float& energy_shift_per_structure, const bool use_weight, const bool do_shift, int device_id);
+    std::vector<float>& energy_shift, const bool use_weight, const bool do_shift, int device_id);
   float get_rmse_virial(Parameters& para, const bool use_weight, int device_id);
 
 private:

--- a/src/main_nep/dataset.cuh
+++ b/src/main_nep/dataset.cuh
@@ -33,7 +33,9 @@ public:
   std::vector<int> Na_cpu;     // number of atoms in each configuration
   std::vector<int> Na_sum_cpu; // prefix sum of Na_cpu
 
-  std::vector<int> type_of_structures; // 0 for pure 0, 1 for pure 1, num_types for compounds
+  std::vector<int> type_of_structure; // 0 for pure 0, 1 for pure 1, num_types for compounds
+  std::vector<int> count_of_type;
+  GPU_Vector<float> energy_shift_gpu;
 
   GPU_Vector<int> type;           // atom type (0, 1, 2, 3, ...)
   GPU_Vector<float> r;            // position
@@ -67,7 +69,11 @@ public:
   construct(Parameters& para, std::vector<Structure>& structures, int n1, int n2, int device_id);
   float get_rmse_force(Parameters& para, const bool use_weight, int device_id);
   float get_rmse_energy(
-    std::vector<float>& energy_shift, const bool use_weight, const bool do_shift, int device_id);
+    Parameters& para,
+    std::vector<float>& energy_shift,
+    const bool use_weight,
+    const bool do_shift,
+    int device_id);
   float get_rmse_virial(Parameters& para, const bool use_weight, int device_id);
 
 private:

--- a/src/main_nep/dataset.cuh
+++ b/src/main_nep/dataset.cuh
@@ -33,6 +33,8 @@ public:
   std::vector<int> Na_cpu;     // number of atoms in each configuration
   std::vector<int> Na_sum_cpu; // prefix sum of Na_cpu
 
+  std::vector<int> type_of_structures; // 0 for pure 0, 1 for pure 1, num_types for compounds
+
   GPU_Vector<int> type;           // atom type (0, 1, 2, 3, ...)
   GPU_Vector<float> r;            // position
   GPU_Vector<float> box;          // (expanded) box and inverse box (18 components)

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -133,7 +133,7 @@ void Fitness::compute(
       const float* individual = population + deviceCount * n * para.number_of_variables;
       potential->find_force(para, individual, train_set[batch_id], false, deviceCount);
       for (int m = 0; m < deviceCount; ++m) {
-        std::vector<float> energy_shift(para.num_types);
+        std::vector<float> energy_shift(para.num_types + 1);
         fitness[deviceCount * n + m + 0 * para.population_size] =
           para.lambda_e * train_set[batch_id][m].get_rmse_energy(energy_shift, true, true, m);
         fitness[deviceCount * n + m + 1 * para.population_size] =
@@ -219,7 +219,7 @@ void Fitness::report_error(
   if (0 == (generation + 1) % 100) {
     int batch_id = generation % num_batches;
     potential->find_force(para, elite, train_set[batch_id], false, 1);
-    std::vector<float> energy_shift(para.num_types);
+    std::vector<float> energy_shift(para.num_types + 1);
     float rmse_energy_train = train_set[batch_id][0].get_rmse_energy(energy_shift, false, true, 0);
     float rmse_force_train = train_set[batch_id][0].get_rmse_force(para, false, 0);
     float rmse_virial_train = train_set[batch_id][0].get_rmse_virial(para, false, 0);

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -133,10 +133,9 @@ void Fitness::compute(
       const float* individual = population + deviceCount * n * para.number_of_variables;
       potential->find_force(para, individual, train_set[batch_id], false, deviceCount);
       for (int m = 0; m < deviceCount; ++m) {
-        float energy_shift_per_structure_not_used;
+        std::vector<float> energy_shift(para.num_types);
         fitness[deviceCount * n + m + 0 * para.population_size] =
-          para.lambda_e * train_set[batch_id][m].get_rmse_energy(
-                            energy_shift_per_structure_not_used, true, true, m);
+          para.lambda_e * train_set[batch_id][m].get_rmse_energy(energy_shift, true, true, m);
         fitness[deviceCount * n + m + 1 * para.population_size] =
           para.lambda_f * train_set[batch_id][m].get_rmse_force(para, true, m);
         fitness[deviceCount * n + m + 2 * para.population_size] =
@@ -220,21 +219,18 @@ void Fitness::report_error(
   if (0 == (generation + 1) % 100) {
     int batch_id = generation % num_batches;
     potential->find_force(para, elite, train_set[batch_id], false, 1);
-    float energy_shift_per_structure;
-    float rmse_energy_train =
-      train_set[batch_id][0].get_rmse_energy(energy_shift_per_structure, false, true, 0);
+    std::vector<float> energy_shift(para.num_types);
+    float rmse_energy_train = train_set[batch_id][0].get_rmse_energy(energy_shift, false, true, 0);
     float rmse_force_train = train_set[batch_id][0].get_rmse_force(para, false, 0);
     float rmse_virial_train = train_set[batch_id][0].get_rmse_virial(para, false, 0);
 
     // correct the last bias parameter in the NN
     if (para.train_mode == 0) {
-      elite[para.number_of_variables_ann - 1] += energy_shift_per_structure;
+      elite[para.number_of_variables_ann - 1] += energy_shift[0];
     }
 
     potential->find_force(para, elite, test_set, false, 1);
-    float energy_shift_per_structure_not_used;
-    float rmse_energy_test =
-      test_set[0].get_rmse_energy(energy_shift_per_structure_not_used, false, false, 0);
+    float rmse_energy_test = test_set[0].get_rmse_energy(energy_shift, false, false, 0);
     float rmse_force_test = test_set[0].get_rmse_force(para, false, 0);
     float rmse_virial_test = test_set[0].get_rmse_virial(para, false, 0);
 

--- a/src/main_nep/nep3.cuh
+++ b/src/main_nep/nep3.cuh
@@ -59,13 +59,13 @@ public:
   };
 
   struct ANN {
-    int dim = 0;          // dimension of the descriptor
-    int num_neurons1 = 0; // number of neurons in the hidden layer
-    int num_para = 0;     // number of parameters
-    const float* w0[100]; // weight from the input layer to the hidden layer
-    const float* b0[100]; // bias for the hidden layer
-    const float* w1[100]; // weight from the hidden layer to the output layer
-    const float* b1;      // bias for the output layer
+    int dim = 0;                   // dimension of the descriptor
+    int num_neurons1 = 0;          // number of neurons in the hidden layer
+    int num_para = 0;              // number of parameters
+    const float* w0[NUM_ELEMENTS]; // weight from the input layer to the hidden layer
+    const float* b0[NUM_ELEMENTS]; // bias for the hidden layer
+    const float* w1[NUM_ELEMENTS]; // weight from the hidden layer to the output layer
+    const float* b1[NUM_ELEMENTS]; // bias for the output layer
     const float* c;
   };
 

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -141,7 +141,18 @@ void Parameters::calculate_parameters()
   dim = dim_radial + dim_angular;
   q_scaler_cpu.resize(dim, 1.0e10f);
 
-  number_of_variables_ann = (dim + 2) * num_neurons1 * (version == 4 ? num_types : 1) + 1;
+  // a single NN for NEP2 and NEP3:
+  number_of_variables_ann = (dim + 2) * num_neurons1 + 1;
+
+  // one NN for one element but all elements share the same output bias in NEP4:
+  if (version == 4) {
+    number_of_variables_ann = (dim + 2) * num_neurons1 * num_types + 1;
+  }
+
+  // one NN for one element and each element has its own output bias in NEP5:
+  if (version == 5) {
+    number_of_variables_ann = (dim + 2) * num_neurons1 * num_types + num_types;
+  }
 
   if (version == 2) {
     number_of_variables_descriptor =
@@ -392,8 +403,8 @@ void Parameters::parse_version(const char** param, int num_param)
   if (!is_valid_int(param[1], &version)) {
     PRINT_INPUT_ERROR("version should be an integer.\n");
   }
-  if (version < 2 || version > 4) {
-    PRINT_INPUT_ERROR("version should = 2 or 3 or 4.");
+  if (version < 2 || version > 5) {
+    PRINT_INPUT_ERROR("version should = 2 or 3 or 4 or 5.");
   }
 }
 


### PR DESCRIPTION
This is NEP5, a version that complements NEP4. NEP4 will not work when there are only pure subsystems (A, B, C, ...), but NEP5 can work even in this case. However, it seems there is no advantage of NEP5 over NEP4 when there are compound subsystems (such as AB, AC, BC, ABC, ...). Because in practice one should not only have pure subsystems, we should not need NEP5 at all. So I will probably abandom this PR, but I would like to wait for some converged training results...
