### PR TITLE
Added documentation for new keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ local
 public*
 \#*
 
-nep
-gpumd
+/nep
+/gpumd

--- a/doc/gpumd/input_parameters/change_box.rst
+++ b/doc/gpumd/input_parameters/change_box.rst
@@ -64,7 +64,7 @@ This keyword accepts 1 or 3 or 6 parameters.
 
 In the case of 1 parameter :math:`\delta` (in units of Ångstrom)::
 
- change_box delta
+ change_box <delta>
 
 we have
 
@@ -87,7 +87,7 @@ we have
 
 In the case of 3 parameters, :math:`\delta_{xx}` (in units of Ångstrom), :math:`\delta_{yy}` (in units of Ångstrom), and :math:`\delta_{zz}` (in units of Ångstrom)::
   
-   change_box delta_xx delta_yy delta_zz
+   change_box <delta_xx> <delta_yy> <delta_zz>
 
 we have
 
@@ -111,7 +111,7 @@ we have
 
 In the case of 6 parameters (the box type must be triclinic), :math:`\delta_{xx}` (in units of Ångstrom), :math:`\delta_{yy}` (in units of Ångstrom), :math:`\delta_{zz}` (in units of Ångstrom), :math:`\epsilon_{yz}` (dimensionless strain), :math:`\epsilon_{xz}` (dimensionless strain), and :math:`\epsilon_{xy}` (dimensionless strain)::
 
-  change_box delta_xx delta_yy delta_zz epsilon_yz epsilon_xz epsilon_xy
+  change_box <delta_xx> <delta_yy> <delta_zz> <epsilon_yz> <epsilon_xz> <epsilon_xy>
 
 we have
 

--- a/doc/gpumd/input_parameters/compute.rst
+++ b/doc/gpumd/input_parameters/compute.rst
@@ -12,7 +12,7 @@ The results are written to the :ref:`compute.out output file <compute_out>`.
 Syntax
 ------
 It is used in the following way::
-  compute grouping_method sample_interval output_interval quantity_1 quantity_2 ...
+  compute <grouping_method> <sample_interval> <output_interval> {<quantity>}
 
 The first parameter :attr:`grouping_method` refers to the grouping method defined in the :ref:`simulation model file <model_xyz>`.
 This parameter should be an integer and a number :math:`m` means the :math:`m`-th grouping method (we count from 0) in the :ref:`simulation model file <model_xyz>`.

--- a/doc/gpumd/input_parameters/compute_cohesive.rst
+++ b/doc/gpumd/input_parameters/compute_cohesive.rst
@@ -14,7 +14,7 @@ Syntax
 
 This keyword is used as follows::
 
-  compute_cohesive e1 e2 num_points
+  compute_cohesive <e1> <e2> <num_points>
 
 Here,
 :attr:`e1` is the smaller box-scaling factor,

--- a/doc/gpumd/input_parameters/compute_dos.rst
+++ b/doc/gpumd/input_parameters/compute_dos.rst
@@ -15,7 +15,7 @@ Syntax
 ------
 For this keyword, the command looks like::
 
-  compute_dos sample_interval Nc omega_max <optional_args>
+  compute_dos <sample_interval> <Nc> <omega_max> [{<optional_arg>}]
 
 with parameters defined as:
 
@@ -23,17 +23,17 @@ with parameters defined as:
 * :attr:`Nc`: Maximum number of correlation steps
 * :attr:`omega_max`: Maximum angular frequency :math:`\omega_{max}=2\pi\nu_{max}` used in the :term:`PDOS` calculation
 
-The :attr:`optional_args` provide additional functionality by allowing special keywords.
+The optional arguments (:attr:`optional_arg`) provide additional functionality by allowing special keywords.
 The keywords for this function are :attr:`group` and :attr:`num_dos_points`.
 These keywords can be used in any order but the parameters associated with each must follow directly.
 The parameters are:
 
-* :attr:`group group_method group`
+* :attr:`group <group_method> <group>`
 
  * :attr:`group_method`: The grouping method to use for computation
  * :attr:`group`: The group in the grouping method to use
 
-* :attr:`num_dos_points points`
+* :attr:`num_dos_points <points>`
 
  * :attr:`points`: Number of frequency points to be used in the DOS calculation (:attr:`Nc` if option not selected)
 

