### PR TITLE
PIMD-NPT

### DIFF
--- a/doc/bibliography.rst
+++ b/doc/bibliography.rst
@@ -34,6 +34,18 @@ Bibliography
    | J. Chem. Phys. **126**, 014101 (2007)
    | DOI: `10.1063/1.2408420 <https://doi.org/10.1063/1.2408420>`_
 
+.. [Ceriotti2010]
+   | Michele Ceriotti, Michele Parrinello, Thomas E. Markland, and David E. Manolopoulos
+   | *Efficient stochastic thermostatting of path integral molecular dynamics*
+   | J. Chem. Phys. **133**, 124104 (2010)
+   | DOI: `10.1063/1.3489925 <https://doi.org/10.1063/1.3489925>`_
+
+.. [Craig2004]
+   | Ian R. Craig and David E. Manolopoulos
+   | *Quantum statistics and classical mechanics: Real time correlation functions from ring polymer molecular dynamics*
+   | J. Chem. Phys. **121**, 3368 (2004)
+   | DOI: `10.1063/1.1777575 <https://doi.org/10.1063/1.1777575>`_
+
 .. [Dai2006]
    | X. D. Dai, Y. Kong, J. H. Li, and B. X. Liu
    | *Extended Finnis–Sinclair potential for bcc and fcc metals and alloys*
@@ -117,6 +129,12 @@ Bibliography
    | *Direct calculation of modal contributions to thermal conductivity via Green-Kubo modal analysis*
    | New J. Phys. **18**, 013028 (2016)
    | DOI: `10.1088/1367-2630/18/1/013028 <https://doi.org/10.1088/1367-2630/18/1/013028>`_
+   
+.. [Rossi2014]
+   | Mariana Rossi, Michele Ceriotti, and David E. Manolopoulos
+   | *How to remove the spurious resonances from ring polymer molecular dynamics*
+   | J. Chem. Phys. **140**, 234116 (2014)
+   | DOI: `10.1063/1.4883861 <https://doi.org/10.1063/1.4883861>`_
 
 .. [Schaul2011]
    | T. Schaul, T. Glasmachers, and J. Schmidhuber

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -62,11 +62,17 @@ Glossary
    NN
         neural network
 
+   PIMD
+        path-integral molecular dynamics
+
    PDOS
         phonon density of states
 
    RMSE
         `root-mean-square error <https://en.wikipedia.org/wiki/Root-mean-square_deviation>`_
+
+   RPMD
+        ring-polymer molecular dynamics
 
    RTC
         :ref:`running thermal conductivity <running_thermal_conductivity>`
@@ -85,6 +91,9 @@ Glossary
 
    SVR
         :ref:`stochastic velocity rescaling thermostat <svr_thermostat>` [Bussi2007b]_
+
+   TRPMD
+        thermostatted ring-polymer molecular dynamics
 
    VAC
         velocity auto-correlation

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -62,11 +62,11 @@ Glossary
    NN
         neural network
 
-   PIMD
-        path-integral molecular dynamics
-
    PDOS
         phonon density of states
+
+   PIMD
+        path-integral molecular dynamics
 
    RMSE
         `root-mean-square error <https://en.wikipedia.org/wiki/Root-mean-square_deviation>`_

