### PR TITLE
Fixed integration of MSST ensemble in documentation

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -53,6 +53,9 @@ Glossary
    MSD
         mean square displacement
 
+   MSST
+        :ref:`Multi-scale shock technique <msst>` [Reed2003]_
+
    MTTK
         :ref:`Martyna-Tuckerman-Tobias-Klein integrator <mttk>` [Martyna1994]_
 

--- a/doc/gpumd/input_parameters/ensemble_msst.rst
+++ b/doc/gpumd/input_parameters/ensemble_msst.rst
@@ -1,22 +1,33 @@
+.. _msst:
 .. _kw_ensemble_msst:
+.. index::
+   single: msst (keyword in run.in)
+   single: MSST integrator
 
 :attr:`ensemble` (MSST)
 =======================
 
-This keyword is used to set up a Multi-Scale Shock Technique (MSST) integrator. Please check [Reed2003]_ for more details.
+This keyword is used to set up a multi-scale shock technique (:term:`MSST`) integrator.
+Please check [Reed2003]_ for more details.
 
 Syntax
 ------
 
 The parameters can be specified as follows::
 
-    ensemble msst <direction> <shock_velocity> qmass <qmass_value> mu <mu_value> tscale <tscale_value>
+    ensemble msst <direction> <shock_velocity> qmass <qmass_value> mu <mu_value> [tscale <tscale_value>]
 
-- :attr:`<direction>`: The direction of the shock wave. It can be ``x``, ``y``, or ``z``.
+- :attr:`<direction>`: The direction of the shock wave. It can be ``x``, ``y`` or ``z``.
 - :attr:`<shock_velocity>`: The shock velocity of the shock wave in km/s.
-- :attr:`<qmass_value>`: The mass of the simulation cell. It affects the compression speed. Its unit is :math:`\frac{amu^2}{Å^4}`.
-- :attr:`<mu_value>`: The artificial viscosity. It improves convergence. Its unit is :math:`\frac{\sqrt{amu \times eV}}{Å^2}`.
-- :attr:`<tscale>`: The ratio of kinetic energy that turns into cell kinetic energy. This helps speed up the simulation. This keyword is optional, and the default value is ``0``.
+- :attr:`<qmass_value>`: The mass of the simulation cell.
+  It affects the compression speed.
+  Its unit is :math:`\mathrm{amu}^2/\mathrm{Å}^4`.
+- :attr:`<mu_value>`: The artificial viscosity.
+  It improves convergence.
+  Its unit is :math:`\sqrt{\mathrm{amu} \times \mathrm{eV}}/\mathrm{Å}^2`.
+- :attr:`<tscale_value>`: The ratio of kinetic energy that turns into cell kinetic energy.
+  This helps speed up the simulation.
+  This keyword is optional, and the default value is ``0``.
 
 Example
 --------
@@ -25,4 +36,4 @@ Example
 
     ensemble msst x 15 qmass 10000 mu 10
 
-This command performs an MSST simulation with a shock wave velocity of 15 km/s in the x direction.
+This command performs an :term:`MSST` simulation with a shock wave velocity of 15 km/s in the x direction.

--- a/doc/gpumd/input_parameters/index.rst
+++ b/doc/gpumd/input_parameters/index.rst
@@ -23,6 +23,7 @@ Below you can find a listing of keywords for the ``run.in`` input file.
    ensemble_mttk
    ensemble_heat
    ensemble_pimd
+   ensemble_msst
    fix
    time_step
    plumed


### PR DESCRIPTION
The MSST documentation page was not included in the documentation, which caused the CI to fail.
This PR also includes some very minor changes to the formatting and the linking, and adds indexing of the keyword.