### PR TITLE
improve documentation before releasing GPUMD-v3.9

### DIFF
--- a/doc/bibliography.rst
+++ b/doc/bibliography.rst
@@ -177,6 +177,18 @@ Bibliography
    | *How to remove the spurious resonances from ring polymer molecular dynamics*
    | J. Chem. Phys. **140**, 234116 (2014)
    | DOI: `10.1063/1.4883861 <https://doi.org/10.1063/1.4883861>`_
+   
+.. [Sadigh2012a]
+   | Babak Sadigh, Paul Erhart, Alexander Stukowski, Alfredo Caro, Enrique Martinez, and Luis Zepeda-Ruiz
+   | *Scalable parallel Monte Carlo algorithm for atomistic simulations of precipitation in alloys*
+   | Phys. Rev. B **85**, 184203 (2012)
+   | DOI: `10.1103/PhysRevB.85.184203 <https://doi.org/10.1103/PhysRevB.85.184203>`_
+
+.. [Sadigh2012b]
+   | Babak Sadigh and Paul Erhart
+   | *Calculation of excess free energies of precipitates via direct thermodynamic integration across phase boundaries*
+   | Phys. Rev. B **86**, 134204 (2012)
+   | DOI: `10.1103/PhysRevB.86.134204 <https://doi.org/10.1103/PhysRevB.86.134204>`_
 
 .. [Schaul2011]
    | T. Schaul, T. Glasmachers, and J. Schmidhuber

--- a/doc/bibliography.rst
+++ b/doc/bibliography.rst
@@ -100,6 +100,12 @@ Bibliography
    | Phys. Rev. B. **104**, 104309 (2021)
    | DOI: `10.1103/PhysRevB.104.104309 <https://doi.org/10.1103/PhysRevB.104.104309>`_
 
+.. [Fan2021b]
+   | Zheyong Fan, Jose Hugo Garcia, Aron W Cummings, Jose Eduardo Barrios-Vargas, Michel Panhans, Ari Harju, Frank Ortmann, and Stephan Roche
+   | *Linear scaling quantum transport methodologies*
+   | Physics Reports **903**, 1 (2021)
+   | DOI: `10.1016/j.physrep.2020.12.001 <https://doi.org/10.1016/j.physrep.2020.12.001>`_
+
 .. [Fan2022a]
    | Zheyong Fan
    | *Improving the accuracy of the neuroevolution machine learning potentials for multi-component systems*

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -77,6 +77,9 @@ Glossary
    PIMD
         path-integral molecular dynamics
 
+   RDF
+        radial distribution function
+
    RMSE
         `root-mean-square error <https://en.wikipedia.org/wiki/Root-mean-square_deviation>`_
 

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -47,6 +47,9 @@ Glossary
    LJ
         :ref:`Lennard-Jones <lennard_jones_potential>` potential
 
+   MC
+        Monte Carlo
+
    MD
         molecular dynamics
 
@@ -89,6 +92,9 @@ Glossary
    SDC
         self-diffusion coefficient
 
+   SGC
+        semi-grand canonical
+
    SHC
         spectral heat current
 
@@ -103,6 +109,9 @@ Glossary
 
    VAC
         velocity auto-correlation
+
+   VCSGC
+        variance-constrained semi-grand canonical [Sadigh2012a]_ [Sadigh2012b]_
 
    ZBL
         universal potential by Ziegler, Biersack, and Littmark [Ziegler1985]_

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -47,6 +47,9 @@ Glossary
    LJ
         :ref:`Lennard-Jones <lennard_jones_potential>` potential
 
+   LSQT
+        linear-scaling quantum transport
+
    MC
         Monte Carlo
 

--- a/doc/gpumd/input_parameters/compute_lsqt.rst
+++ b/doc/gpumd/input_parameters/compute_lsqt.rst
@@ -21,7 +21,7 @@ This keyword is used as follows::
 * :attr:`transport_direction` is the transport direction, which can take values ``x``, ``y``, and ``z``.
 * :attr:`num_moments` is the number of the Chebyshev moments for the energy resolution operator.
 * The :attr:`num_energies` energy points increase linearly from :attr:`E_1` (eV) to :attr:`E_2` (eV).
-* :attr:`E_max` (eV) is an energy value taht should be (slightly) larger than the maximum of the absolute energy of the tight-binding model. This can be determined by trial and error.
+* :attr:`E_max` (eV) is an energy value that should be (slightly) larger than the maximum of the absolute energy of the tight-binding model. This can be determined by trial and error.
 
 Example
 -------

--- a/doc/gpumd/input_parameters/compute_lsqt.rst
+++ b/doc/gpumd/input_parameters/compute_lsqt.rst
@@ -18,7 +18,7 @@ This keyword is used as follows::
 
   compute_lsqt <transport_direction> <num_moments> <num_energies> <E_1> <E_2> <E_max>
 
-* :attr:`transport_direction` is the transport direction, which can take values x, y, and z.
+* :attr:`transport_direction` is the transport direction, which can take values ``x``, ``y``, and ``z``.
 * :attr:`num_moments` is the number of the Chebyshev moments for the energy resolution operator.
 * The :attr:`num_energies` energy points increase linearly from :attr:`E_1` (eV) to :attr:`E_2` (eV).
 * :attr:`E_max` (eV) is an energy value taht should be (slightly) larger than the maximum of the absolute energy of the tight-binding model. This can be determined by trial and error.

--- a/doc/gpumd/input_parameters/compute_lsqt.rst
+++ b/doc/gpumd/input_parameters/compute_lsqt.rst
@@ -1,0 +1,29 @@
+.. _kw_compute_lsqt:
+.. index::
+   single: compute_lsqt (keyword in run.in)
+
+:attr:`compute_lsqt`
+====================
+
+This keyword is used to compute the electronic transport properties using the linear-scaling quantum transport (:term:`LSQT`) [Fan2021b]_ approach.
+The :term:`LSQT` and :term:`MD` are coupled to account for electron-phonon scattering. 
+Currently, only a tight-binding model for carbon is supported (hard coded).
+The results will be written into the files lsqt_dos.out, lsqt_velocity.out, and lsqt_sigma.out.
+This feature is preliminary and changes might be made in the near future.
+
+Syntax
+------
+
+This keyword is used as follows::
+
+  compute_lsqt <transport_direction> <num_moments> <num_energies> <E_1> <E_2> <E_max>
+
+* :attr:`transport_direction` is the transport direction, which can take values x, y, and z.
+* :attr:`num_moments` is the number of the Chebyshev moments for the energy resolution operator.
+* The :attr:`num_energies` energy points increase linearly from :attr:`E_1` (eV) to :attr:`E_2` (eV).
+* :attr:`E_max` (eV) is an energy value taht should be (slightly) larger than the maximum of the absolute energy of the tight-binding model. This can be determined by trial and error.
+
+Example
+-------
+
+   compute_lsqt x 3000 10001 -8.1 8.1 8.2

--- a/doc/gpumd/input_parameters/compute_lsqt.rst
+++ b/doc/gpumd/input_parameters/compute_lsqt.rst
@@ -6,7 +6,7 @@
 ====================
 
 This keyword is used to compute the electronic transport properties using the linear-scaling quantum transport (:term:`LSQT`) [Fan2021b]_ approach.
