### PR TITLE
Nep defaults

### DIFF
--- a/doc/nep/input_files/nep_in.rst
+++ b/doc/nep/input_files/nep_in.rst
@@ -79,7 +79,7 @@ Here is an example :attr:`nep.in` file using all the default parameters::
   version       4       # default
   cutoff     	8 4     # default
   n_max      	4 4     # default
-  basis_size	8 8     # default
+  basis_size	12 12   # default
   l_max      	4 2 0   # default
   neuron     	30      # default
   lambda_e      1.0     # default

--- a/doc/nep/input_parameters/basis_size.rst
+++ b/doc/nep/input_parameters/basis_size.rst
@@ -14,6 +14,6 @@ The syntax is::
 where :attr:`<N_bas_R>` and :attr:`<N_bas_A>` set :math:`N_\mathrm{bas}^\mathrm{R}` and :math:`N_\mathrm{bas}^\mathrm{A}`, respectively.
 The parameters must satisfy :math:`0 \leq N_\mathrm{bas}^\mathrm{R},N_\mathrm{bas}^\mathrm{A} \leq 19`.
 
-The default values of :math:`N_\mathrm{bas}^\mathrm{R}=8` and :math:`N_\mathrm{bas}^\mathrm{A}=8` are usually sufficient.
+The default values of :math:`N_\mathrm{bas}^\mathrm{R}=12` and :math:`N_\mathrm{bas}^\mathrm{A}=12` are usually sufficient.
 
 **Note:** These parameters should not be confused with :math:`n_\mathrm{max}^\mathrm{R}` and :math:`n_\mathrm{max}^\mathrm{A}`, which are set via the :ref:`n_max keyword <kw_n_max>`.

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -77,8 +77,8 @@ void Parameters::set_default_parameters()
   version = 4;                 // NEP4 is the best
   rc_radial = 8.0f;            // large enough for vdw/coulomb
   rc_angular = 4.0f;           // large enough in most cases
-  basis_size_radial = 8;       // large enough in most cases
-  basis_size_angular = 8;      // large enough in most cases
+  basis_size_radial = 12;      // large enough in most cases
+  basis_size_angular = 12;     // large enough in most cases
   n_max_radial = 4;            // a relatively small value to achieve high speed
   n_max_angular = 4;           // a relatively small value to achieve high speed
   L_max = 4;                   // the only supported value
@@ -94,11 +94,11 @@ void Parameters::set_default_parameters()
   population_size = 50;        // almost optimal
   maximum_generation = 100000; // a good starting point
   type_weight_cpu.resize(NUM_ELEMENTS);
-  zbl_para.resize(440);        // Maximum number of zbl parameters
+  zbl_para.resize(440); // Maximum number of zbl parameters
   for (int n = 0; n < NUM_ELEMENTS; ++n) {
     type_weight_cpu[n] = 1.0f; // uniform weight by default
   }
-  enable_zbl = false; // default is not to include ZBL
+  enable_zbl = false;   // default is not to include ZBL
   flexible_zbl = false; // default Universal ZBL
 }
 
@@ -245,7 +245,8 @@ void Parameters::report_inputs()
       printf("    (input)   will add the flexible ZBL potential\n");
     } else {
       printf(
-        "    (input)   will add the universal ZBL potential with outer cutoff %g A and inner cutoff %g A.\n",
+        "    (input)   will add the universal ZBL potential with outer cutoff %g A and inner "
+        "cutoff %g A.\n",
         zbl_rc_outer, zbl_rc_inner);
     }
   } else {

--- a/src/makefile
+++ b/src/makefile
@@ -7,6 +7,8 @@
 #    You can consider removing -Xcompiler "/wd 4819"
 # 3) Add -DUSE_PLUMED to CFLAGS when use the PLUMED plugin
 #    and remove it otherwise.
+# 4) Add -DUSE_TABLE to speed up MD simulations with NEP
+#    using pre-computed radial functions in the descriptors
 ###########################################################
 
 


### PR DESCRIPTION
* We found the `basis_size 12 12` is usually much better than `basis_size 8 8`.
* Mention the `-DUSE_TABLE` option in `makefile`.