### PR TITLE
Allow to select stable and development versions in documentation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,12 +39,29 @@ build:linux:
     paths:
       - public
   script:
+    # prepare homepage
+    - mkdir -p public/dev
+    # --------------------------
+    # DEVELOPMENT VERSION
+    - git checkout master
     - tag=$(git describe --tags | tail -1)
     - echo "tag= $tag"
+    # build user guide
     - sed -i "s/version = ''/version = '$tag'/" doc/conf.py
+    - sphinx-build -W doc/ public/dev/
+    - git checkout -- doc/source/conf.py
+    # --------------------------
+    # STABLE VERSION
+    - tag=$(git tag | tail -1)
+    - echo "tag= $tag"
+    - git checkout $tag
+    # build user guide
     - sphinx-build -W doc/ public/
+    # --------------------------
+    # clean up
     - ls -l public/
     - chmod go-rwX -R public/
+
 
 documentation:test:
   extends: .documentation

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@ import sphinx_rtd_theme
 project = 'GPUMD'
 author = 'The GPUMD developer team'
 version = ''
-copyright = '2022'
+copyright = '2023'
 site_url = 'https://gpumd.org'
 
 extensions = [


### PR DESCRIPTION
This allows the user to select between the documentation at the point of the latest release (`stable`) and the current master (`developement`).
It works in the same way as, e.g., in the [`hiphive` documentation](https://hiphive.materialsmodeling.org/); see lower left corner.

<img width="335" alt="Screenshot 2023-02-28 at 07 23 14" src="https://user-images.githubusercontent.com/19806064/221771219-3bf07349-cbbb-419f-ab8b-de52ef01ec71.png">