-The :term:`LSQT` and :term:`MD` are coupled to account for electron-phonon scattering. 
+:term:`LSQT` and :term:`MD` are coupled to account for electron-phonon scattering. 
 Currently, only a tight-binding model for carbon is supported (hard coded).
 The results will be written into the files lsqt_dos.out, lsqt_velocity.out, and lsqt_sigma.out.
 This feature is preliminary and changes might be made in the near future.

--- a/doc/gpumd/input_parameters/compute_rdf.rst
+++ b/doc/gpumd/input_parameters/compute_rdf.rst
@@ -1,0 +1,27 @@
+.. _kw_compute_rdf:
+.. index::
+   single: compute_rdf (keyword in run.in)
+
+:attr:`compute_rdf`
+===================
+
+This keyword is used to compute the radial distribution function (:term:`RDF`) for the whole system or pairs of species. It works for both classical :term:`MD` and :term:`PIMD`.
+
+Syntax
+------
+
+This keyword is used as follows::
+
+  compute_rdf <cutoff> <num_bins> <interval> [atom <i1> <i2> atom <i3> <i4> ...]
+
+This means that the :term:`RDF` calculations will be performed every :attr:`interval` steps, with :attr:`num_bins`data points evenly distributed from 0 to :attr:`cutoff` (in units of Angstrom) in terms the distance between atom pairs.
+
+Without the optional parameters, only the total :term:`RDF` will be calculated.
+
+To additionally calculate the partial :term:`RDF` for a pair of species, one can specify the types of the two species after the word "atom". The types 0, 1, 2, ... correspond to the species in the potential file in order. Currently, one can specify at most 6 pairs. 
+
+Example
+-------
+
+   compute_rdf 8.0 400 1000 # total RDF every 1000 MD steps with 400 data up to 8 Angstrom
+   compute_rdf 8.0 400 1000 atom 0 0 atom 1 1 atom 0 1 # additionally calculate 3 partial RDFs

--- a/doc/gpumd/input_parameters/compute_rdf.rst
+++ b/doc/gpumd/input_parameters/compute_rdf.rst
@@ -5,7 +5,7 @@
 :attr:`compute_rdf`
 ===================
 
-This keyword is used to compute the radial distribution function (:term:`RDF`) for the whole system or pairs of species. 
+This keyword is used to compute the radial distribution function (:term:`RDF`) for all atoms or pairs of species. 
 It works for both classical :term:`MD` and :term:`PIMD`.
 The results will be written to the :ref:`rdf.out <rdf_out>` file.
 

--- a/doc/gpumd/input_parameters/compute_rdf.rst
+++ b/doc/gpumd/input_parameters/compute_rdf.rst
@@ -5,7 +5,9 @@
 :attr:`compute_rdf`
 ===================
 
-This keyword is used to compute the radial distribution function (:term:`RDF`) for the whole system or pairs of species. It works for both classical :term:`MD` and :term:`PIMD`.
+This keyword is used to compute the radial distribution function (:term:`RDF`) for the whole system or pairs of species. 
+It works for both classical :term:`MD` and :term:`PIMD`.
+The results will be written to the :ref:`rdf.out <rdf_out>` file.
 
 Syntax
 ------

--- a/doc/gpumd/input_parameters/dump_exyz.rst
+++ b/doc/gpumd/input_parameters/dump_exyz.rst
@@ -12,20 +12,25 @@ Syntax
 
 .. code::
 
+   dump_exyz <interval> <has_velocity>
    dump_exyz <interval> <has_velocity> <has_force>
+   dump_exyz <interval> <has_velocity> <has_force> <has_potential>
 
 Here, the :attr:`interval` parameter is the output interval (number of steps) of the data.
 :attr:`has_velocity` can be 1 or 0, which means the velocities will or will not be included in the output.
 :attr:`has_force` can be 1 or 0, which means the forces will or will not be included in the output.
+:attr:`has_potential` can be 1 or 0, which means the atomic potentials will or will not be included in the output.
+Atom positions will always be included in the output.
 
 Examples
 --------
-
-To dump the positions, velocities, and forces every 1000 steps for a run, one can add::
-
-  dump_exyz 1000 1 1
-
-before the :ref:`run keyword <kw_run>`.
+    # ensemble keyword here
+    dump_exyz 1000 # dump positions every 1000 steps
+    dump_exyz 1000 1 # dump positions and velocities
+    dump_exyz 1000 1 1 # dump positions, velocities, and forces
+    dump_exyz 1000 1 1 1 # dump positions, velocities, forces, and potentials
+    dump_exyz 1000 0 1 1 # dump positions, forces and potentials
+    run 1000000
 
 Caveats
 -------

--- a/doc/gpumd/input_parameters/electron_stop.rst
+++ b/doc/gpumd/input_parameters/electron_stop.rst
@@ -1,0 +1,25 @@
+.. _kw_electron_stop:
+.. index::
+   single: electron_stop (keyword in run.in)
+
+:attr:`electron_stop`
+=====================
+
+This keyword is used to apply electron stopping forces to high-energy atoms during a run. This is usually used in radiation damage simulations.
+
+Syntax
+------
+
+This keyword is used as follows::
+
+  electron_stop <file>
+
+Here, :attr:`file` is the file containing a table of the stopping power data.
+The first line of the file should have 3 values: the first is the number of data points to be listed :math:`N`; the second is the minimum of the energy range :math:`E_{\rm min}`; the third is the maximum of the energy range :math:`E_{\rm max}`. The stopping power data listed after this line should have :math:`N` lines, each corresponding to one energy, which increases linearly from :math:`E_{\rm min}` to :math:`E_{\rm max}` with an interval of :math:`(E_{\rm max} - E_{\rm min})/(N-1)`. For these :math:`N` lines, the number of columns is the number of species for the used potential. That is, each species should have a column of stopping power data in this file. The order of the species here should follow that as defined in the potential file.
+
+Example
+-------
+
+An example is::
+
+   electron_stop my_stopping_power.txt

--- a/doc/gpumd/input_parameters/index.rst
+++ b/doc/gpumd/input_parameters/index.rst
@@ -26,6 +26,8 @@ Below you can find a listing of keywords for the ``run.in`` input file.
    fix
    time_step
    plumed
+   mc
+   electron_stop
 
 .. toctree::
    :maxdepth: 1
@@ -47,6 +49,8 @@ Below you can find a listing of keywords for the ``run.in`` input file.
    compute_msd
    compute_shc
    compute_viscosity
+   compute_lsqt
+   compute_rdf
 
 .. toctree::
    :maxdepth: 1

--- a/doc/gpumd/input_parameters/mc.rst
+++ b/doc/gpumd/input_parameters/mc.rst
@@ -88,7 +88,7 @@ This means that
 Example 3
 ---------
 
-Here is an example for using the :term:`VCSGC` :term:`MC` ensemble:
+Here is an example for sampling in the :term:`VCSGC` ensemble:
   
   ensemble nvt_lan 300 300 100
   # other keywords for the run

