### PR TITLE
Add the "move" keyword in run.in to do mechanical loading

### DIFF
--- a/src/integrate/ensemble.cuh
+++ b/src/integrate/ensemble.cuh
@@ -64,7 +64,9 @@ public:
   int type; // ensemble type in a specific run
   int source;
   int sink;
-  int fixed_group;    // ID of the group in which the atoms will be fixed
+  int fixed_group = -1; // ID of the group in which the atoms will be fixed
+  int move_group = -1;  // ID of the group in which the atoms will move with a constant velocity
+  double move_velocity[3];
   double temperature; // target temperature at a specific time
   double delta_temperature;
   double target_pressure[6];
@@ -94,7 +96,6 @@ protected:
     const GPU_Vector<double>& force_per_atom,
     GPU_Vector<double>& position_per_atom,
     GPU_Vector<double>& velocity_per_atom);
-
 
   void scale_velocity_global(const double factor, GPU_Vector<double>& velocity_per_atom);
 

--- a/src/integrate/ensemble_bdp.cu
+++ b/src/integrate/ensemble_bdp.cu
@@ -33,10 +33,14 @@ void Ensemble_BDP::initialize_rng()
 #endif
 };
 
-Ensemble_BDP::Ensemble_BDP(int t, int fg, double T, double Tc)
+Ensemble_BDP::Ensemble_BDP(int t, int fg, int mg, double* mv, double T, double Tc)
 {
   type = t;
   fixed_group = fg;
+  move_group = mg;
+  move_velocity[0] = mv[0];
+  move_velocity[1] = mv[1];
+  move_velocity[2] = mv[2];
   temperature = T;
   temperature_coupling = Tc;
   initialize_rng();
@@ -82,6 +86,7 @@ void Ensemble_BDP::integrate_nvt_bdp_2(
 
   // get thermo
   int N_fixed = (fixed_group == -1) ? 0 : group[0].cpu_size[fixed_group];
+  N_fixed += (move_group == -1) ? 0 : group[0].cpu_size[move_group];
   find_thermo(
     true, volume, group, mass, potential_per_atom, velocity_per_atom, virial_per_atom, thermo);
 

--- a/src/integrate/ensemble_bdp.cuh
+++ b/src/integrate/ensemble_bdp.cuh
@@ -20,7 +20,7 @@
 class Ensemble_BDP : public Ensemble
 {
 public:
-  Ensemble_BDP(int, int, double, double);
+  Ensemble_BDP(int, int, int, double*, double, double);
   Ensemble_BDP(int, int, int, int, double, double, double);
   virtual ~Ensemble_BDP(void);
 

--- a/src/integrate/ensemble_ber.cu
+++ b/src/integrate/ensemble_ber.cu
@@ -21,10 +21,14 @@ The Berendsen thermostat and barostat:
 #include "ensemble_ber.cuh"
 #include "npt_utilities.cuh"
 
-Ensemble_BER::Ensemble_BER(int t, int fg, double T, double Tc)
+Ensemble_BER::Ensemble_BER(int t, int fg, int mg, double* mv, double T, double Tc)
 {
   type = t;
   fixed_group = fg;
+  move_group = mg;
+  move_velocity[0] = mv[0];
+  move_velocity[1] = mv[1];
+  move_velocity[2] = mv[2];
   temperature = T;
   temperature_coupling = 1.0 / Tc;
 }

--- a/src/integrate/ensemble_ber.cuh
+++ b/src/integrate/ensemble_ber.cuh
@@ -19,7 +19,7 @@
 class Ensemble_BER : public Ensemble
 {
 public:
-  Ensemble_BER(int, int, double, double);
+  Ensemble_BER(int, int, int, double*, double, double);
   Ensemble_BER(int, int, double, double, double*, int, double*, int, int, int, double*);
   virtual ~Ensemble_BER(void);
 

--- a/src/integrate/ensemble_nhc.cu
+++ b/src/integrate/ensemble_nhc.cu
@@ -23,10 +23,14 @@ Oxford University Press, 2010.
 #include "utilities/common.cuh"
 #define DIM 3
 
-Ensemble_NHC::Ensemble_NHC(int t, int fg, int N, double T, double Tc, double dt)
+Ensemble_NHC::Ensemble_NHC(int t, int fg, int mg, double* mv, int N, double T, double Tc, double dt)
 {
   type = t;
   fixed_group = fg;
+  move_group = mg;
+  move_velocity[0] = mv[0];
+  move_velocity[1] = mv[1];
+  move_velocity[2] = mv[2];
   temperature = T;
   temperature_coupling = Tc;
   // position and momentum variables for one NHC

--- a/src/integrate/ensemble_nhc.cuh
+++ b/src/integrate/ensemble_nhc.cuh
@@ -19,7 +19,7 @@
 class Ensemble_NHC : public Ensemble
 {
 public:
-  Ensemble_NHC(int, int, int, double, double, double);
+  Ensemble_NHC(int, int, int, double*, int, double, double, double);
   Ensemble_NHC(int, int, int, int, int, int, double, double, double, double);
   virtual ~Ensemble_NHC(void);
 

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -39,7 +39,7 @@ void Integrate::initialize(
     if (move_group == fixed_group) {
       PRINT_INPUT_ERROR("The fixed and moving groups cannot be the same.");
     }
-    if (type != 1 || type != 2 || type != 4) {
+    if (type != 1 && type != 2 && type != 4) {
       PRINT_INPUT_ERROR(
         "It is only allowed to use nvt_ber, nvt_nhc, or nvt_bdp with a moving group.");
     }

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -53,15 +53,19 @@ public:
   void parse_ensemble(Box& box, const char** param, int num_param, std::vector<Group>& group);
   void parse_deform(const char**, int);
   void parse_fix(const char**, int, std::vector<Group>& group);
+  void parse_move(const char**, int, std::vector<Group>& group);
 
   // these data will be used to initialize ensemble
   int type; // ensemble type in a specific run
   int source;
   int sink;
   int fixed_group = -1; // ID of the group in which the atoms will be fixed
-  double temperature;   // target temperature at a specific time
-  double temperature1;  // target initial temperature for a run
-  double temperature2;  // target final temperature for a run
+  int move_group = -1;  // ID of the group in which the atoms will move with a constant velocity
+  double move_velocity[3];
+
+  double temperature;  // target temperature at a specific time
+  double temperature1; // target initial temperature for a run
+  double temperature2; // target final temperature for a run
   double delta_temperature;
   double target_pressure[6];
   int num_target_pressure_components;

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -186,8 +186,8 @@ void Run::perform_a_run()
     integrate.compute2(time_step, double(step) / number_of_steps, group, box, atom, thermo);
 
     measure.process(
-      number_of_steps, step, integrate.fixed_group, global_time, integrate.temperature2, integrate,
-      box, group, thermo, atom, force);
+      number_of_steps, step, integrate.fixed_group, integrate.move_group, global_time,
+      integrate.temperature2, integrate, box, group, thermo, atom, force);
 
     velocity.correct_velocity(
       step, atom.cpu_mass, atom.position_per_atom, atom.cpu_position_per_atom,
@@ -311,6 +311,8 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
     measure.compute.parse(param, num_param, group);
   } else if (strcmp(param[0], "fix") == 0) {
     integrate.parse_fix(param, num_param, group);
+  } else if (strcmp(param[0], "move") == 0) {
+    integrate.parse_move(param, num_param, group);
   } else if (strcmp(param[0], "run") == 0) {
     parse_run(param, num_param);
   } else {

--- a/src/measure/measure.cu
+++ b/src/measure/measure.cu
@@ -90,11 +90,11 @@ void Measure::finalize(
   modal_analysis.method = NO_METHOD;
 }
 
-
 void Measure::process(
   const int number_of_steps,
   int step,
   const int fixed_group,
+  const int move_group,
   const double global_time,
   const double temperature,
   Integrate& integrate,
@@ -105,9 +105,9 @@ void Measure::process(
   Force& force)
 {
   const int number_of_atoms = atom.cpu_type.size();
-  const int number_of_atoms_fixed = (fixed_group < 0) ? 0 : group[0].cpu_size[fixed_group];
-  dump_thermo.process(
-    step, number_of_atoms, number_of_atoms_fixed, box, thermo);
+  int number_of_atoms_fixed = (fixed_group < 0) ? 0 : group[0].cpu_size[fixed_group];
+  number_of_atoms_fixed += (move_group < 0) ? 0 : group[0].cpu_size[move_group];
+  dump_thermo.process(step, number_of_atoms, number_of_atoms_fixed, box, thermo);
   dump_position.process(
     step, box, group, atom.cpu_atom_symbol, atom.cpu_type, atom.position_per_atom,
     atom.cpu_position_per_atom);
@@ -117,14 +117,15 @@ void Measure::process(
     atom.velocity_per_atom, atom.cpu_position_per_atom, atom.cpu_velocity_per_atom);
   dump_force.process(step, group, atom.force_per_atom);
   dump_exyz.process(
-     step, global_time, box, atom.cpu_atom_symbol, atom.cpu_type, atom.position_per_atom,
-     atom.cpu_position_per_atom, atom.velocity_per_atom, atom.cpu_velocity_per_atom, 
-     atom.force_per_atom, atom.virial_per_atom, thermo);
-  dump_observer.process(step, global_time, number_of_atoms_fixed, group, box, atom, force, integrate, thermo);
+    step, global_time, box, atom.cpu_atom_symbol, atom.cpu_type, atom.position_per_atom,
+    atom.cpu_position_per_atom, atom.velocity_per_atom, atom.cpu_velocity_per_atom,
+    atom.force_per_atom, atom.virial_per_atom, thermo);
+  dump_observer.process(
+    step, global_time, number_of_atoms_fixed, group, box, atom, force, integrate, thermo);
 
   compute.process(
-    step, integrate.ensemble->energy_transferred, group, atom.mass, atom.potential_per_atom, atom.force_per_atom,
-    atom.velocity_per_atom, atom.virial_per_atom);
+    step, integrate.ensemble->energy_transferred, group, atom.mass, atom.potential_per_atom,
+    atom.force_per_atom, atom.velocity_per_atom, atom.virial_per_atom);
   dos.process(step, group, atom.velocity_per_atom);
   sdc.process(step, group, atom.velocity_per_atom);
   msd.process(step, group, atom.unwrapped_position);

--- a/src/measure/measure.cuh
+++ b/src/measure/measure.cuh
@@ -18,14 +18,16 @@
 #include "dos.cuh"
 #include "dump_exyz.cuh"
 #include "dump_force.cuh"
+#include "dump_observer.cuh"
 #include "dump_position.cuh"
 #include "dump_restart.cuh"
 #include "dump_thermo.cuh"
 #include "dump_velocity.cuh"
-#include "dump_observer.cuh"
+#include "force/force.cuh"
 #include "hac.cuh"
 #include "hnemd_kappa.cuh"
 #include "hnemdec_kappa.cuh"
+#include "integrate/integrate.cuh"
 #include "modal_analysis.cuh"
 #include "model/box.cuh"
 #include "model/group.cuh"
@@ -34,8 +36,6 @@
 #include "shc.cuh"
 #include "utilities/gpu_vector.cuh"
 #include "viscosity.cuh"
-#include "force/force.cuh"
-#include "integrate/integrate.cuh"
 #ifdef USE_NETCDF
 #include "dump_netcdf.cuh"
 #endif
@@ -67,6 +67,7 @@ public:
     const int number_of_steps,
     int step,
     const int fixed_group,
+    const int move_group,
     const double global_time,
     const double temperature,
     Integrate& integrate,
@@ -75,8 +76,7 @@ public:
     GPU_Vector<double>& thermo,
     Atom& atom,
     Force& force);
-  
-     
+
   DOS dos;
   SDC sdc;
   MSD msd;


### PR DESCRIPTION
To solve issue #256 

Syntax in `run.in`:

```
move <moving_group_id> <velocity_x> <velocIty_y> <velocity_z>
```

One can only use the following three `ensemble` types: `nvt_ber`, `nvt_nhc`, and `nvt_bdp`.