### PR TITLE
Implement PIMD and RPMD

### DIFF
--- a/src/integrate/ensemble.cuh
+++ b/src/integrate/ensemble.cuh
@@ -14,6 +14,7 @@
 */
 
 #pragma once
+#include "model/atom.cuh"
 #include "model/box.cuh"
 #include "model/group.cuh"
 #include "utilities/gpu_vector.cuh"
@@ -30,25 +31,15 @@ public:
   virtual void compute1(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo) = 0;
 
   virtual void compute2(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo) = 0;
 
   void find_thermo(

--- a/src/integrate/ensemble_bao.cu
+++ b/src/integrate/ensemble_bao.cu
@@ -355,53 +355,59 @@ void Ensemble_BAO::operator_B(
 void Ensemble_BAO::compute1(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
   if (type == 5) {
-    operator_B(time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    operator_B(
+      time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
 
-    operator_A(time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    operator_A(
+      time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
 
-    integrate_nvt_lan(mass, velocity_per_atom);
+    integrate_nvt_lan(atom.mass, atom.velocity_per_atom);
 
-    operator_A(time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    operator_A(
+      time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
   } else {
-    operator_B(time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    operator_B(
+      time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
 
-    operator_A(time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    operator_A(
+      time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
 
-    integrate_heat_lan(group, mass, velocity_per_atom);
+    integrate_heat_lan(group, atom.mass, atom.velocity_per_atom);
 
-    operator_A(time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    operator_A(
+      time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
   }
 }
 
 void Ensemble_BAO::compute2(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
   if (type == 5) {
-    operator_B(time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    operator_B(
+      time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
 
     find_thermo(
-      true, box.get_volume(), group, mass, potential_per_atom, velocity_per_atom, virial_per_atom,
-      thermo);
+      true, box.get_volume(), group, atom.mass, atom.potential_per_atom, atom.velocity_per_atom,
+      atom.virial_per_atom, thermo);
   } else {
-    operator_B(time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    operator_B(
+      time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
   }
 }

--- a/src/integrate/ensemble_bao.cuh
+++ b/src/integrate/ensemble_bao.cuh
@@ -27,25 +27,15 @@ public:
   virtual void compute1(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
   virtual void compute2(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
 protected:
@@ -71,8 +61,7 @@ protected:
     GPU_Vector<double>& position_per_atom,
     GPU_Vector<double>& velocity_per_atom);
 
-  void
-  integrate_nvt_lan(const GPU_Vector<double>& mass, GPU_Vector<double>& velocity_per_atom);
+  void integrate_nvt_lan(const GPU_Vector<double>& mass, GPU_Vector<double>& velocity_per_atom);
 
   void integrate_heat_lan(
     const std::vector<Group>& group,

--- a/src/integrate/ensemble_bdp.cu
+++ b/src/integrate/ensemble_bdp.cu
@@ -152,37 +152,29 @@ void Ensemble_BDP::integrate_heat_bdp_2(
 void Ensemble_BDP::compute1(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
   velocity_verlet(
-    true, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    true, time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+    atom.velocity_per_atom);
 }
 
 void Ensemble_BDP::compute2(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
   if (type == 4) {
     integrate_nvt_bdp_2(
-      time_step, box.get_volume(), group, mass, potential_per_atom, force_per_atom, virial_per_atom,
-      position_per_atom, velocity_per_atom, thermo);
+      time_step, box.get_volume(), group, atom.mass, atom.potential_per_atom, atom.force_per_atom,
+      atom.virial_per_atom, atom.position_per_atom, atom.velocity_per_atom, thermo);
   } else {
     integrate_heat_bdp_2(
-      time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+      time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
   }
 }

--- a/src/integrate/ensemble_bdp.cuh
+++ b/src/integrate/ensemble_bdp.cuh
@@ -27,25 +27,15 @@ public:
   virtual void compute1(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
   virtual void compute2(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
 protected:

--- a/src/integrate/ensemble_ber.cu
+++ b/src/integrate/ensemble_ber.cu
@@ -185,42 +185,35 @@ cpu_pressure_triclinic(Box& box, double* p0, double* p_coupling, double* thermo,
 void Ensemble_BER::compute1(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
   velocity_verlet(
-    true, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    true, time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+    atom.velocity_per_atom);
 }
 
 void Ensemble_BER::compute2(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
-  const int number_of_atoms = mass.size();
+  const int number_of_atoms = atom.mass.size();
 
   velocity_verlet(
-    false, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    false, time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+    atom.velocity_per_atom);
 
   find_thermo(
-    true, box.get_volume(), group, mass, potential_per_atom, velocity_per_atom, virial_per_atom,
-    thermo);
+    true, box.get_volume(), group, atom.mass, atom.potential_per_atom, atom.velocity_per_atom,
+    atom.virial_per_atom, thermo);
   gpu_berendsen_temperature<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
-    number_of_atoms, temperature, temperature_coupling, thermo.data(), velocity_per_atom.data(),
-    velocity_per_atom.data() + number_of_atoms, velocity_per_atom.data() + 2 * number_of_atoms);
+    number_of_atoms, temperature, temperature_coupling, thermo.data(),
+    atom.velocity_per_atom.data(), atom.velocity_per_atom.data() + number_of_atoms,
+    atom.velocity_per_atom.data() + 2 * number_of_atoms);
   CUDA_CHECK_KERNEL
 
   if (type == 11) {
@@ -228,8 +221,9 @@ void Ensemble_BER::compute2(
       double scale_factor;
       cpu_pressure_isotropic(box, target_pressure, pressure_coupling, thermo.data(), scale_factor);
       gpu_pressure_isotropic<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
-        number_of_atoms, scale_factor, position_per_atom.data(),
-        position_per_atom.data() + number_of_atoms, position_per_atom.data() + number_of_atoms * 2);
+        number_of_atoms, scale_factor, atom.position_per_atom.data(),
+        atom.position_per_atom.data() + number_of_atoms,
+        atom.position_per_atom.data() + number_of_atoms * 2);
     } else if (num_target_pressure_components == 3) {
       double scale_factor[3];
       cpu_pressure_orthogonal(
@@ -237,16 +231,16 @@ void Ensemble_BER::compute2(
         thermo.data(), scale_factor);
       gpu_pressure_orthogonal<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
         number_of_atoms, scale_factor[0], scale_factor[1], scale_factor[2],
-        position_per_atom.data(), position_per_atom.data() + number_of_atoms,
-        position_per_atom.data() + number_of_atoms * 2);
+        atom.position_per_atom.data(), atom.position_per_atom.data() + number_of_atoms,
+        atom.position_per_atom.data() + number_of_atoms * 2);
       CUDA_CHECK_KERNEL
     } else {
       double mu[9];
       cpu_pressure_triclinic(box, target_pressure, pressure_coupling, thermo.data(), mu);
       gpu_pressure_triclinic<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
         number_of_atoms, mu[0], mu[1], mu[2], mu[3], mu[4], mu[5], mu[6], mu[7], mu[8],
-        position_per_atom.data(), position_per_atom.data() + number_of_atoms,
-        position_per_atom.data() + number_of_atoms * 2);
+        atom.position_per_atom.data(), atom.position_per_atom.data() + number_of_atoms,
+        atom.position_per_atom.data() + number_of_atoms * 2);
     }
   }
 }

--- a/src/integrate/ensemble_ber.cuh
+++ b/src/integrate/ensemble_ber.cuh
@@ -26,24 +26,14 @@ public:
   virtual void compute1(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
   virtual void compute2(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 };

--- a/src/integrate/ensemble_lan.cu
+++ b/src/integrate/ensemble_lan.cu
@@ -153,53 +153,47 @@ void Ensemble_LAN::integrate_heat_lan_half(
 void Ensemble_LAN::compute1(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
   if (type == 3) {
-    integrate_nvt_lan_half(mass, velocity_per_atom);
+    integrate_nvt_lan_half(atom.mass, atom.velocity_per_atom);
 
     velocity_verlet(
-      true, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+      true, time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
   } else {
-    integrate_heat_lan_half(group, mass, velocity_per_atom);
+    integrate_heat_lan_half(group, atom.mass, atom.velocity_per_atom);
 
     velocity_verlet(
-      true, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+      true, time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
   }
 }
 
 void Ensemble_LAN::compute2(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
   if (type == 3) {
     velocity_verlet(
-      false, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+      false, time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
 
-    integrate_nvt_lan_half(mass, velocity_per_atom);
+    integrate_nvt_lan_half(atom.mass, atom.velocity_per_atom);
 
     find_thermo(
-      true, box.get_volume(), group, mass, potential_per_atom, velocity_per_atom, virial_per_atom,
-      thermo);
+      true, box.get_volume(), group, atom.mass, atom.potential_per_atom, atom.velocity_per_atom,
+      atom.virial_per_atom, thermo);
   } else {
     velocity_verlet(
-      false, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+      false, time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
 
-    integrate_heat_lan_half(group, mass, velocity_per_atom);
+    integrate_heat_lan_half(group, atom.mass, atom.velocity_per_atom);
   }
 }

--- a/src/integrate/ensemble_lan.cuh
+++ b/src/integrate/ensemble_lan.cuh
@@ -27,25 +27,15 @@ public:
   virtual void compute1(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
   virtual void compute2(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
 protected:

--- a/src/integrate/ensemble_nhc.cu
+++ b/src/integrate/ensemble_nhc.cu
@@ -322,43 +322,35 @@ void Ensemble_NHC::integrate_heat_nhc_2(
 void Ensemble_NHC::compute1(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
   if (type == 2) {
     integrate_nvt_nhc_1(
-      time_step, box.get_volume(), group, mass, potential_per_atom, force_per_atom, virial_per_atom,
-      position_per_atom, velocity_per_atom, thermo);
+      time_step, box.get_volume(), group, atom.mass, atom.potential_per_atom, atom.force_per_atom,
+      atom.virial_per_atom, atom.position_per_atom, atom.velocity_per_atom, thermo);
   } else {
     integrate_heat_nhc_1(
-      time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+      time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
   }
 }
 
 void Ensemble_NHC::compute2(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
   if (type == 2) {
     integrate_nvt_nhc_2(
-      time_step, box.get_volume(), group, mass, potential_per_atom, force_per_atom, virial_per_atom,
-      position_per_atom, velocity_per_atom, thermo);
+      time_step, box.get_volume(), group, atom.mass, atom.potential_per_atom, atom.force_per_atom,
+      atom.virial_per_atom, atom.position_per_atom, atom.velocity_per_atom, thermo);
   } else {
     integrate_heat_nhc_2(
-      time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+      time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+      atom.velocity_per_atom);
   }
 }

--- a/src/integrate/ensemble_nhc.cuh
+++ b/src/integrate/ensemble_nhc.cuh
@@ -26,25 +26,15 @@ public:
   virtual void compute1(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
   virtual void compute2(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
 protected:

--- a/src/integrate/ensemble_npt_scr.cu
+++ b/src/integrate/ensemble_npt_scr.cu
@@ -213,40 +213,32 @@ static void cpu_pressure_triclinic(
 void Ensemble_NPT_SCR::compute1(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
   velocity_verlet(
-    true, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    true, time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+    atom.velocity_per_atom);
 }
 
 void Ensemble_NPT_SCR::compute2(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
-  const int number_of_atoms = mass.size();
+  const int number_of_atoms = atom.mass.size();
 
   velocity_verlet(
-    false, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    false, time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+    atom.velocity_per_atom);
 
   int N_fixed = (fixed_group == -1) ? 0 : group[0].cpu_size[fixed_group];
   find_thermo(
-    true, box.get_volume(), group, mass, potential_per_atom, velocity_per_atom, virial_per_atom,
-    thermo);
+    true, box.get_volume(), group, atom.mass, atom.potential_per_atom, atom.velocity_per_atom,
+    atom.virial_per_atom, thermo);
 
   double ek[1];
   thermo.copy_to_host(ek, 1);
@@ -255,23 +247,25 @@ void Ensemble_NPT_SCR::compute2(
   double sigma = ndeg * K_B * temperature * 0.5;
   double factor = resamplekin(ek[0], sigma, ndeg, temperature_coupling, rng);
   factor = sqrt(factor / ek[0]);
-  scale_velocity_global(factor, velocity_per_atom);
+  scale_velocity_global(factor, atom.velocity_per_atom);
 
   if (num_target_pressure_components == 1) {
     double scale_factor;
     cpu_pressure_isotropic(
       rng, box, temperature, target_pressure, pressure_coupling, thermo.data(), scale_factor);
     gpu_pressure_isotropic<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
-      number_of_atoms, scale_factor, position_per_atom.data(),
-      position_per_atom.data() + number_of_atoms, position_per_atom.data() + number_of_atoms * 2);
+      number_of_atoms, scale_factor, atom.position_per_atom.data(),
+      atom.position_per_atom.data() + number_of_atoms,
+      atom.position_per_atom.data() + number_of_atoms * 2);
   } else if (num_target_pressure_components == 3) {
     double scale_factor[3];
     cpu_pressure_orthogonal(
       rng, deform_x, deform_y, deform_z, deform_rate, box, temperature, target_pressure,
       pressure_coupling, thermo.data(), scale_factor);
     gpu_pressure_orthogonal<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
-      number_of_atoms, scale_factor[0], scale_factor[1], scale_factor[2], position_per_atom.data(),
-      position_per_atom.data() + number_of_atoms, position_per_atom.data() + number_of_atoms * 2);
+      number_of_atoms, scale_factor[0], scale_factor[1], scale_factor[2],
+      atom.position_per_atom.data(), atom.position_per_atom.data() + number_of_atoms,
+      atom.position_per_atom.data() + number_of_atoms * 2);
     CUDA_CHECK_KERNEL
   } else {
     double mu[9];
@@ -279,7 +273,7 @@ void Ensemble_NPT_SCR::compute2(
       rng, box, temperature, target_pressure, pressure_coupling, thermo.data(), mu);
     gpu_pressure_triclinic<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
       number_of_atoms, mu[0], mu[1], mu[2], mu[3], mu[4], mu[5], mu[6], mu[7], mu[8],
-      position_per_atom.data(), position_per_atom.data() + number_of_atoms,
-      position_per_atom.data() + number_of_atoms * 2);
+      atom.position_per_atom.data(), atom.position_per_atom.data() + number_of_atoms,
+      atom.position_per_atom.data() + number_of_atoms * 2);
   }
 }

--- a/src/integrate/ensemble_npt_scr.cuh
+++ b/src/integrate/ensemble_npt_scr.cuh
@@ -26,25 +26,15 @@ public:
   virtual void compute1(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
   virtual void compute2(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
 protected:

--- a/src/integrate/ensemble_nve.cu
+++ b/src/integrate/ensemble_nve.cu
@@ -33,35 +33,27 @@ Ensemble_NVE::~Ensemble_NVE(void)
 void Ensemble_NVE::compute1(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
   velocity_verlet(
-    true, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    true, time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+    atom.velocity_per_atom);
 }
 
 void Ensemble_NVE::compute2(
   const double time_step,
   const std::vector<Group>& group,
-  const GPU_Vector<double>& mass,
-  const GPU_Vector<double>& potential_per_atom,
-  const GPU_Vector<double>& force_per_atom,
-  const GPU_Vector<double>& virial_per_atom,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   GPU_Vector<double>& thermo)
 {
   velocity_verlet(
-    false, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+    false, time_step, group, atom.mass, atom.force_per_atom, atom.position_per_atom,
+    atom.velocity_per_atom);
 
   find_thermo(
-    false, box.get_volume(), group, mass, potential_per_atom, velocity_per_atom, virial_per_atom,
-    thermo);
+    false, box.get_volume(), group, atom.mass, atom.potential_per_atom, atom.velocity_per_atom,
+    atom.virial_per_atom, thermo);
 }

--- a/src/integrate/ensemble_nve.cuh
+++ b/src/integrate/ensemble_nve.cuh
@@ -25,24 +25,14 @@ public:
   virtual void compute1(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
   virtual void compute2(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 };

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -63,7 +63,7 @@ Ensemble_PIMD::Ensemble_PIMD(
       double pi_factor = 2.0 * PI * j * k / number_of_beads;
       if (k == 0) {
         transformation_matrix_cpu[jk] = sqrt_factor_1;
-      } else if (k < number_of_beads / 2) { // TODO: check n is even
+      } else if (k < number_of_beads / 2) {
         transformation_matrix_cpu[jk] = sqrt_factor_2 * cos(pi_factor);
       } else if (k == number_of_beads / 2) {
         transformation_matrix_cpu[jk] = sqrt_factor_1 * sign_factor;

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -252,8 +252,8 @@ static __global__ void gpu_langevin(
                            : exp(-time_step * omega_n * sin(k * PI / number_of_beads));
       double c2 = sqrt((1 - c1 * c1) * K_B * temperature * number_of_beads / g_mass[n]);
       for (int d = 0; d < 3; ++d) {
-        int index_dn = d * number_of_atoms + n;
-        velocity[k][index_dn] = c1 * velocity[k][index_dn] + c2 * CURAND_NORMAL(&state);
+        int index_kd = k * 3 + d;
+        velocity_normal[index_kd] = c1 * velocity_normal[index_kd] + c2 * CURAND_NORMAL(&state);
       }
     }
     g_state[n] = state;

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -27,12 +27,14 @@ References for implementation:
 Ensemble_PIMD::Ensemble_PIMD(
   int number_of_atoms_input,
   int number_of_beads_input,
+  int number_of_steps_pimd_input,
   double temperature_input,
   double temperature_coupling_input,
   Atom& atom)
 {
   number_of_atoms = number_of_atoms_input;
   number_of_beads = number_of_beads_input;
+  number_of_steps_pimd = number_of_steps_pimd_input;
   temperature = temperature_input;
   temperature_coupling = temperature_coupling_input;
   omega_n = number_of_beads * K_B * temperature / HBAR;
@@ -133,8 +135,8 @@ static __global__ void gpu_nve_1(
       }
     }
 
-    double velocity_normal[384];
-    double position_normal[384];
+    double velocity_normal[MAX_NUM_BEADS * 3];
+    double position_normal[MAX_NUM_BEADS * 3];
     for (int k = 0; k < number_of_beads; ++k) {
       for (int d = 0; d < 3; ++d) {
         double temp_velocity = 0.0;
@@ -217,7 +219,7 @@ static __global__ void gpu_langevin(
   int n = blockIdx.x * blockDim.x + threadIdx.x;
   if (n < number_of_atoms) {
 
-    double velocity_normal[384];
+    double velocity_normal[MAX_NUM_BEADS * 3];
 
     for (int k = 0; k < number_of_beads; ++k) {
       for (int d = 0; d < 3; ++d) {

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -290,12 +290,13 @@ static __global__ void gpu_average(
   int n = blockIdx.x * blockDim.x + threadIdx.x;
   if (n < number_of_atoms) {
     double pos_ave[3] = {0.0}, vel_ave[3] = {0.0}, pot_ave = 0.0, for_ave[3] = {0.0},
-           vir_ave[3] = {0.0};
+           vir_ave[9] = {0.0};
     for (int k = 0; k < number_of_beads; ++k) {
       for (int d = 0; d < 3; ++d) {
-        pos_ave[d] += position[k][d * number_of_atoms + n];
-        vel_ave[d] += velocity[k][d * number_of_atoms + n];
-        for_ave[d] += force[k][d * number_of_atoms + n];
+        int index_dn = d * number_of_atoms + n;
+        pos_ave[d] += position[k][index_dn];
+        vel_ave[d] += velocity[k][index_dn];
+        for_ave[d] += force[k][index_dn];
       }
       pot_ave += potential[k][n];
       for (int d = 0; d < 9; ++d) {
@@ -304,9 +305,10 @@ static __global__ void gpu_average(
     }
     double number_of_beads_inverse = 1.0 / number_of_beads;
     for (int d = 0; d < 3; ++d) {
-      position_averaged[d * number_of_atoms + n] = pos_ave[d] * number_of_beads_inverse;
-      velocity_averaged[d * number_of_atoms + n] = vel_ave[d] * number_of_beads_inverse;
-      force_averaged[d * number_of_atoms + n] = for_ave[d] * number_of_beads_inverse;
+      int index_dn = d * number_of_atoms + n;
+      position_averaged[index_dn] = pos_ave[d] * number_of_beads_inverse;
+      velocity_averaged[index_dn] = vel_ave[d] * number_of_beads_inverse;
+      force_averaged[index_dn] = for_ave[d] * number_of_beads_inverse;
     }
     potential_averaged[n] = pot_ave * number_of_beads_inverse;
     for (int d = 0; d < 9; ++d) {

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -444,7 +444,9 @@ gpu_find_thermo(const double volume, const double NkBT, const double* g_sum_1024
   if (tid == 0) {
     if (bid == 0) {
       g_thermo[bid] = 1.5 * NkBT + s_data[0];
-    } else if (bid > 1) {
+    } else if (bid == 1) {
+      g_thermo[bid] = s_data[0];
+    } else {
       g_thermo[bid] = (NkBT + s_data[0]) / volume;
     }
   }
@@ -520,7 +522,7 @@ void Ensemble_PIMD::compute2(
   CUDA_CHECK_KERNEL
 
   gpu_find_sum_1024<<<1024, 128>>>(
-    number_of_atoms, kinetic_energy_virial_part.data(), atom.position_per_atom.data(),
+    number_of_atoms, kinetic_energy_virial_part.data(), atom.potential_per_atom.data(),
     atom.virial_per_atom.data(), sum_1024.data());
   CUDA_CHECK_KERNEL
 

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -23,17 +23,23 @@ The global path-integral Langevin equation (PILE) thermostat:
 #include "utilities/common.cuh"
 #include <cstdlib>
 
-Ensemble_PIMD::Ensemble_PIMD(int t, int fg, int N, double T, double Tc)
+Ensemble_PIMD::Ensemble_PIMD(
+  int number_of_atoms_input,
+  int number_of_beads_input,
+  double temperature_input,
+  double temperature_coupling_input,
+  double temperature_coupling_beads_input)
 {
-  type = t;
-  fixed_group = fg;
-  temperature = T;
-  temperature_coupling = Tc;
-  c1 = exp(-0.5 / temperature_coupling);
-  c2 = sqrt((1 - c1 * c1) * K_B * T);
-  curand_states.resize(N);
-  int grid_size = (N - 1) / 128 + 1;
-  initialize_curand_states<<<grid_size, 128>>>(curand_states.data(), N, rand());
+  number_of_atoms = number_of_atoms_input;
+  number_of_beads = number_of_beads_input;
+  temperature = temperature_input;
+  temperature_coupling = temperature_coupling_input;
+  temperature_coupling_beads = temperature_coupling_beads_input;
+  c1 = exp(-0.5 / temperature_coupling_beads);
+  c2 = sqrt((1 - c1 * c1) * K_B * temperature);
+  curand_states.resize(number_of_atoms);
+  int grid_size = (number_of_atoms - 1) / 128 + 1;
+  initialize_curand_states<<<grid_size, 128>>>(curand_states.data(), number_of_atoms, rand());
   CUDA_CHECK_KERNEL
 }
 

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -1,0 +1,102 @@
+/*
+    Copyright 2017 Zheyong Fan, Ville Vierimaa, Mikko Ervasti, and Ari Harju
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*----------------------------------------------------------------------------80
+The global path-integral Langevin equation (PILE) thermostat:
+[1] Ceriotti et al., J. Chem. Phys. 133, 124104 (2010).
+------------------------------------------------------------------------------*/
+
+#include "ensemble_pimd.cuh"
+#include "langevin_utilities.cuh"
+#include "utilities/common.cuh"
+#include <cstdlib>
+
+Ensemble_PIMD::Ensemble_PIMD(int t, int fg, int N, double T, double Tc)
+{
+  type = t;
+  fixed_group = fg;
+  temperature = T;
+  temperature_coupling = Tc;
+  c1 = exp(-0.5 / temperature_coupling);
+  c2 = sqrt((1 - c1 * c1) * K_B * T);
+  curand_states.resize(N);
+  int grid_size = (N - 1) / 128 + 1;
+  initialize_curand_states<<<grid_size, 128>>>(curand_states.data(), N, rand());
+  CUDA_CHECK_KERNEL
+}
+
+Ensemble_PIMD::~Ensemble_PIMD(void)
+{
+  // nothing
+}
+
+// wrapper of the global Langevin thermostatting kernels
+void Ensemble_PIMD::integrate_nvt_lan_half(
+  const GPU_Vector<double>& mass, GPU_Vector<double>& velocity_per_atom)
+{
+  const int number_of_atoms = mass.size();
+
+  gpu_langevin<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
+    curand_states.data(), number_of_atoms, c1, c2, mass.data(), velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms, velocity_per_atom.data() + 2 * number_of_atoms);
+  CUDA_CHECK_KERNEL
+
+  gpu_find_momentum<<<4, 1024>>>(
+    number_of_atoms, mass.data(), velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms, velocity_per_atom.data() + 2 * number_of_atoms);
+  CUDA_CHECK_KERNEL
+
+  gpu_correct_momentum<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
+    number_of_atoms, velocity_per_atom.data(), velocity_per_atom.data() + number_of_atoms,
+    velocity_per_atom.data() + 2 * number_of_atoms);
+  CUDA_CHECK_KERNEL
+}
+
+void Ensemble_PIMD::compute1(
+  const double time_step,
+  const std::vector<Group>& group,
+  const GPU_Vector<double>& mass,
+  const GPU_Vector<double>& potential_per_atom,
+  const GPU_Vector<double>& force_per_atom,
+  const GPU_Vector<double>& virial_per_atom,
+  Box& box,
+  GPU_Vector<double>& position_per_atom,
+  GPU_Vector<double>& velocity_per_atom,
+  GPU_Vector<double>& thermo)
+{
+  integrate_nvt_lan_half(mass, velocity_per_atom);
+  velocity_verlet(
+    true, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+}
+
+void Ensemble_PIMD::compute2(
+  const double time_step,
+  const std::vector<Group>& group,
+  const GPU_Vector<double>& mass,
+  const GPU_Vector<double>& potential_per_atom,
+  const GPU_Vector<double>& force_per_atom,
+  const GPU_Vector<double>& virial_per_atom,
+  Box& box,
+  GPU_Vector<double>& position_per_atom,
+  GPU_Vector<double>& velocity_per_atom,
+  GPU_Vector<double>& thermo)
+{
+  velocity_verlet(
+    false, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+  integrate_nvt_lan_half(mass, velocity_per_atom);
+  find_thermo(
+    true, box.get_volume(), group, mass, potential_per_atom, velocity_per_atom, virial_per_atom,
+    thermo);
+}

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -33,25 +33,15 @@ public:
   virtual void compute1(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
   virtual void compute2(
     const double time_step,
     const std::vector<Group>& group,
-    const GPU_Vector<double>& mass,
-    const GPU_Vector<double>& potential_per_atom,
-    const GPU_Vector<double>& force_per_atom,
-    const GPU_Vector<double>& virial_per_atom,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     GPU_Vector<double>& thermo);
 
   struct Beads {

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -20,7 +20,13 @@
 class Ensemble_PIMD : public Ensemble
 {
 public:
-  Ensemble_PIMD(int, int, int, double, double);
+  Ensemble_PIMD(
+    int number_of_atoms_input,
+    int number_of_beads_input,
+    double temperature_input,
+    double temperature_coupling_input,
+    double temperature_coupling_beads_input);
+
   virtual ~Ensemble_PIMD(void);
 
   virtual void compute1(
@@ -48,6 +54,9 @@ public:
     GPU_Vector<double>& thermo);
 
 protected:
+  int number_of_atoms = 0;
+  int number_of_beads = 0;
+  double temperature_coupling_beads;
   double c1, c2;
   GPU_Vector<curandState> curand_states;
 

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -55,14 +55,15 @@ public:
     GPU_Vector<double>& thermo);
 
   struct Beads {
-    const double* velocity[128]; // at most 128 beads
-    const double* position[128]; // at most 128 beads
-    const double* force[128];    // at most 128 beads
+    double* velocity[128]; // at most 128 beads
+    double* position[128]; // at most 128 beads
+    double* force[128];    // at most 128 beads
   };
 
 protected:
   int number_of_atoms = 0;
   int number_of_beads = 0;
+  double omega_n;
   double temperature_coupling_beads;
   double c1, c2;
   GPU_Vector<curandState> curand_states;

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -1,0 +1,56 @@
+/*
+    Copyright 2017 Zheyong Fan, Ville Vierimaa, Mikko Ervasti, and Ari Harju
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "ensemble.cuh"
+#include <curand_kernel.h>
+
+class Ensemble_PIMD : public Ensemble
+{
+public:
+  Ensemble_PIMD(int, int, int, double, double);
+  virtual ~Ensemble_PIMD(void);
+
+  virtual void compute1(
+    const double time_step,
+    const std::vector<Group>& group,
+    const GPU_Vector<double>& mass,
+    const GPU_Vector<double>& potential_per_atom,
+    const GPU_Vector<double>& force_per_atom,
+    const GPU_Vector<double>& virial_per_atom,
+    Box& box,
+    GPU_Vector<double>& position_per_atom,
+    GPU_Vector<double>& velocity_per_atom,
+    GPU_Vector<double>& thermo);
+
+  virtual void compute2(
+    const double time_step,
+    const std::vector<Group>& group,
+    const GPU_Vector<double>& mass,
+    const GPU_Vector<double>& potential_per_atom,
+    const GPU_Vector<double>& force_per_atom,
+    const GPU_Vector<double>& virial_per_atom,
+    Box& box,
+    GPU_Vector<double>& position_per_atom,
+    GPU_Vector<double>& velocity_per_atom,
+    GPU_Vector<double>& thermo);
+
+protected:
+  double c1, c2;
+  GPU_Vector<curandState> curand_states;
+
+  void
+  integrate_nvt_lan_half(const GPU_Vector<double>& mass, GPU_Vector<double>& velocity_per_atom);
+};

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -26,7 +26,7 @@ public:
     int number_of_beads_input,
     double temperature_input,
     double temperature_coupling_input,
-    double temperature_coupling_beads_input);
+    Atom& atom);
 
   virtual ~Ensemble_PIMD(void);
 
@@ -45,9 +45,11 @@ public:
     GPU_Vector<double>& thermo);
 
   struct Beads {
-    double* velocity[128]; // at most 128 beads
-    double* position[128]; // at most 128 beads
-    double* force[128];    // at most 128 beads
+    double* velocity;
+    double* position;
+    double* force;
+    double* potential;
+    double* virial;
   };
 
 protected:
@@ -55,9 +57,6 @@ protected:
   int number_of_beads = 0;
   double omega_n;
   GPU_Vector<curandState> curand_states;
-  std::vector<GPU_Vector<double>> position;
-  std::vector<GPU_Vector<double>> velocity;
-  std::vector<GPU_Vector<double>> force;
   GPU_Vector<double> transformation_matrix;
   Beads beads;
 };

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -57,4 +57,5 @@ protected:
   GPU_Vector<double*> force_beads;
   GPU_Vector<double*> virial_beads;
   GPU_Vector<double> transformation_matrix;
+  GPU_Vector<double> kinetic_energy_virial_part;
 };

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -58,4 +58,6 @@ protected:
   GPU_Vector<double*> virial_beads;
   GPU_Vector<double> transformation_matrix;
   GPU_Vector<double> kinetic_energy_virial_part;
+
+  GPU_Vector<double> sum_1024; // for intermidiate summation
 };

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -64,15 +64,10 @@ protected:
   int number_of_atoms = 0;
   int number_of_beads = 0;
   double omega_n;
-  double temperature_coupling_beads;
-  double c1, c2;
   GPU_Vector<curandState> curand_states;
   std::vector<GPU_Vector<double>> position;
   std::vector<GPU_Vector<double>> velocity;
   std::vector<GPU_Vector<double>> force;
   GPU_Vector<double> transformation_matrix;
   Beads beads;
-
-  void
-  integrate_nvt_lan_half(const GPU_Vector<double>& mass, GPU_Vector<double>& velocity_per_atom);
 };

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -16,6 +16,7 @@
 #pragma once
 #include "ensemble.cuh"
 #include <curand_kernel.h>
+#include <vector>
 
 class Ensemble_PIMD : public Ensemble
 {
@@ -53,12 +54,23 @@ public:
     GPU_Vector<double>& velocity_per_atom,
     GPU_Vector<double>& thermo);
 
+  struct Beads {
+    const double* velocity[128]; // at most 128 beads
+    const double* position[128]; // at most 128 beads
+    const double* force[128];    // at most 128 beads
+  };
+
 protected:
   int number_of_atoms = 0;
   int number_of_beads = 0;
   double temperature_coupling_beads;
   double c1, c2;
   GPU_Vector<curandState> curand_states;
+  std::vector<GPU_Vector<double>> position;
+  std::vector<GPU_Vector<double>> velocity;
+  std::vector<GPU_Vector<double>> force;
+  GPU_Vector<double> transformation_matrix;
+  Beads beads;
 
   void
   integrate_nvt_lan_half(const GPU_Vector<double>& mass, GPU_Vector<double>& velocity_per_atom);

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -24,6 +24,7 @@ public:
   Ensemble_PIMD(
     int number_of_atoms_input,
     int number_of_beads_input,
+    int number_of_steps_pimd_input,
     double temperature_input,
     double temperature_coupling_input,
     Atom& atom);
@@ -47,6 +48,7 @@ public:
 protected:
   int number_of_atoms = 0;
   int number_of_beads = 0;
+  int number_of_steps_pimd;
   double omega_n;
   GPU_Vector<curandState> curand_states;
   GPU_Vector<double*> position_beads;

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -44,19 +44,15 @@ public:
     Atom& atom,
     GPU_Vector<double>& thermo);
 
-  struct Beads {
-    double* velocity;
-    double* position;
-    double* force;
-    double* potential;
-    double* virial;
-  };
-
 protected:
   int number_of_atoms = 0;
   int number_of_beads = 0;
   double omega_n;
   GPU_Vector<curandState> curand_states;
+  GPU_Vector<double*> position_beads;
+  GPU_Vector<double*> velocity_beads;
+  GPU_Vector<double*> potential_beads;
+  GPU_Vector<double*> force_beads;
+  GPU_Vector<double*> virial_beads;
   GPU_Vector<double> transformation_matrix;
-  Beads beads;
 };

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -178,9 +178,7 @@ void Integrate::compute1(
     atom.position_temp.data() + num_atoms, atom.position_temp.data() + num_atoms * 2);
   CUDA_CHECK_KERNEL
 
-  ensemble->compute1(
-    time_step, group, atom.mass, atom.potential_per_atom, atom.force_per_atom, atom.virial_per_atom,
-    box, atom.position_per_atom, atom.velocity_per_atom, thermo);
+  ensemble->compute1(time_step, group, box, atom, thermo);
 
   gpu_update_unwrapped_position<<<(num_atoms - 1) / 128 + 1, 128>>>(
     num_atoms, atom.position_per_atom.data(), atom.position_per_atom.data() + num_atoms,
@@ -206,9 +204,7 @@ void Integrate::compute2(
       temperature1 + (temperature2 - temperature1) * step_over_number_of_steps;
   }
 
-  ensemble->compute2(
-    time_step, group, atom.mass, atom.potential_per_atom, atom.force_per_atom, atom.virial_per_atom,
-    box, atom.position_per_atom, atom.velocity_per_atom, thermo);
+  ensemble->compute2(time_step, group, box, atom, thermo);
 }
 
 // coding conventions:

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -644,7 +644,7 @@ void Integrate::parse_ensemble(
       printf("Use NVT-PIMD ensemble for this run.\n");
       printf("    temperature is %g K.\n", temperature);
       printf("    tau_T is %g time_step.\n", temperature_coupling);
-      printf("    number of steps within PIMD is %d time_step.\n", number_of_steps_pimd);
+      printf("    number of steps within PIMD is %d.\n", number_of_steps_pimd);
       printf("    number of beads is %d.\n", number_of_beads);
       break;
     default:

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -488,6 +488,9 @@ void Integrate::parse_ensemble(
     if (number_of_beads < 2 || number_of_beads > 128) {
       PRINT_INPUT_ERROR("number of beads should be >= 2 and <= 128.");
     }
+    if (number_of_beads % 2 != 0) {
+      PRINT_INPUT_ERROR("number of beads should be an even number.");
+    }
   }
 
   switch (type) {

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -31,7 +31,7 @@ The driver class for the various integrators.
 #include "utilities/read_file.cuh"
 
 void Integrate::initialize(
-  const int number_of_atoms, const double time_step, const std::vector<Group>& group)
+  const int number_of_atoms, const double time_step, const std::vector<Group>& group, Atom& atom)
 {
   if (move_group >= 0) {
     if (fixed_group < 0) {
@@ -101,8 +101,7 @@ void Integrate::initialize(
       break;
     case 31: // NVT-PIMD
       ensemble.reset(new Ensemble_PIMD(
-        number_of_atoms, number_of_beads, temperature, temperature_coupling,
-        temperature_coupling_beads));
+        number_of_atoms, number_of_beads, temperature, temperature_coupling, atom));
       break;
     default:
       printf("Illegal integrator!\n");

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -450,6 +450,16 @@ void Integrate::parse_ensemble(
     }
   }
 
+  // 5. number of beads in PIMD
+  if (type == 6) {
+    if (!is_valid_int(param[5], &number_of_beads)) {
+      PRINT_INPUT_ERROR("number of beads should be an integer.");
+    }
+    if (number_of_beads < 2 || number_of_beads > 128) {
+      PRINT_INPUT_ERROR("number of beads should be >= 2 and <= 128.");
+    }
+  }
+
   switch (type) {
     case 0:
       printf("Use NVE ensemble for this run.\n");
@@ -488,6 +498,13 @@ void Integrate::parse_ensemble(
       printf("    initial temperature is %g K.\n", temperature1);
       printf("    final temperature is %g K.\n", temperature2);
       printf("    tau_T is %g time_step.\n", temperature_coupling);
+      break;
+    case 6:
+      printf("Use NVT-PIMD ensemble for this run.\n");
+      printf("    initial temperature is %g K.\n", temperature1);
+      printf("    final temperature is %g K.\n", temperature2);
+      printf("    tau_T is %g time_step.\n", temperature_coupling);
+      printf("    number of beads is %d.\n", number_of_beads);
       break;
     case 11:
       printf("Use NPT ensemble for this run.\n");

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -101,7 +101,8 @@ void Integrate::initialize(
       break;
     case 31: // NVT-PIMD
       ensemble.reset(new Ensemble_PIMD(
-        number_of_atoms, number_of_beads, temperature, temperature_coupling, atom));
+        number_of_atoms, number_of_beads, number_of_steps_pimd, temperature, temperature_coupling,
+        atom));
       break;
     default:
       printf("Illegal integrator!\n");
@@ -468,20 +469,23 @@ void Integrate::parse_ensemble(
       PRINT_INPUT_ERROR("Temperature coupling should >= 1.");
     }
 
-    // temperature_coupling for the beads
-    if (!is_valid_real(param[4], &temperature_coupling_beads)) {
-      PRINT_INPUT_ERROR("Temperature coupling should be a number.");
+    // number of steps to be with PIMD, after which using TRPMD
+    if (!is_valid_int(param[4], &number_of_steps_pimd)) {
+      PRINT_INPUT_ERROR("Number of steps within the PIMD stage should be an integer.");
     }
-    if (temperature_coupling_beads < 1.0) {
-      PRINT_INPUT_ERROR("Temperature coupling should >= 1.");
+    if (number_of_steps_pimd < 1) {
+      PRINT_INPUT_ERROR("Number of steps within the PIMD stage should >= 1.");
     }
 
     // number of beads
     if (!is_valid_int(param[5], &number_of_beads)) {
       PRINT_INPUT_ERROR("number of beads should be an integer.");
     }
-    if (number_of_beads < 2 || number_of_beads > 128) {
-      PRINT_INPUT_ERROR("number of beads should be >= 2 and <= 128.");
+    if (number_of_beads < 2) {
+      PRINT_INPUT_ERROR("number of beads should >= 2.");
+    }
+    if (number_of_beads > MAX_NUM_BEADS) {
+      PRINT_INPUT_ERROR("number of beads should <= 128.");
     }
     if (number_of_beads % 2 != 0) {
       PRINT_INPUT_ERROR("number of beads should be an even number.");
@@ -639,8 +643,8 @@ void Integrate::parse_ensemble(
     case 31:
       printf("Use NVT-PIMD ensemble for this run.\n");
       printf("    temperature is %g K.\n", temperature);
-      printf("    physical coupling is %g time_step.\n", temperature_coupling);
-      printf("    internal coupling is %g time_step.\n", temperature_coupling_beads);
+      printf("    tau_T is %g time_step.\n", temperature_coupling);
+      printf("    number of steps within PIMD is %d time_step.\n", number_of_steps_pimd);
       printf("    number of beads is %d.\n", number_of_beads);
       break;
     default:

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -24,6 +24,7 @@ The driver class for the various integrators.
 #include "ensemble_nhc.cuh"
 #include "ensemble_npt_scr.cuh"
 #include "ensemble_nve.cuh"
+#include "ensemble_pimd.cuh"
 #include "integrate.cuh"
 #include "model/atom.cuh"
 #include "utilities/common.cuh"
@@ -243,6 +244,11 @@ void Integrate::parse_ensemble(
     type = 5;
     if (num_param != 5) {
       PRINT_INPUT_ERROR("ensemble nvt_bao should have 3 parameters.");
+    }
+  } else if (strcmp(param[1], "nvt_pimd") == 0) {
+    type = 6;
+    if (num_param != 6) {
+      PRINT_INPUT_ERROR("ensemble nvt_pimd should have 4 parameters.");
     }
   } else if (strcmp(param[1], "npt_ber") == 0) {
     type = 11;

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -80,4 +80,5 @@ public:
 
   // PIMD
   int number_of_beads;
+  double temperature_coupling_beads;
 };

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -77,4 +77,7 @@ public:
   int deform_y = 0;
   int deform_z = 0;
   double deform_rate[3];
+
+  // PIMD
+  int number_of_beads;
 };

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -28,8 +28,8 @@ class Integrate
 public:
   std::unique_ptr<Ensemble> ensemble;
 
-  void
-  initialize(const int number_of_atoms, const double time_step, const std::vector<Group>& group);
+  void initialize(
+    const int number_of_atoms, const double time_step, const std::vector<Group>& group, Atom& atom);
 
   void finalize();
 

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -80,5 +80,5 @@ public:
 
   // PIMD
   int number_of_beads;
-  double temperature_coupling_beads;
+  int number_of_steps_pimd; // after this number of steps, switch to RPMD
 };

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -172,9 +172,17 @@ void Run::perform_a_run()
 
     integrate.compute1(time_step, double(step) / number_of_steps, group, box, atom, thermo);
 
-    force.compute(
-      box, atom.position_per_atom, atom.type, group, atom.potential_per_atom, atom.force_per_atom,
-      atom.virial_per_atom, atom.velocity_per_atom, atom.mass);
+    if (integrate.type == 31) { // PIMD
+      for (int k = 0; k < integrate.number_of_beads; ++k) {
+        force.compute(
+          box, atom.position_beads[k], atom.type, group, atom.potential_beads[k],
+          atom.force_beads[k], atom.virial_beads[k], atom.velocity_beads[k], atom.mass);
+      }
+    } else {
+      force.compute(
+        box, atom.position_per_atom, atom.type, group, atom.potential_per_atom, atom.force_per_atom,
+        atom.virial_per_atom, atom.velocity_per_atom, atom.mass);
+    }
 
 #ifdef USE_PLUMED
     if (measure.plmd.use_plumed == 1 && (step % measure.plmd.interval) == 0) {

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -152,7 +152,7 @@ void Run::execute_run_in()
 
 void Run::perform_a_run()
 {
-  integrate.initialize(N, time_step, group);
+  integrate.initialize(N, time_step, group, atom);
   measure.initialize(number_of_steps, time_step, box, group, atom, force);
 
 #ifdef USE_PLUMED

--- a/src/measure/dump_thermo.cuh
+++ b/src/measure/dump_thermo.cuh
@@ -24,6 +24,8 @@ public:
   void parse(const char** param, int num_param);
   void preprocess();
   void process(
+    const bool is_pimd,
+    const double temperature_target,
     const int step,
     const int number_of_atoms,
     const int number_of_atoms_fixed,

--- a/src/measure/measure.cu
+++ b/src/measure/measure.cu
@@ -107,7 +107,9 @@ void Measure::process(
   const int number_of_atoms = atom.cpu_type.size();
   int number_of_atoms_fixed = (fixed_group < 0) ? 0 : group[0].cpu_size[fixed_group];
   number_of_atoms_fixed += (move_group < 0) ? 0 : group[0].cpu_size[move_group];
-  dump_thermo.process(step, number_of_atoms, number_of_atoms_fixed, box, thermo);
+  dump_thermo.process(
+    integrate.type == 31, integrate.temperature, step, number_of_atoms, number_of_atoms_fixed, box,
+    thermo);
   dump_position.process(
     step, box, group, atom.cpu_atom_symbol, atom.cpu_type, atom.position_per_atom,
     atom.cpu_position_per_atom);

--- a/src/model/atom.cuh
+++ b/src/model/atom.cuh
@@ -38,9 +38,9 @@ public:
   GPU_Vector<double> virial_per_atom;    // per-atom virial (9 components)
   GPU_Vector<double> potential_per_atom; // per-atom potential energy (1 component)
   // for beads in PIMD
-  GPU_Vector<double> position_beads;
-  GPU_Vector<double> velocity_beads;
-  GPU_Vector<double> force_beads;
-  GPU_Vector<double> potential_beads;
-  GPU_Vector<double> virial_beads;
+  std::vector<GPU_Vector<double>> position_beads;
+  std::vector<GPU_Vector<double>> velocity_beads;
+  std::vector<GPU_Vector<double>> force_beads;
+  std::vector<GPU_Vector<double>> potential_beads;
+  std::vector<GPU_Vector<double>> virial_beads;
 };

--- a/src/model/atom.cuh
+++ b/src/model/atom.cuh
@@ -37,4 +37,10 @@ public:
   GPU_Vector<double> heat_per_atom;      // per-atom heat current (5 components)
   GPU_Vector<double> virial_per_atom;    // per-atom virial (9 components)
   GPU_Vector<double> potential_per_atom; // per-atom potential energy (1 component)
+  // for beads in PIMD
+  GPU_Vector<double> position_beads;
+  GPU_Vector<double> velocity_beads;
+  GPU_Vector<double> force_beads;
+  GPU_Vector<double> potential_beads;
+  GPU_Vector<double> virial_beads;
 };

--- a/src/utilities/common.cuh
+++ b/src/utilities/common.cuh
@@ -17,6 +17,7 @@
 
 const int NUM_ELEMENTS = 103;
 #define PI 3.14159265358979
+#define HBAR 6.465412e-2                             // Planck's constant
 #define K_B 8.617343e-5                              // Boltzmann's constant
 #define K_C 14.399645                                // 1/(4*PI*epsilon_0)
 #define K_C_SP 14.399645f                            // 1/(4*PI*epsilon_0)

--- a/src/utilities/common.cuh
+++ b/src/utilities/common.cuh
@@ -15,6 +15,7 @@
 
 #pragma once
 
+const int MAX_NUM_BEADS = 128;
 const int NUM_ELEMENTS = 103;
 #define PI 3.14159265358979
 #define HBAR 6.465412e-2                             // Planck's constant


### PR DESCRIPTION
# This PR aims to implement PIMD and RPMD

- To solve issue #79 
- Only consider NVT (PIMD) and NVE (RPMD) here, leaving NPT for future work.
- Usage: 
```
ensemble nvt_pimd <temperature> <tau> <step_within_pimd> <num_beads>
```
- `temperature` is the target temperature.
- `tau` is the coupling time (inverse of friction) in the local Langevin thermostat.
- `step_within_pimd` is the step (during this run) starting from which to switch off the thermostats for the centroid modes. For example, if this run has 20 000 steps, and `step_within_pimd` is 10 000, it means that the centroid modes will be thermostatted from step 0 to 9 999 (this is called PIMD) and not thermostatted from step 10 000 to 19 999 (this is called thermostatted ring-polymer MD, or TRPMD).
- `num_beads` is the number of beads, which must even numbers from 2 to 128.
- Full documentation will be left for another PR.