### PR TITLE
Fix to documentation

### DIFF
--- a/doc/gpumd/input_parameters/compute.rst
+++ b/doc/gpumd/input_parameters/compute.rst
@@ -12,6 +12,7 @@ The results are written to the :ref:`compute.out output file <compute_out>`.
 Syntax
 ------
 It is used in the following way::
+
   compute <grouping_method> <sample_interval> <output_interval> {<quantity>}
 
 The first parameter :attr:`grouping_method` refers to the grouping method defined in the :ref:`simulation model file <model_xyz>`.

--- a/doc/gpumd/input_parameters/compute_dos.rst
+++ b/doc/gpumd/input_parameters/compute_dos.rst
@@ -11,6 +11,7 @@ If this keyword appears in a run, the mass-weighted :term:`VAC` function will be
 
 The results of these calculations will be written to :ref:`mvac.out <mvac_out>` (for the mass-normalized :term:`VAC` function) and :ref:`dos.out <dos_out>` (for the :term:`DOS`).
 
+
 Syntax
 ------
 For this keyword, the command looks like::
@@ -26,21 +27,25 @@ with parameters defined as:
 The optional arguments (:attr:`optional_arg`) provide additional functionality by allowing special keywords.
 The keywords for this function are :attr:`group` and :attr:`num_dos_points`.
 These keywords can be used in any order but the parameters associated with each must follow directly.
-The parameters are:
 
-* :attr:`group <group_method> <group>`
+The option :attr:`group` has two parameters::
 
- * :attr:`group_method`: The grouping method to use for computation
- * :attr:`group`: The group in the grouping method to use
+  group <group_method> <group>
 
-* :attr:`num_dos_points <points>`
+where :attr:`group_method` is the grouping method to use for computation and :attr:`group` is the index of the group to use.
 
- * :attr:`points`: Number of frequency points to be used in the DOS calculation (:attr:`Nc` if option not selected)
+The option :attr:`num_dos_points` has one parameter::
+
+  num_dos_points <points>
+
+where :attr:`points` is the number of frequency points to be used in the DOS calculation.
+It defaults to :attr:`Nc` if the :attr:`num_dos_points` option is not specified.
+
 
 Example
 -------
 
-An example of this keyword is::
+An example for the use of this keyword is::
   
   compute_dos 5 200 400.0 group 1 1 num_dos_points 300
 
@@ -57,6 +62,7 @@ This means that you
 Caveats
 -------
 This keyword cannot be used in the same run as the :ref:`compute_sdc keyword <kw_compute_sdc>`.
+
 
 Related tutorial
 ----------------


### PR DESCRIPTION
* fixes rendering error on [page for `compute` keyword](https://gpumd.org/gpumd/input_parameters/compute.html)
* clarifies description of optional arguments on [page for `compute_dos` keyword](https://gpumd.org/gpumd/input_parameters/compute_dos.html)