--- a/doc/gpumd/input_parameters/ensemble.rst
+++ b/doc/gpumd/input_parameters/ensemble.rst
@@ -135,19 +135,23 @@ If the first parameter is :attr:`heat_lan`, it is similar to the case of :attr:`
 
 :attr:`pimd`
 ^^^^^^^^^^^^
-If the first parameter is :attr:`pimd`, it means that the current run will use path-integral molecular dynamics (:term:`PIMD`). It can be used in the followying ways::
+If the first parameter is :attr:`pimd`, it means that the current run will use path-integral molecular dynamics (:term:`PIMD`).
+
+It can be used in the following ways::
 
     ensemble pimd <num_beads> <T_1> <T_2> <T_coup> 
     ensemble pimd <num_beads> <T_1> <T_2> <T_coup> {<pressure_control_parameters>}
 
 In both cases, :attr:`num_beads` is the number of beads in the ring polymer, which should be a positive even integer no larger than 128.
-The first case is similar to the NVT ensemble with :attr:`nvt_lan` as we have used the Langevin thermostat for both the internal and the centroid modes [Ceriotti2010]_. 
+The first case is similar to the NVT ensemble with :attr:`nvt_lan` as the Langevin thermostat is used for both the internal and the centroid modes [Ceriotti2010]_. 
 The second case is similar to the NPT ensemble with :attr:`npt_ber`, where a Berendsen barostat is added compared to the first case.
-:attr:`pimd` (that is, not :attr:`rpmd` or :attr:`trpmd` below) must be the first run that requires to set :attr:`num_beads` and one cannot change :attr:`num_beads` from run to run.
+Note that :attr:`pimd` (that is, not :attr:`rpmd` or :attr:`trpmd` described below) must be the first run that requires to set :attr:`num_beads` and one cannot change :attr:`num_beads` from run to run.
 
 :attr:`rpmd`
 ^^^^^^^^^^^^
-If the first parameter is :attr:`rpmd`, it means that the current run will use ring-polymer molecular dynamics (:term:`RPMD`) [Craig2004]_. It can be used in the followying way::
+If the first parameter is :attr:`rpmd`, it means that the current run will use ring-polymer molecular dynamics (:term:`RPMD`) [Craig2004]_.
+
+It can be used as follows::
 
     ensemble rpmd <num_beads> 
 
@@ -155,7 +159,9 @@ This can be understood as the NVE version of :term:`PIMD`, where no thermostat i
 
 :attr:`trpmd`
 ^^^^^^^^^^^^^
-If the first parameter is :attr:`trpmd`, it means that the current run will use thermostatted ring-polymer molecular dynamics (:term:`TRPMD`) [Rossi2014]_. It can be used in the followying way::
+If the first parameter is :attr:`trpmd`, it means that the current run will use thermostatted ring-polymer molecular dynamics (:term:`TRPMD`) [Rossi2014]_.
+
+It can be used as follows::
 
     ensemble trpmd <num_beads> 
 

--- a/doc/gpumd/input_parameters/ensemble.rst
+++ b/doc/gpumd/input_parameters/ensemble.rst
@@ -134,18 +134,19 @@ If the first parameter is :attr:`heat_bdp`, it is similar to the case of :attr:`
 If the first parameter is :attr:`heat_lan`, it is similar to the case of :attr:`heat_nhc`, but using the :ref:`Langevin method <langevin_thermostat>`.
 
 :attr:`pimd`
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^
 If the first parameter is :attr:`pimd`, it means that the current run will use path-integral molecular dynamics (:term:`PIMD`). It can be used in the followying ways::
 
     ensemble pimd <num_beads> <T_1> <T_2> <T_coup> 
     ensemble pimd <num_beads> <T_1> <T_2> <T_coup> {<pressure_control_parameters>}
 
-In both cases, :attr:`num_beads` is the number of beads in the ring polymer.
+In both cases, :attr:`num_beads` is the number of beads in the ring polymer, which should be a positive even integer no larger than 128.
 The first case is similar to the NVT ensemble with :attr:`nvt_lan` as we have used the Langevin thermostat for both the internal and the centroid modes [Ceriotti2010]_. 
 The second case is similar to the NPT ensemble with :attr:`npt_ber`, where a Berendsen barostat is added compared to the first case.
+:attr:`pimd` (that is, not :attr:`rpmd` or :attr:`trpmd` below) must be the first run that requires to set :attr:`num_beads` and one cannot change :attr:`num_beads` from run to run.
 
 :attr:`rpmd`
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^
 If the first parameter is :attr:`rpmd`, it means that the current run will use ring-polymer molecular dynamics (:term:`RPMD`) [Craig2004]_. It can be used in the followying way::
 
     ensemble rpmd <num_beads> 
@@ -153,7 +154,7 @@ If the first parameter is :attr:`rpmd`, it means that the current run will use r
 This can be understood as the NVE version of :term:`PIMD`, where no thermostat is applied.
 
 :attr:`trpmd`
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^
 If the first parameter is :attr:`trpmd`, it means that the current run will use thermostatted ring-polymer molecular dynamics (:term:`TRPMD`) [Rossi2014]_. It can be used in the followying way::
 
     ensemble trpmd <num_beads> 