--- a/doc/gpumd/input_parameters/compute_elastic.rst
+++ b/doc/gpumd/input_parameters/compute_elastic.rst
@@ -13,7 +13,7 @@ Syntax
 
 This keyword is used as follows::
 
-  compute_elastic strain_value symmetry_type
+  compute_elastic <strain_value> <symmetry_type>
 
 :attr:`strain_value` is the amount of strain to be applied in the calculations.
 

--- a/doc/gpumd/input_parameters/compute_gkma.rst
+++ b/doc/gpumd/input_parameters/compute_gkma.rst
@@ -14,7 +14,7 @@ Syntax
 
 .. code::
 
-   compute_gkma sample_interval first_mode last_mode bin_option size
+   compute_gkma <sample_interval> <first_mode> <last_mode> <bin_option> <size>
 
 :attr:`sample_interval` is the sampling interval (in number of steps) used to compute the heat modal heat current.
 

--- a/doc/gpumd/input_parameters/compute_hac.rst
+++ b/doc/gpumd/input_parameters/compute_hac.rst
@@ -12,7 +12,7 @@ Syntax
 ------
 This keyword has 3 parameters::
 
-  compute_hac sampling_interval correlation_steps output_interval
+  compute_hac <sampling_interval> <correlation_steps> <output_interval>
 
 The first parameter is the sampling interval for the heat current data. 
 The second parameter is the maximum correlations steps. 

--- a/doc/gpumd/input_parameters/compute_hnema.rst
+++ b/doc/gpumd/input_parameters/compute_hnema.rst
@@ -13,7 +13,7 @@ Syntax
 
 .. code::
 
-   compute_hnema sample_interval output_interval Fe_x Fe_y Fe_z first_mode last_mode bin_option size
+   compute_hnema <sample_interval> <output_interval> <Fe_x> <Fe_y> <Fe_z> <first_mode> <last_mode> <bin_option> <size>
 
 :attr:`sample_interval` is the sampling interval (in number of steps) used to compute the heat modal heat current.
 Must be a divisor of :attr:`output_interval`.

--- a/doc/gpumd/input_parameters/compute_hnemd.rst
+++ b/doc/gpumd/input_parameters/compute_hnemd.rst
@@ -13,7 +13,7 @@ Syntax
 
 .. code::
 
-   compute_hnemd output_interval Fe_x Fe_y Fe_z
+   compute_hnemd <output_interval> <Fe_x> <Fe_y> <Fe_z>
 
 The first parameter is the output interval.
 

--- a/doc/gpumd/input_parameters/compute_msd.rst
+++ b/doc/gpumd/input_parameters/compute_msd.rst
@@ -13,18 +13,18 @@ Syntax
 ------
 For this keyword, the command looks like::
   
-  compute_msd sample_interval Nc <optional_arg>
+  compute_msd <sample_interval> <Nc> [<optional_arg>]
 
 with parameters defined as
 
 * :attr:`sample_interval`: Sampling interval of the position data
 * :attr:`Nc`: Maximum number of correlation steps
 
-The :attr:`optional_arg` allows an additional special keyword.
+The optional argument :attr:`optional_arg` allows an additional special keyword.
 The keyword for this function is :attr:`group`.
 The parameters are:
 
-* :attr:`group group_method group`, where :attr:`group_method` is the grouping method to use for computation and :attr:`group` is the group in the grouping method to use
+* :attr:`group <group_method> <group>`, where :attr:`group_method` is the grouping method to use for computation and :attr:`group` is the group in the grouping method to use
 
 Examples
 --------

--- a/doc/gpumd/input_parameters/compute_phonon.rst
+++ b/doc/gpumd/input_parameters/compute_phonon.rst
@@ -27,7 +27,7 @@ Syntax
 
 This keyword is used as follows::
 
-  compute_phonon cutoff displacement
+  compute_phonon <cutoff> <displacement>
 
 :attr:`cutoff` is the cutoff distance (in units of Å) for calculating the force constants.
 

--- a/doc/gpumd/input_parameters/compute_sdc.rst
+++ b/doc/gpumd/input_parameters/compute_sdc.rst
@@ -13,18 +13,18 @@ Syntax
 ------
 For this keyword, the command looks like::
   
