### PR TITLE
Fix small bugs in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,11 @@ src/nep*
 *~
 local
 public
+public.*
 \#*
 
 /nep
-/gpumd
+/gpumd*
 
 __pycache__/
 */__pycache__/

--- a/doc/nep/input_parameters/index.rst
+++ b/doc/nep/input_parameters/index.rst
@@ -13,7 +13,7 @@ Below you can find a listing of keywords for the ``nep.in`` input file.
 
    version
    prediction
-   train_mode
+   mode
    type
    type_weight
    zbl

--- a/doc/nep/input_parameters/prediction.rst
+++ b/doc/nep/input_parameters/prediction.rst
@@ -1,4 +1,4 @@
-.. _kw_type:
+.. _kw_prediction:
 .. index::
    single: prediction (keyword in nep.in)
 


### PR DESCRIPTION
This PR introduces small fixes in the documentation that affect the visibility of `nep.in` keywords.

* `nep/mode` is now included in the documentation
* fixed references to `nep/prediction` keyword
* small updates to `.gitignore` file