### PR TITLE
increase lambda_e and lambda_v from 0 can speed up

### DIFF
--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -32,6 +32,8 @@ https://doi.org/10.1145/2001576.2001692
 
 SNES::SNES(Parameters& para, Fitness* fitness_function)
 {
+  lambda_e_final = para.lambda_e;
+  lambda_v_final = para.lambda_v;
   maximum_generation = para.maximum_generation;
   number_of_variables = para.number_of_variables;
   population_size = para.population_size;
@@ -105,6 +107,8 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
     "RMSE-V-Test");
 
   for (int n = 0; n < maximum_generation; ++n) {
+    para.lambda_e = (lambda_e_final * n) / maximum_generation;
+    para.lambda_v = (lambda_v_final * n) / maximum_generation;
     create_population(para);
     fitness_function->compute(n, para, population.data(), fitness.data() + 3 * population_size);
     regularize(para);

--- a/src/main_nep/snes.cuh
+++ b/src/main_nep/snes.cuh
@@ -30,6 +30,8 @@ protected:
   int number_of_variables = 10;
   int population_size = 20;
   float eta_sigma = 0.1f;
+  float lambda_e_final = 1.0f;
+  float lambda_v_final = 0.1f;
   std::vector<int> index;
   std::vector<float> fitness;
   std::vector<float> fitness_copy;


### PR DESCRIPTION
Inspired by the DeePMD code (https://github.com/deepmodeling/deepmd-kit), I tried to increase the energy and virial weights from 0 to the specified values linearly during the training, and it turned out this can indeed lead to faster training. The figure below shows testing results on silicon (data from https://journals.aps.org/prx/abstract/10.1103/PhysRevX.8.041048). The labels `new` and `old` mean using varying and constant weights for energy and virial, respectively.

![image](https://user-images.githubusercontent.com/24891193/205985669-db05db6f-c923-4daf-a376-2851c931b07e.png)



`nep.in`:
```
type        1 Si
version     2
cutoff      5 5
n_max       8 8
l_max       4
neuron      30
lambda_1    0.05
lambda_2    0.05
batch 	    50
population  30
generation  10000
```