--- a/doc/gpumd/input_parameters/mc.rst
+++ b/doc/gpumd/input_parameters/mc.rst
@@ -5,18 +5,76 @@
 :attr:`mc`
 ==========
 
-This keyword is used to invoke the monte carlo (MC) simulation, usually in combination with the MD simulation. 
-Three MC ensembles are supported, including the canonical, the semi-grand canonical (SGC), and the variance-constrained semi-grand canonical (VCSGC) [CITE] ones. 
+The :attr:`mc` keyword is used to invoke monte carlo (:term:`MC`) simulation, usually in combination with :term:`MD` simulation. 
+Three :term:`MC` ensembles are supported, including the canonical, the semi-grand canonical (:term:`SGC`), and the variance-constrained semi-grand canonical (:term:`VCSGC`) [Sadigh2012a]_ [Sadigh2012b]_ ones. 
+
+This keyword can only be used when the potential is :term:`NEP`.
 
 Syntax
 ------
 
-- SGC ensemble:
+:attr:`canonical`
+^^^^^^^^^^^^^^^^^
+If the first parameter is :attr:`canonical`, it means to use the canonical :term:`MC` ensemble.
 
-  mc sgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {species_0 mu_0 species_1 mu_1 ...} [group <grouping_method>  <group_id>]
+It can be used in the following way::
+
+    mc canonical <md_steps> <mc_trials> <T_i> <T_f> [group <grouping_method> <group_id>]
+
+:attr:`sgc`
+^^^^^^^^^^^
+If the first parameter is :attr:`sgc`, it means to use the :term:`SGC` :term:`MC` ensemble.
+
+It can be used in the following way::
+
+    mc sgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {species_0 mu_0 species_1 mu_1 ...} [group <grouping_method>  <group_id>]
+
+:attr:`vcsgc`
+^^^^^^^^^^^
+If the first parameter is :attr:`vcsgc`, it means to use the :term:`VCSGC` :term:`MC` ensemble.
+
+It can be used in the following way::
+
+    mc vcsgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {species_0 phi_0 species_1 phi_1 ...} kappa [group <grouping_method>  <group_id>]
+
+* :attr:`mc_trials`: :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps.
+
+* The instant temperature for the :term:`MC` ensemble will linearly change from attr:`T_i` to attr:`T_f`.
+
+* :attr:`num_species` is the number of species to be involved in the :term:`SGC` or :term:`	VCSGC` ensemble. 
+It is required to be no less than 2 and no larger than 4.
+
+* For the :term:`SGC` ensemble, after specifying the number of species to be involved, the chemical symbols and chemical potentials for these species should be listed, in an arbitrary order.
+
+* For the :term:`VCSGC` ensemble, after specifying the number of species to be involved, the chemical symbols and (dimensionless) :math:`\phi` parameters for these species should be listed, in an arbitrary order. 
+One then needs to specify the (dimensionless) :math:`\kappa` parameter.
+The :math:`\phi` and :math:`\kappa` parameters constrain the average and variance of the species concentrations, respectively.
+(Do we need to cite papers for the exact definitions of these parameters?)
+
+* The listed species must be supported by the :term:`NEP` model.
+
+* For all the :term:`MC` ensembles, there is an option to specify the grouping method :atrr:`grouping_method` and the group ID :atrr:`group_id` in the given grouping method, after the parameter :atrr:`group`. See the examples below for concrete illustrations.
+
+* There must have at least one listed species in the initial model system or specified group. 
+For example, if you list Au and Cu for doing :term:`SGC` :term:`MC`, the system/group must have some Au or Cu atoms (or both); otherwise the :term:`MC` trail cannot get started.
+
+Example 1
+---------
+
+An example for using the canonical :term:`MC` ensemble is
   
-- VCSGC ensemble:
+  ensemble nvt_lan 300 300 100
+  # other keywords for the run
+  mc canonical 100 200 500 100 group 1 3
+  run 1000000
 
-  mc vcsgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {species_0 phi_0 species_1 phi_1 ...} kappa [group <grouping_method>  <group_id>]
-  
+This means that
 
+* Will perform 200 :term:`MC` trials after every 100 :term:`MD` steps.
+* The temperature for the :term:`MC` ensemble will be linearly changed from 500 to 300 K, even though the temperature for the :term:`MD` ensemble is kept to be 300 K.
+* Only the atom in group 3 of grouping method 1 will be involved in the :term:`MC` process. 
+
+Example 2
+---------
+
+TODO

--- a/doc/gpumd/input_parameters/mc.rst
+++ b/doc/gpumd/input_parameters/mc.rst
@@ -97,7 +97,7 @@ Here is an example for using the :term:`VCSGC` :term:`MC` ensemble:
 
 This means
 
-* Will perform 1000 :term:`MC` trials after every 200 :term:`MD` steps.
+* Perform 1000 :term:`MC` trials after every 200 :term:`MD` steps.
 * The temperature for the :term:`MC` ensemble will be kept at 500 K.
 * Only the Al and Ag atoms are involved in the :term:`MC` process.
   The dimensionless :math:`\phi` parameters for Al and Ag are -2 and 0, respectively.

--- a/doc/gpumd/input_parameters/mc.rst
+++ b/doc/gpumd/input_parameters/mc.rst
@@ -1,0 +1,14 @@
+.. _kw_mc:
+.. index::
+   single: mc (keyword in run.in)
+
+:attr:`mc`
+==========
+
+This keyword is used to invoke the monte carlo (MC) simulation, usually in combination with the MD simulation. 
+
+Syntax
+------
+
+  mc todo
+

--- a/doc/gpumd/input_parameters/mc.rst
+++ b/doc/gpumd/input_parameters/mc.rst
@@ -6,9 +6,17 @@
 ==========
 
 This keyword is used to invoke the monte carlo (MC) simulation, usually in combination with the MD simulation. 
+Three MC ensembles are supported, including the canonical, the semi-grand canonical (SGC), and the variance-constrained semi-grand canonical (VCSGC) [CITE] ones. 
 
 Syntax
 ------
 
-  mc todo
+- SGC ensemble:
+
+  mc sgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {species_0 mu_0 species_1 mu_1 ...} [group <grouping_method>  <group_id>]
+  
+- VCSGC ensemble:
+
+  mc vcsgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {species_0 phi_0 species_1 phi_1 ...} kappa [group <grouping_method>  <group_id>]
+  
 

--- a/doc/gpumd/input_parameters/mc.rst
+++ b/doc/gpumd/input_parameters/mc.rst
@@ -37,26 +37,21 @@ It can be used in the following way::
 
     mc vcsgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {species_0 phi_0 species_1 phi_1 ...} kappa [group <grouping_method>  <group_id>]
 
-* :attr:`mc_trials`: :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps.
+* :attr:`mc_trials` :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps.
 
 * The instant temperature for the :term:`MC` ensemble will linearly change from attr:`T_i` to attr:`T_f`.
 
