### PR TITLE
extend to use 8 zbl parameters

### DIFF
--- a/doc/nep/input_parameters/zbl.rst
+++ b/doc/nep/input_parameters/zbl.rst
@@ -18,3 +18,9 @@ The "inner" cutoff of the :term:`ZBL` potential, below which value the pair inte
 When this keyword is absent, the :term:`ZBL` potential will not be enabled and the value of :math:`r_\mathrm{c}^\mathrm{ZBL-outer}` is irrelevant.
 
 Permissible values are 1 Å :math:`\leq r_\mathrm{c}^\mathrm{ZBL-outer} \leq` 2.5 Å
+
+One can also use flexible ZBL parameters by providing a `zbl.in` file in the working directory, in which case the :attr:`<cutoff>` parameter is still needed but will not be used.
+For a :math:`n`-species system, there should be :math:`n(n+1)/2` lines in the `zbl.in` files.
+Each line represents a unique pair of species. 
+Counting from 1, the order of the lines is 1-1, 1-2, ..., 1-:math:`n`, 2-2, 2-3, ..., 2-:math:`n`, :math:`n`-:math:`n`.
+For each pair of species, there are 10 parameters to be listed from left to right: the first two are the inner and outer cutoff radii, respectively; the next 8 are the parameters :math:`a_1` to :math:`a_8` in the ZBL function :math:`\phi(x)=a_1e^{-a_2x}+a_3e^{-a_4x}+a_5e^{-a_6x}+a_7e^{-a_8x}`.