-  compute_sdc sample_interval Nc <optional_arg>
+  compute_sdc <sample_interval> <Nc> [<optional_arg>]
 
 with parameters defined as
 
 * :attr:`sample_interval`: Sampling interval of the velocity data
 * :attr:`Nc`: Maximum number of correlation steps
 
-The :attr:`optional_arg` allows an additional special keyword.
+The optional argument :attr:`optional_arg` allows an additional special keyword.
 The keyword for this function is :attr:`group`.
 The parameters are:
 
-* :attr:`group group_method group`, where :attr:`group_method` is the grouping method to use for computation and :attr:`group` is the group in the grouping method to use
+* :attr:`group <group_method> <group>`, where :attr:`group_method` is the grouping method to use for computation and :attr:`group` is the group in the grouping method to use
 
 Examples
 --------

--- a/doc/gpumd/input_parameters/compute_shc.rst
+++ b/doc/gpumd/input_parameters/compute_shc.rst
@@ -14,7 +14,7 @@ Syntax
 
 .. code::
 
-   compute_shc sample_interval Nc transport_direction num_omega max_omega <options>
+   compute_shc <sample_interval> <Nc> <transport_direction> <num_omega> <max_omega> [{<optional_arg>}]
 
 :attr:`sample_interval` is the sampling interval (number of steps) between two correlation steps.
 This parameter must be an integer that is :math:`\geq 1` and :math:`\leq 10`. 
@@ -30,9 +30,9 @@ It can only be 0, 1, and 2, corresponding to the :math:`x`, :math:`y`, and :math
 :attr:`max_omega` is the maximum angular frequency (in units of THz) one wants to consider.
 The angular frequency data will be :attr:`max_omega/num_omega, 2*max_omega/num_omega, ..., max_omega`.
 
-:attr:`<options>` can only be :attr:`group`, which requires two parameters::
+:attr:`<optional_arg>` can only be :attr:`group`, which requires two parameters::
 
-   group grouping_method group_id
+   group <grouping_method> <group_id>
 
 This meas that :math:`K(t)` will be calculated for atoms in group :attr:`group_id` of grouping method :attr:`grouping_method`.
 Here :attr:`group_id` should be :math:`\geq 0` and smaller than the number of groups in grouping method :attr:`grouping_method`.

--- a/doc/gpumd/input_parameters/compute_viscosity.rst
+++ b/doc/gpumd/input_parameters/compute_viscosity.rst
@@ -12,7 +12,7 @@ Syntax
 ------
 This keyword has 2 parameters::
 
-  compute_viscosity sampling_interval correlation_steps
+  compute_viscosity <sampling_interval> <correlation_steps>
 
 The first parameter is the sampling interval for the stress data. 
 The second parameter is the total number of correlations steps. 

--- a/doc/gpumd/input_parameters/correct_velocity.rst
+++ b/doc/gpumd/input_parameters/correct_velocity.rst
@@ -1,0 +1,24 @@
+.. index::
+   single: correct_velocity (keyword in run.in)
+
+:attr:`correct_velocity`
+========================
+
+This keyword allows one to enforce zero angular momentum.
+This can be useful as the stochastic nature of most thermostats and barostats available in :program:`gpumd` can cause the conservation of angular momentum to be violated.
+
+Syntax
+------
+* This keyword only has one parameter, which is the interval between which the angular momentum is set to zero::
+  
+    correct_velocity <interval>
+
+
+Example
+-------
+
+The command::
+
+    correct_velocity 10
+
+implies that the angular momentum is strictly set to zero every 10 steps.

--- a/doc/gpumd/input_parameters/deform.rst
+++ b/doc/gpumd/input_parameters/deform.rst
@@ -12,7 +12,7 @@ Syntax
 
 The :attr:`deform` keyord requires 4 parameters::
 
-  deform A_per_step deform_x deform_y deform_z
+  deform <A_per_step> <deform_x> <deform_y> <deform_z>
 
 Here, :attr:`A_per_step` specifies the speed of the increase of the box length, which is in units of Ångstrom/step.
 For example, suppose the box length (in a given direction) in the beginning of a run is 100 Ångstrom and this parameter is :math:`10^{-5}` Ångstrom/step, then a run with :math:`10^{6}` steps will change the box length by 10%.

