### PR TITLE
Fix version information in doc selection

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,7 @@ process = subprocess.Popen(['git', 'tag'], stdout=subprocess.PIPE)
 stdout, _ = process.communicate()
 versions = [s for s in stdout.decode().split('\n') if len(s)]
 if len(versions) > 0:
-    version = versions[-1].replace('v', '')
+    version = versions[-1]
 else:
     version = ''
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,12 +5,20 @@ import os
 import sys
 import re
 import sphinx_rtd_theme
+import subprocess
 
 project = 'GPUMD'
 author = 'The GPUMD developer team'
-version = ''
+process = subprocess.Popen(['git', 'tag'], stdout=subprocess.PIPE)
+stdout, _ = process.communicate()
 copyright = '2023'
 site_url = 'https://gpumd.org'
+
+versions = [s for s in stdout.decode().split('\n') if len(s)]
+if len(versions) > 0:
+    version = versions[-1].replace('v', '')
+else:
+    version = ''
 
 extensions = [
     'sphinx_sitemap',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,7 +55,7 @@ html_theme_options = {'display_version': True}
 html_context = {
     'current_version': version,
     'versions':
-        [('latest stable release',
+        [('latest release',
           '{}'.format(site_url)),
          ('development version',
           '{}/dev'.format(site_url))]}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,11 +9,11 @@ import subprocess
 
 project = 'GPUMD'
 author = 'The GPUMD developer team'
-process = subprocess.Popen(['git', 'tag'], stdout=subprocess.PIPE)
-stdout, _ = process.communicate()
 copyright = '2023'
 site_url = 'https://gpumd.org'
 
+process = subprocess.Popen(['git', 'tag'], stdout=subprocess.PIPE)
+stdout, _ = process.communicate()
 versions = [s for s in stdout.decode().split('\n') if len(s)]
 if len(versions) > 0:
     version = versions[-1].replace('v', '')


### PR DESCRIPTION
This PR fixes the display of the version in the version selection box in the lower left corner of the documentation.

## Before
<img width="200" alt="Screenshot 2023-05-20 at 20 05 02" src="https://github.com/brucefan1983/GPUMD/assets/19806064/9afe3304-d08d-4fc4-8598-9b78aae861a8">

## Now
<img width="200" alt="Screenshot 2023-05-20 at 20 05 43" src="https://github.com/brucefan1983/GPUMD/assets/19806064/2aa338ac-98da-4a11-9673-4557bd362350">
