### PR TITLE
better initial sigma

### DIFF
--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -69,7 +69,7 @@ void SNES::initialize_mu_and_sigma(Parameters& para)
     std::uniform_real_distribution<float> r1(0, 1);
     for (int n = 0; n < number_of_variables; ++n) {
       mu[n] = r1(rng) - 0.5f;
-      sigma[n] = 0.1f;
+      sigma[n] = eta_sigma;
     }
   } else {
     for (int n = 0; n < number_of_variables; ++n) {

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -69,7 +69,7 @@ void SNES::initialize_mu_and_sigma(Parameters& para)
     std::uniform_real_distribution<float> r1(0, 1);
     for (int n = 0; n < number_of_variables; ++n) {
       mu[n] = r1(rng) - 0.5f;
-      sigma[n] = eta_sigma;
+      sigma[n] = eta_sigma * 2.0f;
     }
   } else {
     for (int n = 0; n < number_of_variables; ++n) {


### PR DESCRIPTION
In the SNES method, every trainable parameter has an average $\mu$ and a variance $\sigma$. The SNES algorithm updates these values according to the natural gradient, until every $\sigma \rightarrow 0$. As a start, one must choose appropriate initial values for $\mu$ and $\sigma$. I have tested that $\mu$ can be randomly chosen from -0.5 to 0.5, but I used a fixed value of 0.1 for $\sigma$. In the mathematical literature, the $\sigma$ is chosen to be 1 (I checked some available codes to confirm this). But I found empirically that setting $\sigma=1$ for each variable can lead to violent fluctuations of the loss in the beginning, and by trial and error I have found $\sigma=0.1$ is a good value. However, it seems this value should be decreased with increasing neural network size. Based on some recent tests for many-element systems, I proposed to use the following expression for $\sigma$, which is actually the same as the recommended learning rate of $\sigma$:

$$
\sigma = (3 + \log(N)) / ( 5 \sqrt{N} ).
$$

where $N$ is the total number of fitting parameters.

Here is a picture of this function:
![image](https://user-images.githubusercontent.com/24891193/205510332-fab6afd0-2a20-461d-86ec-1836ff400a65.png)

So a value of $\sigma=0.1$ corresponds to about 300 fitting parameters (my conclusion of choosing $\sigma=0.1$ was exactly based on my initial tests with a few hundred fitting parametes) and if we have 100,000 fitting parameters, the intial $\sigma$ should be about 0.01. I have tested that when there are 100,000 fitting parameters, using $\sigma=0.1$ makes the loss blow up, while using $\sigma$ as in the above expression works well.  