--- a/doc/gpumd/input_parameters/dump_exyz.rst
+++ b/doc/gpumd/input_parameters/dump_exyz.rst
@@ -12,7 +12,7 @@ Syntax
 
 .. code::
 
-   dump_exyz interval has_velocity has_force
+   dump_exyz <interval> <has_velocity> <has_force>
 
 Here, the :attr:`interval` parameter is the output interval (number of steps) of the data.
 :attr:`has_velocity` can be 1 or 0, which means the velocities will or will not be included in the output.
@@ -21,8 +21,6 @@ Here, the :attr:`interval` parameter is the output interval (number of steps) of
 Examples
 --------
 
-Example 1
-^^^^^^^^^
 To dump the positions, velocities, and forces every 1000 steps for a run, one can add::
 
   dump_exyz 1000 1 1

--- a/doc/gpumd/input_parameters/dump_force.rst
+++ b/doc/gpumd/input_parameters/dump_force.rst
@@ -12,13 +12,13 @@ Syntax
 
 .. code::
 
-   dump_force interval <options>
+   dump_force <interval> {<optional_args>}
 
 The :attr:`interval` parameter is the output interval (number of steps) of the atom forces.
-At the moment, :attr:`<options>` can only assume the value :attr:`group`.
+At the moment, the optional arguments (:attr:`optional_args`) can only assume the value :attr:`group`.
 The option :attr:`group` shoud have two parameters::
 
-  group grouping_method group_id
+  group <grouping_method> <group_id>
 
 which means only dumping forces of atoms in group :attr:`group_id` within the grouping method :attr:`grouping_method`.
 If this option is not used, the forces will be written for all the atoms.

--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -13,16 +13,16 @@ Syntax
 
 This keyword has the following format::
 
-  dump_netcdf interval <optional_args>
+  dump_netcdf <interval> [{optional_args}]
 
 The :attr:`interval` parameter is the output interval (number of steps) of the atom positions.
-The :attr:`optional_args` provide additional functionality.
+The optinal arguments (:attr:`optional_args`) provide additional functionality.
 Currently, the following optional argument is accepted:
 
-* :attr:`precision`
+* :attr:`precision <value>`
   
-  * If :attr:`precision` is ``single``, the output data are 32-bit floating point numbers.
-  * If :attr:`precision` is ``double``, the output data are 64-bit floating point numbers.
+  * If :attr:`value` is ``single``, the output data are 32-bit floating point numbers.
+  * If :attr:`value` is ``double``, the output data are 64-bit floating point numbers.
 
   The default value is ``double``.
 

--- a/doc/gpumd/input_parameters/dump_observer.rst
+++ b/doc/gpumd/input_parameters/dump_observer.rst
@@ -16,8 +16,7 @@ Syntax
 
 .. code::
 
-   dump_observer mode interval has_velocity has_force
-
+   dump_observer <mode> <interval> <has_velocity> <has_force>
 
 :attr:`mode` corresponds to the two cases described above, and can be either `observe` or `average`.
 :attr:`interval` parameter is the output interval (number of steps) of the data.

--- a/doc/gpumd/input_parameters/dump_position.rst
+++ b/doc/gpumd/input_parameters/dump_position.rst
@@ -12,15 +12,15 @@ Syntax
 
 .. code::
 
-   dump_position interval <options>
+   dump_position <interval> [{optional_args}]
 
 The :attr:`interval` parameter is the output interval (number of steps) of the atom positions.
 
-The :attr:`<options>` can be :attr:`group` or :attr:`precision`, which can be in any order.
+The optional arguments (:attr:`<optional_args>`) can be :attr:`group` or :attr:`precision`, which can be in any order.
 
 The option :attr:`group` shoud have two parameters::
 
-  group grouping_method group_id
+  group <grouping_method> <group_id>
 
 which means only dumping positions of atoms in group :attr:`group_id` within the grouping method :attr:`grouping_method`.
 If this option is not used, positions will be dumped for all the atoms.

--- a/doc/gpumd/input_parameters/dump_restart.rst
+++ b/doc/gpumd/input_parameters/dump_restart.rst
@@ -12,7 +12,7 @@ Syntax
 
 This keyword only requires a single parameter, which is the output interval (number of steps) of updating the restart file::
 
