### PR TITLE
fix prediction mode for nep2

### DIFF
--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -216,8 +216,10 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
     std::vector<std::string> tokens;
     tokens = get_tokens(input);
     int num_lines_to_be_skipped = 5;
-    if (tokens[0] == "nep_zbl" || tokens[0] == "nep3_zbl" || tokens[0] == "nep4_zbl") {
+    if (tokens[0] == "nep3_zbl" || tokens[0] == "nep4_zbl") {
       num_lines_to_be_skipped = 6;
+    } else if (tokens[0] == "nep") {
+      num_lines_to_be_skipped = 4;
     }
     for (int n = 0; n < num_lines_to_be_skipped; ++n) {
       tokens = get_tokens(input);


### PR DESCRIPTION
The `prediction 1` option has not considered NEP2, now this PR considered it.