-* :attr:`num_species` is the number of species to be involved in the :term:`SGC` or :term:`	VCSGC` ensemble. 
-It is required to be no less than 2 and no larger than 4.
+* :attr:`num_species` is the number of species to be involved in the :term:`SGC` or :term:`VCSGC` ensemble. It is required to be no less than 2 and no larger than 4.
 
 * For the :term:`SGC` ensemble, after specifying the number of species to be involved, the chemical symbols and chemical potentials for these species should be listed, in an arbitrary order.
 
-* For the :term:`VCSGC` ensemble, after specifying the number of species to be involved, the chemical symbols and (dimensionless) :math:`\phi` parameters for these species should be listed, in an arbitrary order. 
-One then needs to specify the (dimensionless) :math:`\kappa` parameter.
-The :math:`\phi` and :math:`\kappa` parameters constrain the average and variance of the species concentrations, respectively.
-(Do we need to cite papers for the exact definitions of these parameters?)
+* For the :term:`VCSGC` ensemble, after specifying the number of species to be involved, the chemical symbols and (dimensionless) :math:`\phi` parameters for these species should be listed, in an arbitrary order. One then needs to specify the (dimensionless) :math:`\kappa` parameter. The :math:`\phi` and :math:`\kappa` parameters constrain the average and variance of the species concentrations, respectively. (Do we need to cite papers for the exact definitions of these parameters?)
 
 * The listed species must be supported by the :term:`NEP` model.
 
 * For all the :term:`MC` ensembles, there is an option to specify the grouping method :atrr:`grouping_method` and the group ID :atrr:`group_id` in the given grouping method, after the parameter :atrr:`group`. See the examples below for concrete illustrations.
 
-* There must have at least one listed species in the initial model system or specified group. 
-For example, if you list Au and Cu for doing :term:`SGC` :term:`MC`, the system/group must have some Au or Cu atoms (or both); otherwise the :term:`MC` trail cannot get started.
+* There must be at least one listed species in the initial model system or specified group. For example, if you list Au and Cu for doing :term:`SGC` :term:`MC`, the system or the specified group must have some Au or Cu atoms (or both); otherwise the :term:`MC` trial cannot get started.
 
 Example 1
 ---------
@@ -72,7 +67,7 @@ This means that
 
 * Will perform 200 :term:`MC` trials after every 100 :term:`MD` steps.
 * The temperature for the :term:`MC` ensemble will be linearly changed from 500 to 300 K, even though the temperature for the :term:`MD` ensemble is kept to be 300 K.
-* Only the atom in group 3 of grouping method 1 will be involved in the :term:`MC` process. 
+* Only the atoms in group 3 of grouping method 1 will be involved in the :term:`MC` process. 
 
 Example 2
 ---------

--- a/doc/gpumd/input_parameters/mc.rst
+++ b/doc/gpumd/input_parameters/mc.rst
@@ -5,7 +5,7 @@
 :attr:`mc`
 ==========
 
-The :attr:`mc` keyword is used to invoke monte carlo (:term:`MC`) simulation, usually in combination with :term:`MD` simulation. 
+The :attr:`mc` keyword is used to invoke Monte Carlo (:term:`MC`) simulation, usually in combination with :term:`MD` simulation. 
 Three :term:`MC` ensembles are supported, including the canonical, the semi-grand canonical (:term:`SGC`), and the variance-constrained semi-grand canonical (:term:`VCSGC`) [Sadigh2012a]_ [Sadigh2012b]_ ones. 
 
 This keyword can only be used when the potential is :term:`NEP`.

--- a/doc/gpumd/input_parameters/mc.rst
+++ b/doc/gpumd/input_parameters/mc.rst
@@ -43,7 +43,7 @@ It can be used in the following way::
 
 * :attr:`num_species` is the number of species to be involved in the :term:`SGC` or :term:`VCSGC` ensemble. It is required to be no less than 2 and no larger than 4.
 
-* For the :term:`SGC` ensemble, after specifying the number of species to be involved, the chemical symbols and chemical potentials for these species should be listed, in an arbitrary order.
+* For the :term:`SGC` ensemble, after specifying the number of species to be involved, the chemical symbols and chemical potentials (in units of eV) for these species should be listed, in an arbitrary order.
 
 * For the :term:`VCSGC` ensemble, after specifying the number of species to be involved, the chemical symbols and (dimensionless) :math:`\phi` parameters for these species should be listed, in an arbitrary order. One then needs to specify the (dimensionless) :math:`\kappa` parameter. The :math:`\phi` and :math:`\kappa` parameters constrain the average and variance of the species concentrations, respectively. (Do we need to cite papers for the exact definitions of these parameters?)
 
@@ -72,4 +72,31 @@ This means that
 Example 2
 ---------
 
-TODO
+Here is an example for using the :term:`SGC` :term:`MC` ensemble:
+  
+  ensemble nvt_lan 300 300 100
+  # other keywords for the run
+  mc sgc 100 1000 300 300 2 Cu 0 Au 0.6
+  run 1000000
+
+This means that
+
+* Will perform 1000 :term:`MC` trials after every 100 :term:`MD` steps.
+* The temperature for the :term:`MC` ensemble will be kept at 300 K.
+* Only the Cu and Au atoms are involved in the :term:`MC` process. The Au atoms have a chemical potential of 0.6 eV relative to the Cu atoms.
+
+Example 3
+---------
+
+Here is an example for using the :term:`VCSGC` :term:`MC` ensemble:
+  
+  ensemble nvt_lan 300 300 100
+  # other keywords for the run
+  mc vcsgc 200 1000 500 500 2 Al -2 Ag 0 10000
+  run 1000000
+
+This means that
+
+* Will perform 1000 :term:`MC` trials after every 200 :term:`MD` steps.
+* The temperature for the :term:`MC` ensemble will be kept at 500 K.
+* Only the Al and Ag atoms are involved in the :term:`MC` process. The dimensionless :math:`\phi` parameters for Al and Ag are -2 and 0, respectively. The dimensionless :math:`\kappa` parameter is 10000.

--- a/doc/gpumd/input_parameters/mc.rst
+++ b/doc/gpumd/input_parameters/mc.rst
@@ -99,4 +99,6 @@ This means
 
 * Will perform 1000 :term:`MC` trials after every 200 :term:`MD` steps.
 * The temperature for the :term:`MC` ensemble will be kept at 500 K.
-* Only the Al and Ag atoms are involved in the :term:`MC` process. The dimensionless :math:`\phi` parameters for Al and Ag are -2 and 0, respectively. The dimensionless :math:`\kappa` parameter is 10000.
+* Only the Al and Ag atoms are involved in the :term:`MC` process.
+  The dimensionless :math:`\phi` parameters for Al and Ag are -2 and 0, respectively.
+  The dimensionless :math:`\kappa` parameter is 10000.

--- a/doc/gpumd/input_parameters/mc.rst
+++ b/doc/gpumd/input_parameters/mc.rst
@@ -95,7 +95,7 @@ Here is an example for using the :term:`VCSGC` :term:`MC` ensemble:
   mc vcsgc 200 1000 500 500 2 Al -2 Ag 0 10000
   run 1000000
 
-This means that
+This means
 
 * Will perform 1000 :term:`MC` trials after every 200 :term:`MD` steps.
 * The temperature for the :term:`MC` ensemble will be kept at 500 K.