-  dump_restart interval
+  dump_restart <interval>
 
 Example
 -------

--- a/doc/gpumd/input_parameters/dump_thermo.rst
+++ b/doc/gpumd/input_parameters/dump_thermo.rst
@@ -12,7 +12,7 @@ Syntax
 
 This keyword only requires a single parameter, which is the output interval (number of steps) of the global thermodynamic quantities::
 
-  dump_thermo interval
+  dump_thermo <interval>
 
 Example
 -------

--- a/doc/gpumd/input_parameters/dump_velocity.rst
+++ b/doc/gpumd/input_parameters/dump_velocity.rst
@@ -12,13 +12,13 @@ Syntax
 
 .. code::
 
-   dump_velocity interval <options>
+   dump_velocity <interval> [{optional_args}]
 
 Here, the :attr:`interval` parameter is the output interval (number of steps) of the atomic velocities.
-At the moment, the only permissible value for :attr:`<options>` is :attr:`group`.
+At the moment, the only optional argument (:attr:`optional_args`) is :attr:`group`.
 The option :attr:`group` shoud have two parameters::
 
-  group grouping_method group_id
+  group <grouping_method> <group_id>
 
 which means only dumping velocities of atoms in group :attr:`group_id` within the grouping method :attr:`grouping_method`.
 If this option is not used, velocities will be dumped for all the atoms.

--- a/doc/gpumd/input_parameters/ensemble.rst
+++ b/doc/gpumd/input_parameters/ensemble.rst
@@ -65,15 +65,15 @@ If the first parameter is :attr:`npt_ber`, it means that the ensemble for the cu
 In this case, apart from the same parameters as in the case of :attr:`nvt_ber`, one needs to further specify some target pressure(s), the same number of estimated elastic moduli, and a pressure coupling constant :attr:`p_coup`.
 The general format is::
 
-  ensemble npt_ber T_1 T_2 T_coup <pressure_control_parameters>
+  ensemble npt_ber <T_1> <T_2> <T_coup> {<pressure_control_parameters>}
 
-with three different options for specifying :attr:`<pressure_control_parameters>`:
+with three different options for specifying :attr:`pressure_control_parameters`:
 
 * *Condition 1*: Cell shape updates are isotropic
 
   .. code::
 
-     p_hydro C_hydro p_coup
+     <p_hydro> <C_hydro> <p_coup>
     
   This means you regard your system as isotropic and want to control the three box lengths uniformly according to the hydrostatic pressure :attr:`p_hydro = (p_xx + p_yy + p_zz)/3`.
   All directions should have periodic boundary conditions.
@@ -83,7 +83,7 @@ with three different options for specifying :attr:`<pressure_control_parameters>
 
   .. code::
 
-     p_xx p_yy p_zz C_xx C_yy C_zz p_coup
+     <p_xx> <p_yy> <p_zz> <C_xx> <C_yy> <C_zz> <p_coup>
 
   In this case, the simulation box must be orthogonal.
   The three box lengths will be controlled independently according to their respective target pressures.
@@ -93,7 +93,7 @@ with three different options for specifying :attr:`<pressure_control_parameters>
 
   .. code::
 
-     p_xx p_yy p_zz p_yz p_xz p_xy C_xx C_yy C_zz C_yz C_xz C_xy p_coup
+     <p_xx> <p_yy> <p_zz> <p_yz> <p_xz> <p_xy> <C_xx> <C_yy> <C_zz> <C_yz> <C_xz> <C_xy> <p_coup>
 
   The simulation box must be triclinic and all the directions must be periodic.
   All cell components will be controlled independently according to the 6 target pressure components.
