### PR TITLE
not require abs(c)>0.1

### DIFF
--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -163,14 +163,6 @@ void SNES::create_population(Parameters& para)
       int pv = p * number_of_variables + v;
       s[pv] = r1(rng);
       population[pv] = sigma[v] * s[pv] + mu[v];
-      // avoid zero
-      if (v >= para.number_of_variables_ann) {
-        if (population[pv] > 0) {
-          population[pv] += 0.1f;
-        } else {
-          population[pv] -= 0.1f;
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
In my NEP2 paper, I reauired that abs(c)>0.1 for the descriptor parameters c. Now I think this restriction is not needed. Without this restriction I have observed L1 regularization can select features better and the regression accuracity is usually higher.