--- a/doc/gpumd/output_files/index.rst
+++ b/doc/gpumd/output_files/index.rst
@@ -123,7 +123,7 @@ Output files
      - Append
    * - :ref:`lsqt_velocity.out <lsqt_velocity_out>`
      - :ref:`compute_lsqt <kw_compute_lsqt>`
-     - Electron group veloicty
+     - Electron group velocity
      - Append
    * - :ref:`lsqt_sigma.out <lsqt_sigma_out>`
      - :ref:`compute_lsqt <kw_compute_lsqt>`

--- a/doc/gpumd/output_files/index.rst
+++ b/doc/gpumd/output_files/index.rst
@@ -109,6 +109,10 @@ Output files
      - :ref:`compute_hnemdec <kw_compute_hnemdec>`
      - onsager coefficients
      - Append
+   * - :ref:`rdf.out <rdf_out>`
+     - :ref:`compute_rdf <kw_compute_rdf>`
+     - Radial distribution function (:term:`RDF`)
+     - Append
 
 .. toctree::
    :maxdepth: 0
@@ -139,3 +143,4 @@ Output files
    velocity_out
    viscosity_out
    onsager_out
+   rdf_out

--- a/doc/gpumd/output_files/index.rst
+++ b/doc/gpumd/output_files/index.rst
@@ -113,6 +113,10 @@ Output files
      - :ref:`compute_rdf <kw_compute_rdf>`
      - Radial distribution function (:term:`RDF`)
      - Append
+    * - :ref:`mcmd.out <mcmd_out>`
+     - :ref:`mc <kw_mc>`
+     - Acceptance ratio and species concentrations
+     - Append
 
 .. toctree::
    :maxdepth: 0

--- a/doc/gpumd/output_files/index.rst
+++ b/doc/gpumd/output_files/index.rst
@@ -113,9 +113,21 @@ Output files
      - :ref:`compute_rdf <kw_compute_rdf>`
      - Radial distribution function (:term:`RDF`)
      - Append
-    * - :ref:`mcmd.out <mcmd_out>`
+   * - :ref:`mcmd.out <mcmd_out>`
      - :ref:`mc <kw_mc>`
      - Acceptance ratio and species concentrations
+     - Append
+   * - :ref:`lsqt_dos.out <lsqt_dos_out>`
+     - :ref:`compute_lsqt <kw_compute_lsqt>`
+     - Electronic density of states
+     - Append
+   * - :ref:`lsqt_velocity.out <lsqt_velocity_out>`
+     - :ref:`compute_lsqt <kw_compute_lsqt>`
+     - Electron group veloicty
+     - Append
+   * - :ref:`lsqt_sigma.out <lsqt_sigma_out>`
+     - :ref:`compute_lsqt <kw_compute_lsqt>`
+     - Electrical conductivity
      - Append
 
 .. toctree::
@@ -148,3 +160,7 @@ Output files
    viscosity_out
    onsager_out
    rdf_out
+   mcmd_out
+   lsqt_dos_out
+   lsqt_velocity_out
+   lsqt_sigma_out

--- a/doc/gpumd/output_files/index.rst
+++ b/doc/gpumd/output_files/index.rst
@@ -107,7 +107,7 @@ Output files
      - Append
    * - :ref:`onsager.out <onsager_out>`
      - :ref:`compute_hnemdec <kw_compute_hnemdec>`
-     - onsager coefficients
+     - Onsager coefficients
      - Append
    * - :ref:`rdf.out <rdf_out>`
      - :ref:`compute_rdf <kw_compute_rdf>`

--- a/doc/gpumd/output_files/lsqt_dos.rst
+++ b/doc/gpumd/output_files/lsqt_dos.rst
@@ -1,0 +1,18 @@
+.. _lsqt_dos_out:
+.. index::
+   single: lsqt_dos.out (output file)
+
+``lsqt_dos.out``
+================
+
+This file contains the electronic density of states (:term:`DOS`) from linear-scaling quantum transport (:term:`LSQT`) calculations.
+It is produced when invoking the :ref:`compute_lsqt keyword <kw_compute_lsqt>` in the :ref:`run.in input file <run_in>`.
+
+File format
+-----------
+
+* Each row contains the :term:`DOS` values (in units of states/atom/eV) for the specified energies.
+
+* The number of columns equals the number of energy points. 
+
+* Different rows are from different time points in the :term:`MD` simulation (supposed to be an equilibrium one), which can be averaged.

--- a/doc/gpumd/output_files/lsqt_sigma.rst
+++ b/doc/gpumd/output_files/lsqt_sigma.rst
@@ -1,0 +1,18 @@
+.. _lsqt_sigma_out:
+.. index::
+   single: lsqt_sigma.out (output file)
+
+``lsqt_sigma.out``
+==================
+
+This file contains the running electrical conductivity :math:`\Sigma(E,t)` as a function of energy :math:`E` and correlatioon time :math:`t`, from linear-scaling quantum transport (:term:`LSQT`) calculations.
+It is produced when invoking the :ref:`compute_lsqt keyword <kw_compute_lsqt>` in the :ref:`run.in input file <run_in>`.
+
+File format
+-----------
+
+* The number of columns equals the number of energy points. The energy values can be inferred from the parameters to the :ref:`compute_lsqt keyword <kw_compute_lsqt>`.
+
+* The number of rows equals the product of the number of :term:`MD` steps for one run and the number of independent runs (supposed to be equilibrium ones), and the results from different runs can thus be averaged to reduce the statistical uncertainties.
+
+* The electrical conductivity :math:`\Sigma(E,t)` values are in units of S/m.

--- a/doc/gpumd/output_files/lsqt_sigma.rst
+++ b/doc/gpumd/output_files/lsqt_sigma.rst
@@ -5,7 +5,7 @@
 ``lsqt_sigma.out``
 ==================
 
-This file contains the running electrical conductivity :math:`\Sigma(E,t)` as a function of energy :math:`E` and correlatioon time :math:`t`, from linear-scaling quantum transport (:term:`LSQT`) calculations.
+This file contains the running electrical conductivity :math:`\Sigma(E,t)` as a function of energy :math:`E` and correlation time :math:`t`, from linear-scaling quantum transport (:term:`LSQT`) calculations.
 It is produced when invoking the :ref:`compute_lsqt keyword <kw_compute_lsqt>` in the :ref:`run.in input file <run_in>`.
 
 File format
@@ -15,4 +15,4 @@ File format
 
 * The number of rows equals the product of the number of :term:`MD` steps for one run and the number of independent runs (supposed to be equilibrium ones), and the results from different runs can thus be averaged to reduce the statistical uncertainties.
 
-* The electrical conductivity :math:`\Sigma(E,t)` values are in units of S/m.
+* The electrical conductivity values are in units of S/m.

