### PR TITLE
revert changes about sigma and lambda_ev

### DIFF
--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -32,8 +32,6 @@ https://doi.org/10.1145/2001576.2001692
 
 SNES::SNES(Parameters& para, Fitness* fitness_function)
 {
-  lambda_e_final = para.lambda_e;
-  lambda_v_final = para.lambda_v;
   maximum_generation = para.maximum_generation;
   number_of_variables = para.number_of_variables;
   population_size = para.population_size;
@@ -71,10 +69,8 @@ void SNES::initialize_mu_and_sigma(Parameters& para)
     std::uniform_real_distribution<float> r1(0, 1);
     for (int n = 0; n < number_of_variables; ++n) {
       mu[n] = r1(rng) - 0.5f;
-      sigma[n] = eta_sigma * 2.0f;
+      sigma[n] = 0.1f;
     }
-    lambda_e_step = std::max(1, para.maximum_generation / 10);
-    lambda_v_step = std::max(1, para.maximum_generation / 10);
   } else {
     for (int n = 0; n < number_of_variables; ++n) {
       int count = fscanf(fid_restart, "%f%f", &mu[n], &sigma[n]);
@@ -109,17 +105,6 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
     "RMSE-V-Test");
 
   for (int n = 0; n < maximum_generation; ++n) {
-    if (n + 1 < lambda_e_step) {
-      para.lambda_e = (lambda_e_final * (n + 1)) / lambda_e_step;
-    } else {
-      para.lambda_e = lambda_e_final;
-    }
-    if (n + 1 < lambda_v_step) {
-      para.lambda_v = (lambda_v_final * (n + 1)) / lambda_v_step;
-    } else {
-      para.lambda_v = lambda_v_final;
-    }
-
     create_population(para);
     fitness_function->compute(n, para, population.data(), fitness.data() + 3 * population_size);
     regularize(para);

--- a/src/main_nep/snes.cuh
+++ b/src/main_nep/snes.cuh
@@ -30,10 +30,6 @@ protected:
   int number_of_variables = 10;
   int population_size = 20;
   float eta_sigma = 0.1f;
-  float lambda_e_final = 1.0f;
-  float lambda_v_final = 0.1f;
-  int lambda_e_step = 1; // number of steps within which lamda_e increases to lambda_e_final
-  int lambda_v_step = 1; // number of steps within which lamda_v increases to lambda_v_final
   std::vector<int> index;
   std::vector<float> fitness;
   std::vector<float> fitness_copy;


### PR DESCRIPTION
This PR revert the changes in #344 and #338, for which users have been tested to be not good in general. The solution for many-element systems should be to increase the regularization weights if the training does not converge.