@@ -110,7 +110,7 @@ If the first parameter is :attr:`npt_scr`, it is similar to the case of :attr:`n
 If the first parameter is :attr:`heat_nhc`, it means heating a source region and simultaneously cooling a sink region using local :ref:`Nose-Hoover chain thermostats <nose_hoover_chain_thermostat>`.
 The full command is::
 
-  ensemble heat_nhc T T_coup delta_T label_source label_sink
+  ensemble heat_nhc <T> <T_coup> <delta_T> <label_source> <label_sink>
 
 The target temperatures in the source region with label :attr:`label_source` and the sink region with label :attr:`label_sink` are :attr:`T+delta_T` and :attr:`T-delta_T`, respectively.
 Therefore, the temperature difference between the two regions is two times :attr:`delta_T`.

--- a/doc/gpumd/input_parameters/fix.rst
+++ b/doc/gpumd/input_parameters/fix.rst
@@ -12,7 +12,7 @@ Syntax
 This keyword requires a single parameter which is the label of the group in which the atoms are to be fixed (velocities and forces are always set to zero such that the atoms in the group do not move).
 The full command reads::
 
-  fix group_label
+  fix <group_label>
 
 Here, the :attr:`group_label` refers to the grouping method 0 defined in the :ref:`simulation model file <model_xyz>`.
 

--- a/doc/gpumd/input_parameters/index.rst
+++ b/doc/gpumd/input_parameters/index.rst
@@ -12,6 +12,7 @@ Below you can find a listing of keywords for the ``run.in`` input file.
    :caption: Setup
 
    velocity
+   correct_velocity
    potential
    change_box
    deform

--- a/doc/gpumd/input_parameters/minimize.rst
+++ b/doc/gpumd/input_parameters/minimize.rst
@@ -14,7 +14,7 @@ Syntax
 
 This keyword is used as follows::
 
-  minimize sd force_tolerance maximal_number_of_steps
+  minimize sd <force_tolerance> <maximal_number_of_steps>
 
 Here,
 :attr:`sd` means using the steepest descent method.

--- a/doc/gpumd/input_parameters/run.rst
+++ b/doc/gpumd/input_parameters/run.rst
@@ -11,7 +11,7 @@ Syntax
 ------
 This keyword only requires a single parameter, which is the number of steps to be run::
 
-  run number_of_steps
+  run <number_of_steps>
 
 Example
 -------

--- a/doc/gpumd/input_parameters/time_step.rst
+++ b/doc/gpumd/input_parameters/time_step.rst
@@ -13,11 +13,11 @@ Syntax
 This keyword can accept either one or two parameters. 
 If there is only one parameter, it is the time step (in units of fs) for a run::
 
-  time_step dt_in_fs
+  time_step <dt_in_fs>
 
 If there are two parameters, the first one is the time step and the second one is the maximum distance (in units of Ångstrom) any atom in the system can travel within one step::
 
-  time_step dt_in_fs max_distance_per_step
+  time_step <dt_in_fs> <max_distance_per_step>
 
 Examples
 --------

--- a/doc/gpumd/input_parameters/velocity.rst
+++ b/doc/gpumd/input_parameters/velocity.rst
@@ -11,7 +11,7 @@ Syntax
 ------
 * This keyword only has one parameter, which is the initial temperature of the system::
   
-    velocity initial_temperature
+    velocity <initial_temperature>
 
 * The temperature is in units of kelvin (K).
 

--- a/doc/nep/input_files/train_test_xyz.rst
+++ b/doc/nep/input_files/train_test_xyz.rst
@@ -37,7 +37,9 @@ Essentially any keyword is allowd, but we only read the following ones:
      \boldsymbol{c} &= c_x \boldsymbol{e}_x + c_y \boldsymbol{e}_y + c_z \boldsymbol{e}_z
 
 * :attr:`energy=energy_value` such as :attr:`energy=-123.4` is mandatory and gives the target energy of the structure, which is :math:`-123.4` eV in this example.
-* :attr:`virial="vxx vxy vxz vyx vyy vyz vzx vzy vzz"` is optional and gives the :math:`3\times3` virial tensor of the structure. 
+* :attr:`virial="vxx vxy vxz vyx vyy vyz vzx vzy vzz"` is optional and gives the :math:`3\times3` virial tensor of the structure in eV.
+* :attr:`stress="sxx sxy sxz syx syy syz szx szy szz"` is optional and gives the :math:`3\times3` stress tensor of the structure in GPa.
+  If both :attr:`virial` and :attr:`stress` are present the former is used.
 * :attr:`weight=relative_weight` is optional and gives the relative weight for the current structure in the total loss function.
 * :attr:`properties=property_name:data_type:number_of_columns` is mandatory but only read the following items:
   

--- a/doc/nep/input_parameters/index.rst
+++ b/doc/nep/input_parameters/index.rst
@@ -12,6 +12,8 @@ Below you can find a listing of keywords for the ``nep.in`` input file.
    :caption: Keywords
 
    version
+   prediction
+   train_mode
    type
    type_weight
    zbl

--- a/doc/nep/input_parameters/prediction.rst
+++ b/doc/nep/input_parameters/prediction.rst
@@ -1,0 +1,22 @@
+.. _kw_type:
+.. index::
+   single: prediction (keyword in nep.in)
+
+:attr:`prediction`
+==================
+
+This keyword instructs :program:`nep` to evaluate a model against a set of structures without starting an optimization.
+This requires a ``nep.txt`` file to be present.
+Note that only the structures in ``train.xyz`` are included in the prediction.
+The syntax is::
+
+  prediction <mode>
+
+where :attr:`<mode>` must be an integer that can assume one of the following values.
+
+=====  ===========================
+Value  Mode 
+-----  ---------------------------
+0      optimization mode (default)
+1      prediction mode
+=====  ===========================

--- a/doc/nep/input_parameters/train_mode.rst
+++ b/doc/nep/input_parameters/train_mode.rst
@@ -1,0 +1,21 @@
+.. _kw_type:
+.. index::
+   single: train_mode (keyword in nep.in)
+
+:attr:`train_mode`
+==================
+
+This keyword allows one to specify the type of model that is being trained.
+The syntax is::
+
+  train_mode <mode>
+
+where :attr:`<mode>` must be an integer that can assume one of the following values.
+
+=====  ===================
+Value  Type of model
+-----  -------------------
+0      potential (default)
+1      dipole
+2      polarizability
+=====  ===================

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -331,8 +331,8 @@ void Parameters::report_inputs()
   // some calcuated parameters:
   printf("Some calculated parameters:\n");
   printf("    number of radial descriptor components = %d.\n", dim_radial);
-  printf("    number of angualr descriptor components = %d.\n", dim_angular);
-  printf("    total number of  descriptor components = %d.\n", dim);
+  printf("    number of angular descriptor components = %d.\n", dim_angular);
+  printf("    total number of descriptor components = %d.\n", dim);
   printf("    NN architecture = %d-%d-1.\n", dim, num_neurons1);
   printf(
     "    number of NN parameters to be optimized = %d.\n",
@@ -803,7 +803,7 @@ void Parameters::parse_population(const char** param, int num_param)
   is_population_set = true;
 
   if (num_param != 2) {
-    PRINT_INPUT_ERROR("population should have 1 parameter.\n");
+    PRINT_INPUT_ERROR("The population keyword must be followed by a parameter.\n");
   }
   if (!is_valid_int(param[1], &population_size)) {
     PRINT_INPUT_ERROR("population size should be an integer.\n");
@@ -825,10 +825,9 @@ void Parameters::parse_population(const char** param, int num_param)
     population_should_increase = 0;
   }
   if (population_should_increase != 0) {
-    printf("Hello! I found your input (default) populaiton size is not divisible by total GPU "
-           "numbers.\n");
-    printf("This causes some GPU resources wasted.\n");
-    printf("So I increased population size to %d. I hope you understand.\n", population_size);
+    printf("The input population size is not divisible by the number of GPUs.\n");
+    printf("This causes an inefficient use of resources.\n");
+    printf("The population size has therefore been increase to %d.\n", population_size);
   }
 }
 

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -827,7 +827,7 @@ void Parameters::parse_population(const char** param, int num_param)
   if (population_should_increase != 0) {
     printf("The input population size is not divisible by the number of GPUs.\n");
     printf("This causes an inefficient use of resources.\n");
-    printf("The population size has therefore been increase to %d.\n", population_size);
+    printf("The population size has therefore been increased to %d.\n", population_size);
   }
 }
 


### PR DESCRIPTION
This PR adds documentation for the following keywords
* `correct_velocity` (gpumd)
* `train_mode` (nep)
* `prediction` (nep)

It also introduces a more consistent notation for keyword arguments, largely following a [common convention for syntax notation](https://www3.rocketsoftware.com/rocketd3/support/documentation/mvb/32/refman/proc/syntax_notations.htm).

Finally, `.gitignore` file is updated, as the previous filter for `nep` and `gpumd` was to general, causing new files in the `doc/gpumd` and `doc/nep` not to be considered.