--- a/doc/gpumd/output_files/lsqt_velocity.rst
+++ b/doc/gpumd/output_files/lsqt_velocity.rst
@@ -1,0 +1,20 @@
+.. _lsqt_velocity_out:
+.. index::
+   single: lsqt_velocity.out (output file)
+
+``lsqt_velocity.out``
+=====================
+
+This file contains the group velocity from linear-scaling quantum transport (:term:`LSQT`) calculations.
+It is produced when invoking the :ref:`compute_lsqt keyword <kw_compute_lsqt>` in the :ref:`run.in input file <run_in>`.
+
+File format
+-----------
+
+* Each row contains the group velocity values (in units of m/s) for the specified energies.
+
+* The number of columns equals the number of energy points. 
+
+* Different rows are from different time points in the :term:`MD` simulation (supposed to be an equilibrium one), which can be averaged.
+
+* Data within band gaps are not reliable and should not be trusted.

--- a/doc/gpumd/output_files/lsqt_velocity.rst
+++ b/doc/gpumd/output_files/lsqt_velocity.rst
@@ -5,13 +5,13 @@
 ``lsqt_velocity.out``
 =====================
 
-This file contains the group velocity from linear-scaling quantum transport (:term:`LSQT`) calculations.
+This file contains the electron group velocity from linear-scaling quantum transport (:term:`LSQT`) calculations.
 It is produced when invoking the :ref:`compute_lsqt keyword <kw_compute_lsqt>` in the :ref:`run.in input file <run_in>`.
 
 File format
 -----------
 
-* Each row contains the group velocity values (in units of m/s) for the specified energies.
+* Each row contains the electron group velocity values (in units of m/s) for the specified energies.
 
 * The number of columns equals the number of energy points. 
 

--- a/doc/gpumd/output_files/mcmd_out.rst
+++ b/doc/gpumd/output_files/mcmd_out.rst
@@ -1,0 +1,17 @@
+.. _mcmd_out:
+.. index::
+   single: mcmd.out (output file)
+
+``mcmd.out``
+============
+
+This file contains some data related to (:term:`MC`) simulation.
+It is generated when invoking the :ref:`mc keyword <kw_mc>`.
+
+File format
+-----------
+The data in this file are organized as follows:
+
+* column 1: number of :term:`MD` steps
+* column 2: acceptance ratio of the :term:`MC` trials
+* column 3 and more: species concentrations in the specified order

--- a/doc/gpumd/output_files/rdf_out.rst
+++ b/doc/gpumd/output_files/rdf_out.rst
@@ -1,0 +1,17 @@
+.. _rdf_out:
+.. index::
+   single: rdf.out (output file)
+
+``rdf.out``
+===========
+
+This file contains the radial distribution function (:term:`RDF`).
+It is generated when invoking the :ref:`compute_rdf keyword <kw_compute_rdf>`.
+
+File format
+-----------
+The data in this file are organized as follows:
+
+* column 1: radius (in units of Å)
+* column 2: The (:term:`RDF`) for the whole system
+* column 3 and more: The (:term:`RDF`) for specific atom pairs if specified

--- a/doc/publications.bib
+++ b/doc/publications.bib
@@ -1,81 +1,9 @@
-@article{LiuBygFan23,
-  title = {Large-scale machine-learning molecular dynamics simulation of primary radiation damage in tungsten},
-  author = {Jiahui Liu and Jesper Byggmastar and Zheyong Fan and Ping Qian and Yanjing Su},
-  year = {preprint},
-  journal = {arXiv.2305.08140},
-  doi = {10.48550/arXiv.2305.08140},
-}
-
-@article{WikFraKub23,
-  title = {Quantifying Dynamic Tilting in Halide Perovskites: Chemical Trends and Local Correlations},
-  author = {Julia Wiktor and Erik Fransson and Dominik Kubicki and Paul Erhart},
-  year = {preprint},
-  journal = {arXiv:2304.07402},
-  doi = {10.48550/arXiv.2304.07402},
-}
-
 @article{EriFraLin23,
   title = {Tuning the lattice thermal conductivity in van-der-Waals structures through rotational (dis)ordering},
   author = {Fredrik Eriksson and Erik Fransson and Christopher Linderälv and Zheyong Fan and Paul Erhart},
   year = {preprint},
   journal = {arXiv:2304.06978},
   doi = {10.48550/arXiv.2304.06978},
-}
-
-@article{RosFraMil23,
-  title = {Anharmonicity of the antiferrodistortive soft mode in barium zirconate {BaZrO₃}},
-  author = {Petter Rosander and Erik Fransson and Cosme Milesi-Brault and Constance Toulouse and Frederic Bourdarot and Andrea Piovano and Alexei Bossak and Mael Guennou, and Göran Wahnström},
-  year = {preprint},
-  journal = {arXiv:2303.12548},
-  doi = {10.48550/arXiv.2303.12548},
-}
-
-@article{FraWikErh23,
-  title = {Phase transitions in inorganic halide perovskites from machine learning potentials},
-  author = {Erik Fransson and Julia Wiktor and Paul Erhart},
-  year = {preprint},
-  journal = {arXiv:2301.03497},
-  doi = {10.48550/arXiv.2301.03497},
-}
-
-@article{FraRosEri23,
-  title = {Probing the limits of the phonon quasi-particle picture: The transition from underdamped to overdamped dynamics in {CsPbBr₃}},
-  author = {Erik Fransson and Petter Rosander and Fredrik Eriksson and J. Magnus Rahm and Terumasa Tadano and Paul Erhart},
-  year = {preprint},
-  journal = {arXiv:2211.08197},
-  doi = {10.48550/arXiv.2211.08197},
-}
-
-@article{LuLiLi23,
-  title = {Insights into the Enhanced Interfacial Thermal Transport Properties at Carbon/Carbon Composite Interfaces Connected by Covalent Bonds: A Molecular Dynamics Study},
-  author = {Chenchen Lu and Zhihui Li and Shanchen Li and Zhen Li and Yingyan Zhang and Junhua Zhao and Ning Wei},
-  year = {preprint},
-  journal = {SSRN.4446200},
-  doi = {10.2139/ssrn.4446200},
-}
-
-@article{ShiWanDon23,
-  title = {Origin of Low Lattice Thermal Conductivity and Mobility of Lead-Free Halide Double Perovskites},
-  author = {Yong-Bo Shi and Hao Wang and Haikuan Dong and Shuo Cao and Ke-Ke Song and Li-Bin Shi and Ping Qian},
-  year = {preprint},
-  journal = {SSRN.4191191},
-  doi = {10.2139/ssrn.4191191},
-}
-
-@article{YanWanMa23,
-  title = {Phonon Transport Across Gan-Diamond Interface: The Nontrivial Role of Pre-Interface Vacancy-Phonon Scattering},
-  author = {Chao Yang and Jian Wang and Dezhi Ma and Zhiqiang Li and Zhiyuan He and Linhua Liu and Zhiwei Fu and Jia-Yue Yang},
-  year = {preprint},
-  journal = {SSRN.4435960},
-  doi = {10.2139/ssrn.4435960},
-}
-
-@misc{YinLiaXu23b,
-      title={Sub-micrometer phonon mean free paths in metal-organic frameworks revealed by machine-learning molecular dynamics simulations}, 
-      author={Penghua Ying and Ting Liang and Ke Xu and Jin Zhang and Jianbin Xu and Zheng Zhong and Zheyong Fan},
-      year={preprint},
-      journal={arXiv:2306.02091},
-      doi={10.48550/arXiv.2306.02091}
 }
 
 @article{AziHirFan17,
@@ -118,6 +46,16 @@
   volume = {35},
   pages = {101093},
   doi = {10.1016/j.mtphys.2023.101093}
+}
+
+@article{CheSheKlo23,
+  title = {Lattice dynamics and thermal transport of PbTe under high pressure},
+  author = {Cheng, Ruihuan and Shen, Xingchen and Klotz, Stefan and Zeng, Zezhu and Li, Zehua and Ivanov, Alexandre and Xiao, Yu and Zhao, Li-Dong and Weber, Frank and Chen, Yue},
+  journal = {Phys. Rev. B},
+  volume = {108},
+  pages = {104306},
+  year = {2023},
+  doi = {10.1103/PhysRevB.108.104306}
 }
 
 @article{DonCaoYin23,
@@ -356,6 +294,36 @@
   doi = {10.1088/1402-4896/ac5af0}
 }
 
