### PR TITLE
Change virial output

### DIFF
--- a/doc/nep/output_files/virial_out.rst
+++ b/doc/nep/output_files/virial_out.rst
@@ -7,15 +7,11 @@
 ================
 
 The ``virial_train.out`` and ``virial_test.out`` files contain the predicted and target virials.
-There are 2 columns.
-The first column gives the virials in units of eV/atom calculated using the :term:`NEP` model.
-The second column gives the corresponding target virials in units of eV/atom.
 
-The are :math:`6N_\mathrm{c}` rows, where :math:`N_\mathrm{c}` is the number of configurations in the :ref:`train.xyz and test.xyz input files <train_test_xyz>`.
+The are :math:`N_\mathrm{c}` rows, where :math:`N_\mathrm{c}` is the number of configurations in the :ref:`train.xyz and test.xyz input files <train_test_xyz>`.
 
-* The first :math:`N_\mathrm{c}` rows correspond to the :math:`xx` component of the virial.
-* The second :math:`N_\mathrm{c}` rows correspond to the :math:`yy` component of the virial.
-* The third :math:`N_\mathrm{c}` rows correspond to the :math:`zz` component of the virial.
-* The fourth :math:`N_\mathrm{c}` rows correspond to the :math:`xy` component of the virial.
-* The fifth :math:`N_\mathrm{c}` rows correspond to the :math:`yz` component of the virial.
-* The sixth :math:`N_\mathrm{c}` rows correspond to the :math:`zx` component of the virial.
+There are 12 columns.
+The first 6 columns give the :math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`yz`, and :math:`zx` virial components calculated using the :term:`NEP` model.
+The last 6 columns give the corresponding target virials.
+
+The virial values are in units of eV/atom.

--- a/doc/nep/output_files/virial_out.rst
+++ b/doc/nep/output_files/virial_out.rst
@@ -8,7 +8,7 @@
 
 The ``virial_train.out`` and ``virial_test.out`` files contain the predicted and target virials.
 
-The are :math:`N_\mathrm{c}` rows, where :math:`N_\mathrm{c}` is the number of configurations in the :ref:`train.xyz and test.xyz input files <train_test_xyz>`.
+There are :math:`N_\mathrm{c}` rows, where :math:`N_\mathrm{c}` is the number of configurations in the :ref:`train.xyz and test.xyz input files <train_test_xyz>`.
 
 There are 12 columns.
 The first 6 columns give the :math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`yz`, and :math:`zx` virial components calculated using the :term:`NEP` model.

--- a/src/main_nep/fitness.cuh
+++ b/src/main_nep/fitness.cuh
@@ -47,7 +47,7 @@ protected:
   std::unique_ptr<Potential> potential;
   std::vector<std::vector<Dataset>> train_set;
   std::vector<Dataset> test_set;
-  void predict_energy_or_stress(FILE* fid, float* data, float* ref, Dataset& dataset);
+  void output(int num_components, FILE* fid, float* prediction, float* reference, Dataset& dataset);
   void
   update_energy_force_virial(FILE* fid_energy, FILE* fid_force, FILE* fid_virial, Dataset& dataset);
   void update_dipole(FILE* fid_dipole, Dataset& dataset);

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -168,7 +168,7 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
   if (para.prediction == 0) {
     printf("Started training.\n");
   } else {
-    printf("Started predcting.\n");
+    printf("Started predicting.\n");
   }
 
   print_line_2();

--- a/src/main_nep/structure.cu
+++ b/src/main_nep/structure.cu
@@ -260,7 +260,13 @@ static void read_one_structure(const Parameters& para, std::ifstream& input, Str
       }
     }
     if (!structure.has_virial) {
-      PRINT_INPUT_ERROR("'dipole' is missing in the second line of a frame.");
+      if (para.prediction == 0) {
+        PRINT_INPUT_ERROR("'dipole' is missing in the second line of a frame.");
+      } else {
+        for (int m = 0; m < 6; ++m) {
+          structure.virial[m] = -1e6;
+        }
+      }
     }
   }
 
@@ -283,7 +289,13 @@ static void read_one_structure(const Parameters& para, std::ifstream& input, Str
       }
     }
     if (!structure.has_virial) {
-      PRINT_INPUT_ERROR("'pol' is missing in the second line of a frame.");
+      if (para.prediction == 0) {
+        PRINT_INPUT_ERROR("'pol' is missing in the second line of a frame.");
+      } else {
+        for (int m = 0; m < 6; ++m) {
+          structure.virial[m] = -1e6;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
- Output virial data in 12 columns instead of 2: the first 6 columns for NEP prediction and the last 6 for reference. Ordered as xx, yy, zz, xy, yz, zx.
- Output dipole data in 6 columns instead of 2: the first 3 columns for NEP prediction and the last 3 for reference. Ordered as x, y, z.
- Output polarizability data in 12 columns instead of 2: the first 6 columns for NEP prediction and the last 6 for reference. Ordered as xx, yy, zz, xy, yz, zx.
- Allow for missing dipole and polarizability reference data for the prediction mode.