### PR TITLE
Fixed syntax error on documentation page

### DIFF
--- a/doc/gpumd/input_parameters/ensemble_ti_spring.rst
+++ b/doc/gpumd/input_parameters/ensemble_ti_spring.rst
@@ -21,7 +21,7 @@ The parameters can be specified as follows::
 Please note that the spring constants should be placed at the end of the command.
 
 Example
---------
+-------
 
 .. code-block:: rst
 
@@ -29,7 +29,7 @@ Example
 
 This command switch lambda for 4000 timesteps, and equilibrate for 1000 timesteps. The spring constant is 6 eV/A^2 for Si and 5 eV/A^2 for O.
 
-Output file 
---------
+Output file
+-----------
 
 This command will produce a csv file. The columns are lambda, dlambda, potential energy and spring energy (eV/atom).

--- a/src/makefile
+++ b/src/makefile
@@ -19,11 +19,12 @@ CC = nvcc
 ifdef OS # For Windows with the cl.exe compiler
 CFLAGS = -O3 -arch=sm_60 -Xcompiler "/wd 4819"
 else # For linux
-CFLAGS = -std=c++14 -O3 -arch=sm_75 -DUSE_NETCDF
+CFLAGS = -std=c++14 -O3 -arch=sm_60
 endif
-INC = -I./ -I${HOME}/repos/netcdf/include
-LDFLAGS = -L${HOME}/repos/netcdf/lib
-LIBS = -lcublas -lcusolver -l:libnetcdf.a
+INC = -I./
+LDFLAGS = 
+LIBS = -lcublas -lcusolver
+
 
 ###########################################################
 # source files

--- a/src/makefile
+++ b/src/makefile
@@ -19,12 +19,11 @@ CC = nvcc
 ifdef OS # For Windows with the cl.exe compiler
 CFLAGS = -O3 -arch=sm_60 -Xcompiler "/wd 4819"
 else # For linux
-CFLAGS = -std=c++14 -O3 -arch=sm_60
+CFLAGS = -std=c++14 -O3 -arch=sm_75 -DUSE_NETCDF
 endif
-INC = -I./
-LDFLAGS = 
-LIBS = -lcublas -lcusolver
-
+INC = -I./ -I${HOME}/repos/netcdf/include
+LDFLAGS = -L${HOME}/repos/netcdf/lib
+LIBS = -lcublas -lcusolver -l:libnetcdf.a
 
 ###########################################################
 # source files


### PR DESCRIPTION
This PR fixes a minuscule syntax error on the `ensemble_ti_spring.rst` page that caused the compilation of the documentation and the `pages` job to fail, as a result of which the documentation for the latest version has not been deployed yet.