+@article{FraRahWik23,
+  author = {Fransson, Erik and Rahm, J. Magnus and Wiktor, Julia and Erhart, Paul},
+  title = {Revealing the Free Energy Landscape of Halide Perovskites: Metastability and Transition Characters in CsPbBr3 and MAPbI3},
+  journal = {Chemistry of Materials},
+  volume = {35},
+  pages = {8229-8238},
+  year = {2023},
+  doi = {10.1021/acs.chemmater.3c01740}
+}
+
+@article{FraRosEri23,
+  title = {Limits of the phonon quasi-particle picture at the cubic-to-tetragonal phase transition in halide perovskites},
+  author = {Erik Fransson and Petter Rosander and Fredrik Eriksson and J. Magnus Rahm and Terumasa Tadano and Paul Erhart},
+  year = {2023},
+  volume = {6},
+  pages = {173},
+  journal = {Commun Phys},
+  doi = {10.1038/s42005-023-01297-8},
+}
+
+@article{FraWikErh23,
+  author = {Fransson, Erik and Wiktor, Julia and Erhart, Paul},
+  title = {Phase Transitions in Inorganic Halide Perovskites from Machine-Learned Potentials},
+  journal = {The Journal of Physical Chemistry C},
+  volume = {127},
+  pages = {13773-13781},
+  year = {2023},
+  doi = {10.1021/acs.jpcc.3c01542}
+}
+
 @article{FuParKim20,
   title = {Phonon Confinement and Transport in Ultrathin Films},
   author = {Fu, Bo and Parrish, Kevin D. and Kim, Hyun-Young and Tang, Guihua and McGaughey, Alan J. H.},
@@ -501,6 +469,16 @@
   doi = {10.1016/j.ijheatmasstransfer.2021.122144}
 }
 