--- a/src/force/nep3.cu
+++ b/src/force/nep3.cu
@@ -312,15 +312,7 @@ NEP3::NEP3(const char* file_potential, const int num_atoms)
   // flexible zbl potential parameters
   if (zbl.flexibled) {
     int num_type_zbl = (paramb.num_types * (paramb.num_types + 1)) / 2;
-    for (int d = 0; d < num_type_zbl; ++d) {
-      tokens = get_tokens(input);
-      zbl.rc_flexible_inner[d] = get_float_from_token(tokens[0], __FILE__, __LINE__);
-    }
-    for (int d = 0; d < num_type_zbl; ++d) {
-      tokens = get_tokens(input);
-      zbl.rc_flexible_outer[d] = get_float_from_token(tokens[0], __FILE__, __LINE__);
-    }
-    for (int d = 0; d < 6 * num_type_zbl; ++d) {
+    for (int d = 0; d < 10 * num_type_zbl; ++d) {
       tokens = get_tokens(input);
       zbl.para[d] = get_float_from_token(tokens[0], __FILE__, __LINE__);
     }
@@ -1021,13 +1013,11 @@ static __global__ void find_force_ZBL(
           t2 = type1;
         }
         int zbl_index = t1 * zbl.num_types - (t1 * (t1 - 1)) / 2 + (t2 - t1);
-        float rc_inner = zbl.rc_flexible_inner[zbl_index];
-        float rc_outer = zbl.rc_flexible_outer[zbl_index];
-        float ZBL_para[6];
-        for (int i = 0; i < 6; ++i) {
-          ZBL_para[i] = zbl.para[6 * zbl_index + i];
+        float ZBL_para[10];
+        for (int i = 0; i < 10; ++i) {
+          ZBL_para[i] = zbl.para[10 * zbl_index + i];
         }
-        find_f_and_fp_zbl(ZBL_para, zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
+        find_f_and_fp_zbl(ZBL_para, zizj, a_inv, d12, d12inv, f, fp);
       } else {
         find_f_and_fp_zbl(zizj, a_inv, zbl.rc_inner, zbl.rc_outer, d12, d12inv, f, fp);
       }

--- a/src/force/nep3.cuh
+++ b/src/force/nep3.cuh
@@ -85,9 +85,7 @@ public:
     bool flexibled = false;
     float rc_inner = 1.0f;
     float rc_outer = 2.0f;
-    float rc_flexible_inner[55];
-    float rc_flexible_outer[55];
-    float para[330];
+    float para[550];
     float atomic_numbers[NUM_ELEMENTS];
     int num_types;
   };

--- a/src/force/nep3_multigpu.cu
+++ b/src/force/nep3_multigpu.cu
@@ -290,15 +290,7 @@ NEP3_MULTIGPU::NEP3_MULTIGPU(
   // flexible zbl potential parameters
   if (zbl.flexibled) {
     int num_type_zbl = (paramb.num_types * (paramb.num_types + 1)) / 2;
-    for (int d = 0; d < num_type_zbl; ++d) {
-      tokens = get_tokens(input);
-      zbl.rc_flexible_inner[d] = get_float_from_token(tokens[0], __FILE__, __LINE__);
-    }
-    for (int d = 0; d < num_type_zbl; ++d) {
-      tokens = get_tokens(input);
-      zbl.rc_flexible_outer[d] = get_float_from_token(tokens[0], __FILE__, __LINE__);
-    }
-    for (int d = 0; d < 6 * num_type_zbl; ++d) {
+    for (int d = 0; d < 10 * num_type_zbl; ++d) {
       tokens = get_tokens(input);
       zbl.para[d] = get_float_from_token(tokens[0], __FILE__, __LINE__);
     }
@@ -1270,13 +1262,11 @@ static __global__ void find_force_ZBL(
           t2 = type1;
         }
         int zbl_index = t1 * zbl.num_types - (t1 * (t1 - 1)) / 2 + (t2 - t1);
-        float rc_inner = zbl.rc_flexible_inner[zbl_index];
-        float rc_outer = zbl.rc_flexible_outer[zbl_index];
-        float ZBL_para[6];
-        for (int i = 0; i < 6; ++i) {
-          ZBL_para[i] = zbl.para[6 * zbl_index + i];
+        float ZBL_para[10];
+        for (int i = 0; i < 10; ++i) {
+          ZBL_para[i] = zbl.para[10 * zbl_index + i];
         }
-        find_f_and_fp_zbl(ZBL_para, zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
+        find_f_and_fp_zbl(ZBL_para, zizj, a_inv, d12, d12inv, f, fp);
       } else {
         find_f_and_fp_zbl(zizj, a_inv, zbl.rc_inner, zbl.rc_outer, d12, d12inv, f, fp);
       }

--- a/src/force/nep3_multigpu.cuh
+++ b/src/force/nep3_multigpu.cuh
@@ -116,9 +116,7 @@ public:
     bool flexibled = false;
     float rc_inner = 1.0f;
     float rc_outer = 2.0f;
-    float rc_flexible_inner[55];
-    float rc_flexible_outer[55];
-    float para[330];
+    float para[550];
     float atomic_numbers[NUM_ELEMENTS];
     int num_types;
   };

--- a/src/force/nep3_small_box.cuh
+++ b/src/force/nep3_small_box.cuh
@@ -738,13 +738,11 @@ static __global__ void find_force_ZBL_small_box(
           t2 = type1;
         }
         int zbl_index = t1 * zbl.num_types - (t1 * (t1 - 1)) / 2 + (t2 - t1);
-        float rc_inner = zbl.rc_flexible_inner[zbl_index];
-        float rc_outer = zbl.rc_flexible_outer[zbl_index];
-        float ZBL_para[6];
-        for (int i = 0; i < 6; ++i) {
-          ZBL_para[i] = zbl.para[6 * zbl_index + i];
+        float ZBL_para[10];
+        for (int i = 0; i < 10; ++i) {
+          ZBL_para[i] = zbl.para[10 * zbl_index + i];
         }
-        find_f_and_fp_zbl(ZBL_para, zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
+        find_f_and_fp_zbl(ZBL_para, zizj, a_inv, d12, d12inv, f, fp);
       } else {
         find_f_and_fp_zbl(zizj, a_inv, zbl.rc_inner, zbl.rc_outer, d12, d12inv, f, fp);
       }

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -283,7 +283,7 @@ void Fitness::write_nep_txt(FILE* fid_nep, Parameters& para, float* elite)
     fprintf(fid_nep, "%15.7e\n", para.q_scaler_cpu[d]);
   }
   if (para.flexible_zbl) {
-    for (int d = 0; d < 8 * (para.num_types * (para.num_types + 1) / 2); ++d) {
+    for (int d = 0; d < 10 * (para.num_types * (para.num_types + 1) / 2); ++d) {
       fprintf(fid_nep, "%15.7e\n", para.zbl_para[d]);
     }
   }

--- a/src/main_nep/nep3.cu
+++ b/src/main_nep/nep3.cu
@@ -273,12 +273,8 @@ NEP3::NEP3(
   if (zbl.flexibled) {
     zbl.num_types = para.num_types;
     int num_type_zbl = (para.num_types * (para.num_types + 1)) / 2;
-    for (int n = 0; n < num_type_zbl; ++n) {
-      zbl.rc_flexible_inner[n] = para.zbl_para[n];
-      zbl.rc_flexible_outer[n] = para.zbl_para[n + num_type_zbl];
-    }
-    for (int n = 0; n < num_type_zbl * 6; ++n) {
-      zbl.para[n] = para.zbl_para[n + 2 * num_type_zbl];
+    for (int n = 0; n < num_type_zbl * 10; ++n) {
+      zbl.para[n] = para.zbl_para[n];
     }
   }
 
@@ -797,13 +793,11 @@ static __global__ void find_force_ZBL(
           t2 = type1;
         }
         int zbl_index = t1 * zbl.num_types - (t1 * (t1 - 1)) / 2 + (t2 - t1);
-        float rc_inner = zbl.rc_flexible_inner[zbl_index];
-        float rc_outer = zbl.rc_flexible_outer[zbl_index];
-        float ZBL_para[6];
-        for (int i = 0; i < 6; ++i) {
-          ZBL_para[i] = zbl.para[6 * zbl_index + i];
+        float ZBL_para[10];
+        for (int i = 0; i < 10; ++i) {
+          ZBL_para[i] = zbl.para[10 * zbl_index + i];
         }
-        find_f_and_fp_zbl(ZBL_para, zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
+        find_f_and_fp_zbl(ZBL_para, zizj, a_inv, d12, d12inv, f, fp);
       } else {
         find_f_and_fp_zbl(zizj, a_inv, zbl.rc_inner, zbl.rc_outer, d12, d12inv, f, fp);
       }

--- a/src/main_nep/nep3.cuh
+++ b/src/main_nep/nep3.cuh
@@ -81,9 +81,7 @@ public:
     float rc_inner = 1.0f;
     float rc_outer = 2.0f;
     int num_types;
-    float rc_flexible_inner[55];
-    float rc_flexible_outer[55];
-    float para[330];
+    float para[550];
     float atomic_numbers[NUM_ELEMENTS];
   };
 

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -94,7 +94,7 @@ void Parameters::set_default_parameters()
   population_size = 50;        // almost optimal
   maximum_generation = 100000; // a good starting point
   type_weight_cpu.resize(NUM_ELEMENTS);
-  zbl_para.resize(440); // Maximum number of zbl parameters
+  zbl_para.resize(550); // Maximum number of zbl parameters
   for (int n = 0; n < NUM_ELEMENTS; ++n) {
     type_weight_cpu[n] = 1.0f; // uniform weight by default
   }
@@ -135,7 +135,7 @@ void Parameters::read_zbl_in()
     flexible_zbl = false;
   } else {
     flexible_zbl = true;
-    for (int n = 0; n < (num_types * (num_types + 1) / 2) * 8; ++n) {
+    for (int n = 0; n < (num_types * (num_types + 1) / 2) * 10; ++n) {
       int count = fscanf(fid_zbl, "%f", &zbl_para[n]);
       PRINT_SCANF_ERROR(count, 1, "Reading error for zbl.in.");
     }

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -143,8 +143,6 @@ static __device__ __forceinline__ void find_f_and_fp_zbl(
   const float* zbl_para,
   const float zizj,
   const float a_inv,
-  const float rc_inner,
-  const float rc_outer,
   const float d12,
   const float d12inv,
   float& f,
@@ -152,15 +150,16 @@ static __device__ __forceinline__ void find_f_and_fp_zbl(
 {
   const float x = d12 * a_inv;
   f = fp = 0.0f;
-  find_phi_and_phip_zbl(zbl_para[0], zbl_para[1], x, f, fp);
   find_phi_and_phip_zbl(zbl_para[2], zbl_para[3], x, f, fp);
   find_phi_and_phip_zbl(zbl_para[4], zbl_para[5], x, f, fp);
+  find_phi_and_phip_zbl(zbl_para[6], zbl_para[7], x, f, fp);
+  find_phi_and_phip_zbl(zbl_para[8], zbl_para[9], x, f, fp);
   f *= zizj;
   fp *= zizj * a_inv;
   fp = fp * d12inv - f * d12inv * d12inv;
   f *= d12inv;
   float fc, fcp;
-  find_fc_and_fcp_zbl(rc_inner, rc_outer, d12, fc, fcp);
+  find_fc_and_fcp_zbl(zbl_para[0], zbl_para[1], d12, fc, fcp);
   fp = fp * fc + f * fcp;
   f *= fc;
 }


### PR DESCRIPTION
* Format of the `zbl.in` file, taking 3 species as an example:
```
rc_inner_00  rc_outer_00   <8 parameters for 00 type pair>
rc_inner_01  rc_outer_01   <8 parameters for 01 type pair>
rc_inner_02  rc_outer_02   <8 parameters for 02 type pair>
rc_inner_11  rc_outer_11   <8 parameters for 11 type pair>
rc_inner_12  rc_outer_12   <8 parameters for 12 type pair>
rc_inner_22  rc_outer_22   <8 parameters for 22 type pair>
```

* The universal ZBL version
```
zbl 2.5 # and no a zbl.in file in the working directory
```
is equivalent to the flexible ZBL version:
```
zbl <arbitrary_cutoff_that_will_not_be_used> # and with a zbl.in file in the working directory
```
The `zbl.in` file reads:
```
1.25 2.5 0.18175 3.1998 0.50986 0.94229 0.28022 0.4029 0.02817 0.20162
1.25 2.5 0.18175 3.1998 0.50986 0.94229 0.28022 0.4029 0.02817 0.20162
1.25 2.5 0.18175 3.1998 0.50986 0.94229 0.28022 0.4029 0.02817 0.20162
```