--- a/doc/gpumd/input_parameters/ensemble.rst
+++ b/doc/gpumd/input_parameters/ensemble.rst
@@ -25,6 +25,9 @@ The number of optional parameters depends on the first parameter, which can assu
     heat_nhc
     heat_bdp
     heat_lan
+    pimd
+    rpmd
+    trpmd
 
 :attr:`nve`
 ^^^^^^^^^^^
@@ -128,8 +131,34 @@ If the first parameter is :attr:`heat_bdp`, it is similar to the case of :attr:`
 
 :attr:`heat_lan`
 ^^^^^^^^^^^^^^^^
-if the first parameter is :attr:`heat_lan`, it is similar to the case of :attr:`heat_nhc`, but using the :ref:`Langevin method <langevin_thermostat>`.
+If the first parameter is :attr:`heat_lan`, it is similar to the case of :attr:`heat_nhc`, but using the :ref:`Langevin method <langevin_thermostat>`.
 
+:attr:`pimd`
+^^^^^^^^^^^^^^^
+If the first parameter is :attr:`pimd`, it means that the current run will use path-integral molecular dynamics (:term:`PIMD`). It can be used in the followying ways::
+
+    ensemble pimd <num_beads> <T_1> <T_2> <T_coup> 
+    ensemble pimd <num_beads> <T_1> <T_2> <T_coup> {<pressure_control_parameters>}
+
+In both cases, :attr:`num_beads` is the number of beads in the ring polymer.
+The first case is similar to the NVT ensemble with :attr:`nvt_lan` as we have used the Langevin thermostat for both the internal and the centroid modes [Ceriotti2010]_. 
+The second case is similar to the NPT ensemble with :attr:`npt_ber`, where a Berendsen barostat is added compared to the first case.
+
+:attr:`rpmd`
+^^^^^^^^^^^^^^^
+If the first parameter is :attr:`rpmd`, it means that the current run will use ring-polymer molecular dynamics (:term:`RPMD`) [Craig2004]_. It can be used in the followying way::
+
+    ensemble rpmd <num_beads> 
+
+This can be understood as the NVE version of :term:`PIMD`, where no thermostat is applied.
+
+:attr:`trpmd`
+^^^^^^^^^^^^^^^
+If the first parameter is :attr:`trpmd`, it means that the current run will use thermostatted ring-polymer molecular dynamics (:term:`TRPMD`) [Rossi2014]_. It can be used in the followying way::
+
+    ensemble trpmd <num_beads> 
+
+This is similar to :term:`RPMD`, but the Langevin thermosat is applied to the internal modes.
 
 .. _choice_of_parameters:
 

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -25,8 +25,19 @@ References for implementation:
 
 #include "ensemble_pimd.cuh"
 #include "langevin_utilities.cuh"
+#include "svr_utilities.cuh"
 #include "utilities/common.cuh"
+#include <chrono>
 #include <cstdlib>
+
+void Ensemble_PIMD::initialize_rng()
+{
+#ifdef DEBUG
+  rng = std::mt19937(12345678);
+#else
+  rng = std::mt19937(std::chrono::system_clock::now().time_since_epoch().count());
+#endif
+};
 
 Ensemble_PIMD::Ensemble_PIMD(
   int number_of_atoms_input, int number_of_beads_input, bool thermostat_internal_input, Atom& atom)
@@ -50,6 +61,29 @@ Ensemble_PIMD::Ensemble_PIMD(
   thermostat_internal = true;
   thermostat_centroid = true;
   initialize(atom);
+}
+
+Ensemble_PIMD::Ensemble_PIMD(
+  int number_of_atoms_input,
+  int number_of_beads_input,
+  double temperature_coupling_input,
+  int num_target_pressure_components_input,
+  double target_pressure_input[6],
+  double pressure_coupling_input[6],
+  Atom& atom)
+{
+  number_of_atoms = number_of_atoms_input;
+  number_of_beads = number_of_beads_input;
+  temperature_coupling = temperature_coupling_input;
+  num_target_pressure_components = num_target_pressure_components_input;
+  for (int i = 0; i < 6; i++) {
+    target_pressure[i] = target_pressure_input[i];
+    pressure_coupling[i] = pressure_coupling_input[i];
+  }
+  thermostat_internal = true;
+  thermostat_centroid = true;
+  initialize(atom);
+  initialize_rng();
 }
 
 void Ensemble_PIMD::initialize(Atom& atom)
@@ -554,6 +588,178 @@ gpu_find_thermo(const double volume, const double NkBT, const double* g_sum_1024
   }
 }
 
+static void cpu_pressure_orthogonal(
+  std::mt19937 rng,
+  Box& box,
+  double target_temperature,
+  double* p0,
+  double* p_coupling,
+  double* thermo,
+  double* scale_factor)
+{
+  double p[3];
+  CHECK(cudaMemcpy(p, thermo + 2, sizeof(double) * 3, cudaMemcpyDeviceToHost));
+
+  if (box.pbc_x == 1) {
+    const double scale_factor_Berendsen = 1.0 - p_coupling[0] * (p0[0] - p[0]);
+    const double scale_factor_stochastic =
+      sqrt(2.0 * p_coupling[0] * K_B * target_temperature / box.get_volume()) * gasdev(rng);
+    scale_factor[0] = scale_factor_Berendsen + scale_factor_stochastic;
+    box.cpu_h[0] *= scale_factor[0];
+    box.cpu_h[3] = box.cpu_h[0] * 0.5;
+  } else {
+    scale_factor[0] = 1.0;
+  }
+
+  if (box.pbc_y == 1) {
+    const double scale_factor_Berendsen = 1.0 - p_coupling[1] * (p0[1] - p[1]);
+    const double scale_factor_stochastic =
+      sqrt(2.0 * p_coupling[1] * K_B * target_temperature / box.get_volume()) * gasdev(rng);
+    scale_factor[1] = scale_factor_Berendsen + scale_factor_stochastic;
+    box.cpu_h[1] *= scale_factor[1];
+    box.cpu_h[4] = box.cpu_h[1] * 0.5;
+  } else {
+    scale_factor[1] = 1.0;
+  }
+
+  if (box.pbc_z == 1) {
+    const double scale_factor_Berendsen = 1.0 - p_coupling[2] * (p0[2] - p[2]);
+    const double scale_factor_stochastic =
+      sqrt(2.0 * p_coupling[2] * K_B * target_temperature / box.get_volume()) * gasdev(rng);
+    scale_factor[2] = scale_factor_Berendsen + scale_factor_stochastic;
+    box.cpu_h[2] *= scale_factor[2];
+    box.cpu_h[5] = box.cpu_h[2] * 0.5;
+  } else {
+    scale_factor[2] = 1.0;
+  }
+}
+
+static void cpu_pressure_isotropic(
+  std::mt19937 rng,
+  Box& box,
+  double target_temperature,
+  double* target_pressure,
+  double* p_coupling,
+  double* thermo,
+  double& scale_factor)
+{
+  double p[3];
+  CHECK(cudaMemcpy(p, thermo + 2, sizeof(double) * 3, cudaMemcpyDeviceToHost));
+  const double pressure_instant = (p[0] + p[1] + p[2]) * 0.3333333333333333;
+  const double scale_factor_Berendsen =
+    1.0 - p_coupling[0] * (target_pressure[0] - pressure_instant);
+  // The factor 0.666666666666667 is 2/3, where 3 means the number of directions that are coupled
+  const double scale_factor_stochastic =
+    sqrt(0.666666666666667 * p_coupling[0] * K_B * target_temperature / box.get_volume()) *
+    gasdev(rng);
+  scale_factor = scale_factor_Berendsen + scale_factor_stochastic;
+  box.cpu_h[0] *= scale_factor;
+  box.cpu_h[1] *= scale_factor;
+  box.cpu_h[2] *= scale_factor;
+  box.cpu_h[3] = box.cpu_h[0] * 0.5;
+  box.cpu_h[4] = box.cpu_h[1] * 0.5;
+  box.cpu_h[5] = box.cpu_h[2] * 0.5;
+}
+
+static void cpu_pressure_triclinic(
+  std::mt19937 rng,
+  Box& box,
+  double target_temperature,
+  double* p0,
+  double* p_coupling,
+  double* thermo,
+  double* mu)
+{
+  // p_coupling and p0 are in Voigt notation: xx, yy, zz, yz, xz, xy
+  double p[6]; // but thermo is this order: xx, yy, zz, xy, xz, yz
+  CHECK(cudaMemcpy(p, thermo + 2, sizeof(double) * 6, cudaMemcpyDeviceToHost));
+  mu[0] = 1.0 - p_coupling[0] * (p0[0] - p[0]);    // xx
+  mu[4] = 1.0 - p_coupling[1] * (p0[1] - p[1]);    // yy
+  mu[8] = 1.0 - p_coupling[2] * (p0[2] - p[2]);    // zz
+  mu[3] = mu[1] = -p_coupling[5] * (p0[5] - p[3]); // xy
+  mu[6] = mu[2] = -p_coupling[4] * (p0[4] - p[4]); // xz
+  mu[7] = mu[5] = -p_coupling[3] * (p0[3] - p[5]); // yz
+  double p_coupling_3by3[3][3] = {
+    {p_coupling[0], p_coupling[3], p_coupling[4]},
+    {p_coupling[3], p_coupling[1], p_coupling[5]},
+    {p_coupling[4], p_coupling[5], p_coupling[2]}};
+  const double volume = box.get_volume();
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      mu[r * 3 + c] +=
+        sqrt(2.0 * p_coupling_3by3[r][c] * K_B * target_temperature / volume) * gasdev(rng);
+    }
+  }
+  double h_old[9];
+  for (int i = 0; i < 9; ++i) {
+    h_old[i] = box.cpu_h[i];
+  }
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      double tmp = 0.0;
+      for (int k = 0; k < 3; ++k) {
+        tmp += mu[r * 3 + k] * h_old[k * 3 + c];
+      }
+      box.cpu_h[r * 3 + c] = tmp;
+    }
+  }
+  box.get_inverse();
+}
+
+static __global__ void gpu_pressure_orthogonal(
+  const int number_of_particles,
+  const double scale_factor_x,
+  const double scale_factor_y,
+  const double scale_factor_z,
+  double* g_x,
+  double* g_y,
+  double* g_z)
+{
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < number_of_particles) {
+    g_x[i] *= scale_factor_x;
+    g_y[i] *= scale_factor_y;
+    g_z[i] *= scale_factor_z;
+  }
+}
+
+static __global__ void gpu_pressure_isotropic(
+  int number_of_particles, double scale_factor, double* g_x, double* g_y, double* g_z)
+{
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < number_of_particles) {
+    g_x[i] *= scale_factor;
+    g_y[i] *= scale_factor;
+    g_z[i] *= scale_factor;
+  }
+}
+
+static __global__ void gpu_pressure_triclinic(
+  int number_of_particles,
+  double mu0,
+  double mu1,
+  double mu2,
+  double mu3,
+  double mu4,
+  double mu5,
+  double mu6,
+  double mu7,
+  double mu8,
+  double* g_x,
+  double* g_y,
+  double* g_z)
+{
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < number_of_particles) {
+    double x_old = g_x[i];
+    double y_old = g_y[i];
+    double z_old = g_z[i];
+    g_x[i] = mu0 * x_old + mu1 * y_old + mu2 * z_old;
+    g_y[i] = mu3 * x_old + mu4 * y_old + mu5 * z_old;
+    g_z[i] = mu6 * x_old + mu7 * y_old + mu8 * z_old;
+  }
+}
+
 void Ensemble_PIMD::langevin(const double time_step, Atom& atom)
 {
   if (thermostat_internal) {
@@ -670,4 +876,47 @@ void Ensemble_PIMD::compute2(
   gpu_find_thermo<<<8, 1024>>>(
     box.get_volume(), number_of_atoms * K_B * temperature, sum_1024.data(), thermo.data());
   CUDA_CHECK_KERNEL
+
+  if (num_target_pressure_components == 1) {
+    double scale_factor;
+    cpu_pressure_isotropic(
+      rng, box, temperature, target_pressure, pressure_coupling, thermo.data(), scale_factor);
+    gpu_pressure_isotropic<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
+      number_of_atoms,
+      scale_factor,
+      atom.position_per_atom.data(),
+      atom.position_per_atom.data() + number_of_atoms,
+      atom.position_per_atom.data() + number_of_atoms * 2);
+  } else if (num_target_pressure_components == 3) {
+    double scale_factor[3];
+    cpu_pressure_orthogonal(
+      rng, box, temperature, target_pressure, pressure_coupling, thermo.data(), scale_factor);
+    gpu_pressure_orthogonal<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
+      number_of_atoms,
+      scale_factor[0],
+      scale_factor[1],
+      scale_factor[2],
+      atom.position_per_atom.data(),
+      atom.position_per_atom.data() + number_of_atoms,
+      atom.position_per_atom.data() + number_of_atoms * 2);
+    CUDA_CHECK_KERNEL
+  } else {
+    double mu[9];
+    cpu_pressure_triclinic(
+      rng, box, temperature, target_pressure, pressure_coupling, thermo.data(), mu);
+    gpu_pressure_triclinic<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
+      number_of_atoms,
+      mu[0],
+      mu[1],
+      mu[2],
+      mu[3],
+      mu[4],
+      mu[5],
+      mu[6],
+      mu[7],
+      mu[8],
+      atom.position_per_atom.data(),
+      atom.position_per_atom.data() + number_of_atoms,
+      atom.position_per_atom.data() + number_of_atoms * 2);
+  }
 }

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -16,6 +16,7 @@
 #pragma once
 #include "ensemble.cuh"
 #include <curand_kernel.h>
+#include <random>
 #include <vector>
 
 class Ensemble_PIMD : public Ensemble
@@ -26,6 +27,15 @@ public:
 
   Ensemble_PIMD(
     int number_of_atoms_input, int number_of_beads_input, double temperature_coupling, Atom& atom);
+
+  Ensemble_PIMD(
+    int number_of_atoms_input,
+    int number_of_beads_input,
+    double temperature_coupling,
+    int num_target_pressure_components,
+    double target_pressure[6],
+    double pressure_coupling[6],
+    Atom& atom);
 
   virtual ~Ensemble_PIMD(void);
 
@@ -62,4 +72,6 @@ protected:
 
   void initialize(Atom& atom);
   void langevin(const double time_step, Atom& atom);
+  std::mt19937 rng;
+  void initialize_rng();
 };

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -144,8 +144,19 @@ void Integrate::initialize(
       ensemble.reset(new Ensemble_PIMD(number_of_atoms, number_of_beads, true, atom));
       break;
     case 33: // PIMD
-      ensemble.reset(
-        new Ensemble_PIMD(number_of_atoms, number_of_beads, temperature_coupling, atom));
+      if (num_target_pressure_components == 0) {
+        ensemble.reset(
+          new Ensemble_PIMD(number_of_atoms, number_of_beads, temperature_coupling, atom));
+      } else {
+        ensemble.reset(new Ensemble_PIMD(
+          number_of_atoms,
+          number_of_beads,
+          temperature_coupling,
+          num_target_pressure_components,
+          target_pressure,
+          pressure_coupling,
+          atom));
+      }
       break;
     default:
       printf("Illegal integrator!\n");
@@ -264,6 +275,7 @@ void Integrate::compute2(
 // 1-10:  NVT
 // 11-20: NPT
 // 21-30: heat (NEMD method for heat conductivity)
+// 31-40: PIMD related
 void Integrate::parse_ensemble(
   Box& box, const char** param, int num_param, std::vector<Group>& group)
 {
@@ -335,8 +347,8 @@ void Integrate::parse_ensemble(
     }
   } else if (strcmp(param[1], "pimd") == 0) {
     type = 33;
-    if (num_param != 6) {
-      PRINT_INPUT_ERROR("ensemble pimd should have 4 parameters.");
+    if (num_param != 6 && num_param != 9 && num_param != 13 && num_param != 19) {
+      PRINT_INPUT_ERROR("ensemble pimd should have 4 or 7 or 11 or 17 parameters.");
     }
   } else {
     PRINT_INPUT_ERROR("Invalid ensemble type.");
@@ -516,7 +528,7 @@ void Integrate::parse_ensemble(
   // 5. PIMD related
   if (type >= 31 && type <= 40) {
 
-    // number of beads
+    // number of beads for RPMD, TRPMD, or PIMD
     if (!is_valid_int(param[2], &number_of_beads)) {
       PRINT_INPUT_ERROR("number of beads should be an integer.");
     }
@@ -530,6 +542,7 @@ void Integrate::parse_ensemble(
       PRINT_INPUT_ERROR("number of beads should be an even number.");
     }
 
+    // thermostat and barostat for PIMD
     if (type > 32) {
       // initial temperature
       if (!is_valid_real(param[3], &temperature1)) {
@@ -554,6 +567,83 @@ void Integrate::parse_ensemble(
       }
       if (temperature_coupling < 1.0) {
         PRINT_INPUT_ERROR("Temperature coupling should >= 1.");
+      }
+
+      num_target_pressure_components = 0;
+
+      // pressures:
+      if (num_param >= 9) {
+        if (num_param == 13) {
+          for (int i = 0; i < 3; i++) {
+            if (!is_valid_real(param[6 + i], &target_pressure[i])) {
+              PRINT_INPUT_ERROR("Pressure should be a number.");
+            }
+          }
+          for (int i = 0; i < 3; i++) {
+            if (!is_valid_real(param[9 + i], &elastic_modulus[i])) {
+              PRINT_INPUT_ERROR("elastic modulus should be a number.");
+            }
+            if (elastic_modulus[i] <= 0) {
+              PRINT_INPUT_ERROR("elastic modulus should > 0.");
+            }
+          }
+          num_target_pressure_components = 3;
+          if (box.triclinic == 1) {
+            PRINT_INPUT_ERROR("Cannot use triclinic box with only 3 target pressure components.");
+          }
+        } else if (num_param == 9) { // isotropic
+          if (!is_valid_real(param[6], &target_pressure[0])) {
+            PRINT_INPUT_ERROR("Pressure should be a number.");
+          }
+          if (!is_valid_real(param[7], &elastic_modulus[0])) {
+            PRINT_INPUT_ERROR("elastic modulus should be a number.");
+          }
+          if (elastic_modulus[0] <= 0) {
+            PRINT_INPUT_ERROR("elastic modulus should > 0.");
+          }
+          num_target_pressure_components = 1;
+          if (box.triclinic == 1) {
+            PRINT_INPUT_ERROR("Cannot use triclinic box with only 1 target pressure component.");
+          }
+          if (box.pbc_x == 0 || box.pbc_y == 0 || box.pbc_z == 0) {
+            PRINT_INPUT_ERROR(
+              "Cannot use isotropic pressure with non-periodic boundary in any direction.");
+          }
+        } else { // then must be triclinic box
+          for (int i = 0; i < 6; i++) {
+            if (!is_valid_real(param[6 + i], &target_pressure[i])) {
+              PRINT_INPUT_ERROR("Pressure should be a number.");
+            }
+          }
+          for (int i = 0; i < 6; i++) {
+            if (!is_valid_real(param[12 + i], &elastic_modulus[i])) {
+              PRINT_INPUT_ERROR("elastic modulus should be a number.");
+            }
+            if (elastic_modulus[i] <= 0) {
+              PRINT_INPUT_ERROR("elastic modulus should > 0.");
+            }
+          }
+          num_target_pressure_components = 6;
+          if (box.triclinic == 0) {
+            PRINT_INPUT_ERROR("Must use triclinic box with 6 target pressure components.");
+          }
+          if (box.pbc_x == 0 || box.pbc_y == 0 || box.pbc_z == 0) {
+            PRINT_INPUT_ERROR(
+              "Cannot use 6 pressure components with non-periodic boundary in any direction.");
+          }
+        }
+
+        // pressure_coupling:
+        int index_pressure_coupling = num_target_pressure_components * 2 + 6;
+        if (!is_valid_real(param[index_pressure_coupling], &tau_p)) {
+          PRINT_INPUT_ERROR("Pressure coupling should be a number.");
+        }
+        if (tau_p < 1) {
+          PRINT_INPUT_ERROR("Pressure coupling should >= 1.");
+        }
+        for (int i = 0; i < 6; i++) {
+          pressure_coupling[i] = 1.0 / (tau_p * 3.0 * elastic_modulus[i]);
+        }
       }
     }
   }
@@ -720,6 +810,39 @@ void Integrate::parse_ensemble(
       printf("    initial temperature is %g K.\n", temperature1);
       printf("    final temperature is %g K.\n", temperature2);
       printf("    tau_T is %g time_step.\n", temperature_coupling);
+      if (num_param >= 9) {
+        if (num_target_pressure_components == 1) {
+          printf("    isotropic pressure is %g GPa.\n", target_pressure[0]);
+          printf("    bulk modulus is %g GPa.\n", elastic_modulus[0]);
+        } else if (num_target_pressure_components == 3) {
+          printf("    pressure_xx is %g GPa.\n", target_pressure[0]);
+          printf("    pressure_yy is %g GPa.\n", target_pressure[1]);
+          printf("    pressure_zz is %g GPa.\n", target_pressure[2]);
+          printf("    modulus_xx is %g GPa.\n", elastic_modulus[0]);
+          printf("    modulus_yy is %g GPa.\n", elastic_modulus[1]);
+          printf("    modulus_zz is %g GPa.\n", elastic_modulus[2]);
+        } else if (num_target_pressure_components == 6) {
+          printf("    pressure_xx is %g GPa.\n", target_pressure[0]);
+          printf("    pressure_yy is %g GPa.\n", target_pressure[1]);
+          printf("    pressure_zz is %g GPa.\n", target_pressure[2]);
+          printf("    pressure_yz is %g GPa.\n", target_pressure[3]);
+          printf("    pressure_xz is %g GPa.\n", target_pressure[4]);
+          printf("    pressure_xy is %g GPa.\n", target_pressure[5]);
+          printf("    modulus_xx is %g GPa.\n", elastic_modulus[0]);
+          printf("    modulus_yy is %g GPa.\n", elastic_modulus[1]);
+          printf("    modulus_zz is %g GPa.\n", elastic_modulus[2]);
+          printf("    modulus_yz is %g GPa.\n", elastic_modulus[3]);
+          printf("    modulus_xz is %g GPa.\n", elastic_modulus[4]);
+          printf("    modulus_xy is %g GPa.\n", elastic_modulus[5]);
+        }
+        printf("    tau_p is %g time_step.\n", tau_p);
+
+        // Change the units of pressure form GPa to that used in the code
+        for (int i = 0; i < 6; i++) {
+          target_pressure[i] /= PRESSURE_UNIT_CONVERSION;
+          pressure_coupling[i] *= PRESSURE_UNIT_CONVERSION;
+        }
+      }
       break;
     default:
       PRINT_INPUT_ERROR("Invalid ensemble type.");

--- a/src/model/read_xyz.cu
+++ b/src/model/read_xyz.cu
@@ -153,7 +153,7 @@ static bool need_triclinic()
       if (tokens[0] == "change_box" && tokens.size() == 7) {
         triclinic = true;
       }
-      if (tokens[0] == "ensemble" && tokens.size() == 18) {
+      if (tokens[0] == "ensemble" && tokens.size() >= 18) {
         triclinic = true;
       }
     }


### PR DESCRIPTION
* This PR will implement NPT for PIMD
* Will also add documentation for PIMD, fully resolving issue #79 
* I only made Berendsen barostat working. Perhaps SCR requires nontrivial extension in algorithm.

* Example of isotropic cubic box:
```
potential   Si_Fan_2019.txt
velocity    100

ensemble    pimd 2 100 100 100 -10 100 100
time_step   2
dump_thermo 10
run         2000
```

![image](https://github.com/brucefan1983/GPUMD/assets/24891193/1634f541-b22d-419d-a788-45d656bed0d4)


* Example of orthogonal box:
```
potential   Si_Fan_2019.txt
velocity    100

ensemble    pimd 2 100 100 100 1 2 3 100 100 100 100
time_step   2
dump_thermo 10
run         2000
```
![image](https://github.com/brucefan1983/GPUMD/assets/24891193/cc39fc8e-ae35-4178-ad3a-6280dcc69bc0)


* Example of triclinic box:
```
potential   Si_Fan_2019.txt
velocity    100

ensemble    pimd 2 100 100 100 1 2 3 4 5 6 100 100 100 100 100 100 100
time_step   2
dump_thermo 10
run         2000
```

![image](https://github.com/brucefan1983/GPUMD/assets/24891193/93e000a9-e96b-4336-bf84-e3db8728a103)