+@Article{LiJia23,
+  author ={Li, Yu and Jiang, Jin-Wu},
+  title  ={Vacancy defects impede the transition from peapods to diamond: a neuroevolution machine learning study},
+  journal  ={Phys. Chem. Chem. Phys.},
+  year  ={2023},
+  volume  ={25},
+  pages  ={25629},
+  doi  ={10.1039/D3CP03862A}
+}
+
 @article{LiXioSie2019,
     author = {Li, Zhen and Xiong, Shiyun and Sievers, Charles and Hu, Yue and Fan, Zheyong and Wei, Ning and Bao, Hua and Chen, Shunda and Donadio, Davide and Ala-Nissila, Tapio},
     title = "{Influence of thermostatting on nonequilibrium molecular dynamics simulations of heat conduction in solids}",
@@ -512,6 +490,26 @@
     issn = {0021-9606},
     doi = {10.1063/1.5132543},
     url = {https://doi.org/10.1063/1.5132543}
+}
+
+@article{LiuBygFan23,
+  title = {Large-scale machine-learning molecular dynamics simulation of primary radiation damage in tungsten},
+  author = {Liu, Jiahui and Byggm\"astar, Jesper and Fan, Zheyong and Qian, Ping and Su, Yanjing},
+  journal = {Phys. Rev. B},
+  volume = {108},
+  pages = {054312},
+  year = {2023},
+  doi = {10.1103/PhysRevB.108.054312}
+}
+
+@article{LuLiLi23,
+  title = {Molecular dynamics study of thermal transport properties across covalently bonded graphite-nanodiamond interfaces},
+  journal = {Carbon},
+  volume = {213},
+  pages = {118250},
+  year = {2023},
+  doi = {10.1016/j.carbon.2023.118250},
+  author = {Chenchen Lu and Zhi-hui Li and Shanchen Li and Zhen Li and Yingyan Zhang and Junhua Zhao and Ning Wei}
 }
 
 @article{LunBarDon21,
@@ -578,6 +576,16 @@
   doi = {10.1063/1.5025604}
 }
 
+@article{RosFraMil23,
+  title = {Anharmonicity of the antiferrodistortive soft mode in barium zirconate ${\mathrm{BaZrO}}_{3}$},
+  author = {Rosander, Petter and Fransson, Erik and Milesi-Brault, Cosme and Toulouse, Constance and Bourdarot, Fr\'ed\'eric and Piovano, Andrea and Bossak, Alexei and Guennou, Mael and Wahnstr\"om, G\"oran},
+  journal = {Phys. Rev. B},
+  volume = {108},
+  pages = {014309},
+  year = {2023},
+  doi = {10.1103/PhysRevB.108.014309}
+}
+
 @article{ShaDaiChe22,
   title = {Phonon Thermal Transport in Graphene/h-{BN} Superlattice Monolayers},
   author = {Sha, Wenhao and Dai, Xuan and Chen, Siyu and Guo, Fenglin},
@@ -616,6 +624,26 @@
   doi = {10.1039/D3CP01441J}
 }
 
+@article{ShiLiaWan23,
+  title = {Double-Shock Compression Pathways from Diamond to BC8 Carbon},
+  author = {Shi, Jiuyang and Liang, Zhixing and Wang, Junjie and Pan, Shuning and Ding, Chi and Wang, Yong and Wang, Hui-Tian and Xing, Dingyu and Sun, Jian},
+  journal = {Phys. Rev. Lett.},
+  volume = {131},
+  pages = {146101},
+  year = {2023},
+  doi = {10.1103/PhysRevLett.131.146101}
+}
+
+@article{SuCheWan23,
+  title = {Origin of low lattice thermal conductivity and mobility of lead-free halide double perovskites},
+  journal = {Journal of Alloys and Compounds},
+  volume = {962},
+  pages = {170988},
+  year = {2023},
+  doi = {https://doi.org/10.1016/j.jallcom.2023.170988},
+  author = {Ye Su and Yuan-Yuan Chen and Hao Wang and Hai-Kuan Dong and Shuo Cao and Li-Bin Shi and Ping Qian}
+}
+
 @article{VriOstDol23,
   title = {Thermal Conductivity across Transition Metal Dichalcogenide Bilayers},
   author = {de Vries, Insa F. and Osthues, Helena and Doltsinis, Nikos L.},
@@ -649,6 +677,16 @@
   doi = {10.1103/PhysRevB.107.054303}
 }
 
+@article{WanWanChi23,
+  title = {Phonon transport in freestanding ${\text{SrTiO}}_{3}$ down to the monolayer limit},
+  author = {Wang, Qi and Wang, Chen and Chi, Cheng and Ouyang, Niuchang and Guo, Ruiqiang and Yang, Nuo and Chen, Yue},
+  journal = {Phys. Rev. B},
+  volume = {108},
+  pages = {115435},
+  year = {2023},
+  doi = {10.1103/PhysRevB.108.115435}
+}
+
 @article{WanWanWan22,
   title = {Pressure {Stabilized Lithium-Aluminum Compounds} with {Both Superconducting} and {Superionic Behaviors}},
   author = {Wang, Xiaomeng and Wang, Yong and Wang, Junjie and Pan, Shuning and Lu, Qing and Wang, Hui-Tian and Xing, Dingyu and Sun, Jian},
@@ -669,6 +707,16 @@
   number = {1},
   pages = {1--9},
   doi = {10.1038/s43246-023-00330-1}
+}
+
+@article{WikFraKub23,
+  author = {Wiktor, Julia and Fransson, Erik and Kubicki, Dominik and Erhart, Paul},
+  title = {Quantifying Dynamic Tilting in Halide Perovskites: Chemical Trends and Local Correlations},
+  journal = {Chemistry of Materials},
+  volume = {35},
+  pages = {6737-6744},
+  year = {2023},
+  doi = {10.1021/acs.chemmater.3c00933}
 }
 
 @article{WuHan20,
@@ -744,6 +792,16 @@
   doi = {10.1016/j.surfin.2022.102296}
 }
 
+@article{WuHuaYan23,
+  title = {Suppressed thermal transport in mathematically inspired 2D heterosystems},
+  journal = {Carbon},
+  volume = {213},
+  pages = {118264},
+  year = {2023},
+  doi = {https://doi.org/10.1016/j.carbon.2023.118264},
+  author = {Xin Wu and Xin Huang and Lei Yang and Zhongwei Zhang and Yangyu Guo and Sebastian Volz and Qiang Han and Masahiro Nomura}
+}
+
 @article{WuYinLi23,
   title = {Dual Effects of Hetero-Interfaces on Phonon Thermal Transport across Graphene/{{C₃N}} Lateral Superlattices},
   author = {Wu, Xin and Ying, Penghua and Li, Chunlei and Han, Qiang},
@@ -800,6 +858,17 @@
   doi = {10.1063/5.0108746}
 }
 
+@article{YanWanMa23,
+  title = {Phonon transport across GaN-diamond interface: The nontrivial role of pre-interface vacancy-phonon scattering},
+  journal = {International Journal of Heat and Mass Transfer},
+  volume = {214},
+  pages = {124433},
+  year = {2023},
+  doi = {https://doi.org/10.1016/j.ijheatmasstransfer.2023.124433},
+  author = {Chao Yang and Jian Wang and Dezhi Ma and Zhiqiang Li and Zhiyuan He and Linhua Liu and Zhiwei Fu and Jia-Yue Yang}
+}
+
+
 @article{YinDonLia23,
   title = {Atomistic Insights into the Mechanical Anisotropy and Fragility of Monolayer Fullerene Networks Using Quantum Mechanical Calculations and Machine-Learning Molecular Dynamics Simulations},
   author = {Ying, Penghua and Dong, Haikuan and Liang, Ting and Fan, Zheyong and Zhong, Zheng and Zhang, Jin},
@@ -830,6 +899,16 @@
   doi = {10.1016/j.ijheatmasstransfer.2022.123681}
 }
 
+@article{YinLiaXu23b,
+  author = {Ying, Penghua and Liang, Ting and Xu, Ke and Zhang, Jin and Xu, Jianbin and Zhong, Zheng and Fan, Zheyong},
+  title = {Sub-Micrometer Phonon Mean Free Paths in Metal–Organic Frameworks Revealed by Machine Learning Molecular Dynamics Simulations},
+  journal = {ACS Applied Materials \& Interfaces},
+  volume = {15},
+  pages = {36412},
+  year = {2023},
+  doi = {10.1021/acsami.3c07770}
+}
+
 @article{ZhaFuKon23,
   author = {Rui Zhao and Shucheng Wang and Zhuangzhuang Kong and Yunlei Xu and Kuan Fu and Ping Peng and Cuilan Wu},
   title = {Development of a neuroevolution machine learning potential of Pd-Cu-Ni-P alloys},
@@ -839,6 +918,16 @@
   year = {2023},
   issn = {0264-1275},
   doi = {10.1016/j.matdes.2023.112012},
+}
+
+@article{ZhaCuFan23,
+  title = {Vibrational anharmonicity results in decreased thermal conductivity of amorphous ${\mathrm{HfO}}_{2}$ at high temperature},
+  author = {Zhang, Honggang and Gu, Xiaokun and Fan, Zheyong and Bao, Hua},
+  journal = {Phys. Rev. B},
+  volume = {108},
+  pages = {045422},
+  year = {2023},
+  doi = {10.1103/PhysRevB.108.045422}
 }
 
 @article{ZhaGuoBes21,
@@ -861,4 +950,14 @@
   number = {8},
   pages = {085702},
   doi = {10.1088/1361-648X/acab4a}
+}
+
+@Article{ZhoZenSon23,
+  author ={Zhou, Ziyue and Zeng, Jincheng and Song, Zixuan and Lin, Yanwen and Shi, Qiao and Hao, Yongchao and Fu, Yuequn and Zhang, Zhisen and Wu, Jianyang},
+  title  ={Thermal conductivity of fivefold twinned silicon-germanium heteronanowires},
+  journal  ={Phys. Chem. Chem. Phys.},
+  year  ={2023},
+  volume  ={25},
+  pages  ={25368-25376},
+  doi  ={10.1039/D3CP02926C}
 }

--- a/src/measure/rdf.cu
+++ b/src/measure/rdf.cu
@@ -528,7 +528,7 @@ void RDF::postprocess(const bool is_pimd, const int number_of_beads)
       }
     }
 
-    FILE* fid = fopen("rdf_pimd.out", "w");
+    FILE* fid = fopen("rdf.out", "a");
     fprintf(fid, "#radius");
     for (int a = 0; a < rdf_atom_count; a++) {
       if (a == 0) {
@@ -572,7 +572,7 @@ void RDF::postprocess(const bool is_pimd, const int number_of_beads)
       }
     }
 
-    FILE* fid = fopen("rdf.out", "w");
+    FILE* fid = fopen("rdf.out", "a");
     fprintf(fid, "#radius");
     for (int a = 0; a < rdf_atom_count; a++) {
       if (a == 0) {


### PR DESCRIPTION
* Aim of this PR: Fix the documentation to prepare for releasing GPUMD-v3.9.

* added:
  * `mc`, `electron_stop`, `compute_rdf`, and `compute_lsqt` keywords
  * `rdf.out`, `mcmd.out`, `lsqt_dos.out`, `lsqt_velocity.out`, and `lsqt_sigma.out` files
* updated:
  * publication list
  * `dump_exyz` keyword
