### PR TITLE
Add one line output that confirms when the tabulated radial functions are being

### DIFF
--- a/src/force/nep3.cu
+++ b/src/force/nep3.cu
@@ -287,7 +287,7 @@ NEP3::NEP3(const char* file_potential, const int num_atoms)
   nep_data.cpu_NN_radial.resize(num_atoms);
   nep_data.cpu_NN_angular.resize(num_atoms);
 
-#if USE_TABLE
+#ifdef USE_TABLE
   construct_table(parameters.data());
   printf("    use tabulated radial functions to speed up.\n");
 #endif

--- a/src/force/nep3.cu
+++ b/src/force/nep3.cu
@@ -289,6 +289,7 @@ NEP3::NEP3(const char* file_potential, const int num_atoms)
 
 #if USE_TABLE
   construct_table(parameters.data());
+  printf("The tabulated radial functions have been used to speed up NEP.\n");
 #endif
 }
 

--- a/src/force/nep3.cu
+++ b/src/force/nep3.cu
@@ -231,7 +231,7 @@ NEP3::NEP3(const char* file_potential, const int num_atoms)
   }
   printf("    number of descriptor parameters = %d.\n", num_para_descriptor);
   annmb.num_para += num_para_descriptor;
-  printf("    total number of parameters = %d\n", annmb.num_para);
+  printf("    total number of parameters = %d.\n", annmb.num_para);
 
   paramb.num_c_radial =
     paramb.num_types_sq * (paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1);
@@ -289,7 +289,7 @@ NEP3::NEP3(const char* file_potential, const int num_atoms)
 
 #if USE_TABLE
   construct_table(parameters.data());
-  printf("The tabulated radial functions have been used to speed up NEP.\n");
+  printf("    use tabulated radial functions to speed up.\n");
 #endif
 }
 


### PR DESCRIPTION
To add a line of output that confirms when the tabulated radial functions are being used to speed up NEP.