### PR TITLE
Fixes to documentation

### DIFF
--- a/doc/gpumd/input_parameters/dump_exyz.rst
+++ b/doc/gpumd/input_parameters/dump_exyz.rst
@@ -24,13 +24,14 @@ The atomic positions will always be included in the output.
 
 Examples
 --------
-    # ensemble keyword here
+
+.. code::
+
     dump_exyz 1000        # dump positions every 1000 steps
     dump_exyz 1000 1      # dump positions and velocities
     dump_exyz 1000 1 1    # dump positions, velocities, and forces
     dump_exyz 1000 1 1 1  # dump positions, velocities, forces, and potentials
     dump_exyz 1000 0 1 1  # dump positions, forces and potentials
-    run 1000000
 
 Caveats
 -------

--- a/doc/gpumd/input_parameters/ensemble_mttk.rst
+++ b/doc/gpumd/input_parameters/ensemble_mttk.rst
@@ -70,7 +70,7 @@ This command ramps the temperature from 300 K to 1000 K, while keeping the press
 
     ensemble npt_mttk temp 300 300 aniso 10 10
 
-This command replaces `iso` with `ansio`.
+This command replaces ``iso`` with ``ansio``.
 The three dimensions of the cell thus change independently, but `xy`, `xz` and `yz` remain unchanged.
 
 .. code-block:: rst
@@ -79,7 +79,7 @@ The three dimensions of the cell thus change independently, but `xy`, `xz` and `
 
 All six degrees of freedom of the simulation cell are allowed to change.
 The simulated system will converge to fully hydrostatic pressure. 
-Note that with `iso` and `aniso`, there is no guarantee that the pressure is hydrostatic, as the system is constrained.
+Note that with ``iso`` and ``aniso``, there is no guarantee that the pressure is hydrostatic, as the system is constrained.
 
 .. code-block:: rst
 

--- a/doc/gpumd/input_parameters/mc.rst
+++ b/doc/gpumd/input_parameters/mc.rst
@@ -5,62 +5,61 @@
 :attr:`mc`
 ==========
 
-The :attr:`mc` keyword is used to carry out Monte Carlo (:term:`MC`) trial steps, usually in combination with an :term:`MD` simulation. 
-Three :term:`MC` ensembles are supported, including the canonical, the semi-grand canonical (:term:`SGC`), and the variance-constrained semi-grand canonical (:term:`VCSGC`) [Sadigh2012a]_ [Sadigh2012b]_ ones. 
+The :attr:`mc` keyword is used to carry out Monte Carlo (:term:`MC`) trial steps, usually in combination with a :term:`MD` simulation.
+Three :term:`MC` ensembles are supported, including the canonical, the semi-grand canonical (:term:`SGC`), and the variance-constrained semi-grand canonical (:term:`VCSGC`) [Sadigh2012a]_ [Sadigh2012b]_ ensemble.
 
-This keyword can only be used when the potential is :term:`NEP`.
+This keyword can only be used in combination with :term:`NEP` models.
 
 Syntax
 ------
 
-:attr:`canonical`
-^^^^^^^^^^^^^^^^^
+:`canonical`
+^^^^^^^^^^^^
 If the first parameter is :attr:`canonical`, the system will be sampled in the canonical :term:`MC` ensemble.
-
 It can be used as follows::
 
     mc canonical <md_steps> <mc_trials> <T_i> <T_f> [group <grouping_method> <group_id>]
 
+This means that :attr:`mc_trials` :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps, while the instant temperature for the :term:`MC` ensemble changes linearly from attr:`T_i` to attr:`T_f`.
+
 :attr:`sgc`
 ^^^^^^^^^^^
 If the first parameter is :attr:`sgc`, the system will be sampled in the :term:`SGC` :term:`MC` ensemble.
-
 It can be used as follows::
 
-    mc sgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {species_0 mu_0 species_1 mu_1 ...} [group <grouping_method>  <group_id>]
+    mc sgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {<species_0> <mu_0> <species_1> <mu_1> ...} [group <grouping_method>  <group_id>]
+
+This means that :attr:`mc_trials` :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps, while the instant temperature for the :term:`MC` ensemble changes linearly from attr:`T_i` to attr:`T_f`.
+:attr:`num_species` specifies the number of species that are to be included in the sampling.
+It must be no less than 2 and no larger than 4.
+After specifying the number of species to be involved, the chemical symbols and chemical potentials :math:`\mu_i` (in units of eV) for these species need to be listed.
+The species can be listed in arbitrary order.
+Note that only the differences between the chemical potentials matter.
 
 :attr:`vcsgc`
 ^^^^^^^^^^^^^
 If the first parameter is :attr:`vcsgc`, the system will be sampled in the :term:`VCSGC` :term:`MC` ensemble.
-
 It can be used in the following way::
 
-    mc vcsgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {species_0 phi_0 species_1 phi_1 ...} kappa [group <grouping_method>  <group_id>]
+    mc vcsgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {<species_0> <phi_0> <species_1> <phi_1> ...} kappa [group <grouping_method>  <group_id>]
 
-* :attr:`mc_trials` :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps.
+This means that :attr:`mc_trials` :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps, while the instant temperature for the :term:`MC` ensemble changes linearly from attr:`T_i` to attr:`T_f`.
+:attr:`num_species` specifies the number of species that are to be included in the sampling.
+It must be no less than 2 and no larger than 4.
+After specifying the number of species to be involved, the chemical symbols and the dimensionless :math:`\phi_i` parameters for these species need to be listed.
+The species can be listed in arbitrary order.
+Next one needs to specify the (dimensionless) :math:`\kappa` parameter.
 
-* The instant temperature for the :term:`MC` ensemble will linearly change from attr:`T_i` to attr:`T_f`.
+The :math:`\phi` and :math:`\kappa` parameters constrain the average and variance of the species concentrations, respectively.
+One can usually achieve a sampling of the full composition range by varying :math:`\phi_i` between -1.2 and +1.2, which thus play a role that is equivalent to the :math:`\mu_i` parameters in the :term:`SGC` ensemble.
 
-* :attr:`num_species` is the number of species to be involved in the :term:`SGC` or :term:`VCSGC` ensemble. 
-  It must be no less than 2 and no larger than 4.
+Typically a :math:`\kappa` value of 100 is suitable.
+If the concentration fluctuations are too large (e.g., deep with miscibility gaps) one should increase this value.
 
-* For the :term:`SGC` ensemble, after specifying the number of species to be involved, the chemical symbols and chemical potentials (in units of eV) for these species should be listed.
-  The species can be listed in arbitrary order.
+The choice of parameters that we use here differs from the original papers [Sadigh2012a]_ [Sadigh2012b]_ in terms of normalization and follows the expressions in e.g., [Rahm2021]_.
 
-* For the :term:`VCSGC` ensemble, after specifying the number of species to be involved, the chemical symbols and (dimensionless) :math:`\phi` parameters for these species should be listed.
-  The species can be listed in arbitrary order.
-
-* Next one needs to specify the (dimensionless) :math:`\kappa` parameter.
-
-* The :math:`\phi` and :math:`\kappa` parameters constrain the average and variance of the species concentrations, respectively.
-
-*  One can usually achieve a sampling of the full composition range by varying :math:`\phi` between -1.2 and +1.2.
-
-* Typically a :math:`\kappa` value of 100 is suitable.
-  If the concentration fluctuations are too large (e.g., deep with miscibility gaps) one should increase this value.
-
-* The choice of parameters that we use here differs from the original papers [Sadigh2012a]_ [Sadigh2012b]_ in terms of normalization and follows the expressions in e.g., [Rahm2021]_.
-
+General
+^^^^^^^
 * The listed species must be supported by the :term:`NEP` model.
 
 * For all the :term:`MC` ensembles, there is an option to specify the grouping method :attr:`grouping_method` and the group ID :attr:`group_id` in the given grouping method, after the parameter :attr:`group`. 
@@ -71,7 +70,7 @@ It can be used in the following way::
 Example 1
 ---------
 
-An example for sampling in the canonical ensemble is
+An example for sampling in the canonical ensemble is::
   
   ensemble nvt_lan 300 300 100
   # other keywords for the run
@@ -87,7 +86,7 @@ This means
 Example 2
 ---------
 
-Here is an example for :term:`MC` sampling the :term:`SGC` ensemble:
+Here is an example for :term:`MC` sampling the :term:`SGC` ensemble::
   
   ensemble nvt_lan 300 300 100
   # other keywords for the run
@@ -104,7 +103,7 @@ This means
 Example 3
 ---------
 
-Here is an example for sampling in the :term:`VCSGC` ensemble:
+Here is an example for sampling in the :term:`VCSGC` ensemble::
   
   ensemble nvt_lan 300 300 100
   # other keywords for the run
@@ -116,5 +115,5 @@ This means
 * Perform 1000 :term:`MC` trials after every 200 :term:`MD` steps.
 * The temperature for the :term:`MC` ensemble will be kept at 500 K.
 * Only the Al and Ag atoms are involved in the :term:`MC` process.
-  The dimensionless :math:`\phi` parameters for Al and Ag are -2 and 0, respectively.
+  The dimensionless :math:`\phi` parameters for Al and Ag are −2 and 0, respectively.
   The dimensionless :math:`\kappa` parameter is 10000.

--- a/doc/gpumd/input_parameters/mc.rst
+++ b/doc/gpumd/input_parameters/mc.rst
@@ -13,14 +13,14 @@ This keyword can only be used in combination with :term:`NEP` models.
 Syntax
 ------
 
-:`canonical`
-^^^^^^^^^^^^
+:attr:`canonical`
+^^^^^^^^^^^^^^^^^
 If the first parameter is :attr:`canonical`, the system will be sampled in the canonical :term:`MC` ensemble.
 It can be used as follows::
 
     mc canonical <md_steps> <mc_trials> <T_i> <T_f> [group <grouping_method> <group_id>]
 
-This means that :attr:`mc_trials` :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps, while the instant temperature for the :term:`MC` ensemble changes linearly from attr:`T_i` to attr:`T_f`.
+This means that :attr:`mc_trials` :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps, while the instant temperature for the :term:`MC` ensemble changes linearly from :attr:`T_i` to :attr:`T_f`.
 
 :attr:`sgc`
 ^^^^^^^^^^^
@@ -29,10 +29,11 @@ It can be used as follows::
 
     mc sgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {<species_0> <mu_0> <species_1> <mu_1> ...} [group <grouping_method>  <group_id>]
 
-This means that :attr:`mc_trials` :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps, while the instant temperature for the :term:`MC` ensemble changes linearly from attr:`T_i` to attr:`T_f`.
+This means that :attr:`mc_trials` :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps, while the instant temperature for the :term:`MC` ensemble changes linearly from :attr:`T_i` to :attr:`T_f`.
+
 :attr:`num_species` specifies the number of species that are to be included in the sampling.
 It must be no less than 2 and no larger than 4.
-After specifying the number of species to be involved, the chemical symbols and chemical potentials :math:`\mu_i` (in units of eV) for these species need to be listed.
+After specifying the number of species, one needs to specify their chemical symbols (:attr:`species_i`) and chemical potentials (:attr:`mu_i`) in units of eV.
 The species can be listed in arbitrary order.
 Note that only the differences between the chemical potentials matter.
 
@@ -43,16 +44,16 @@ It can be used in the following way::
 
     mc vcsgc <md_steps> <mc_trials> <T_i> <T_f> <num_species> {<species_0> <phi_0> <species_1> <phi_1> ...} kappa [group <grouping_method>  <group_id>]
 
-This means that :attr:`mc_trials` :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps, while the instant temperature for the :term:`MC` ensemble changes linearly from attr:`T_i` to attr:`T_f`.
+This means that :attr:`mc_trials` :term:`MC` trials are performed every :attr:`md_steps` :term:`MD` steps, while the instant temperature for the :term:`MC` ensemble changes linearly from :attr:`T_i` to :attr:`T_f`.
+
 :attr:`num_species` specifies the number of species that are to be included in the sampling.
 It must be no less than 2 and no larger than 4.
-After specifying the number of species to be involved, the chemical symbols and the dimensionless :math:`\phi_i` parameters for these species need to be listed.
+After specifying the number of species, one needs to specify their chemical symbols (:attr:`species_i`) and chemical potentials (:attr:`phi_i` = :math:`\phi_i`).
 The species can be listed in arbitrary order.
-Next one needs to specify the (dimensionless) :math:`\kappa` parameter.
+Next one needs to specify the (dimensionless) :attr:`kappa` parameter (:math:`\kappa`).
 
 The :math:`\phi` and :math:`\kappa` parameters constrain the average and variance of the species concentrations, respectively.
-One can usually achieve a sampling of the full composition range by varying :math:`\phi_i` between -1.2 and +1.2, which thus play a role that is equivalent to the :math:`\mu_i` parameters in the :term:`SGC` ensemble.
-
+One can usually achieve a sampling of the full composition range by varying :math:`\phi_i` between −1.2 and +1.2, which thus play a role that is equivalent to the :math:`\mu_i` parameters in the :term:`SGC` ensemble.
 Typically a :math:`\kappa` value of 100 is suitable.
 If the concentration fluctuations are too large (e.g., deep with miscibility gaps) one should increase this value.
 
@@ -72,10 +73,7 @@ Example 1
 
 An example for sampling in the canonical ensemble is::
   
-  ensemble nvt_lan 300 300 100
-  # other keywords for the run
   mc canonical 100 200 500 100 group 1 3
-  run 1000000
 
 This means
 
@@ -88,10 +86,7 @@ Example 2
 
 Here is an example for :term:`MC` sampling the :term:`SGC` ensemble::
   
-  ensemble nvt_lan 300 300 100
-  # other keywords for the run
   mc sgc 100 1000 300 300 2 Cu 0 Au 0.6
-  run 1000000
 
 This means
 
@@ -105,10 +100,7 @@ Example 3
 
 Here is an example for sampling in the :term:`VCSGC` ensemble::
   
-  ensemble nvt_lan 300 300 100
-  # other keywords for the run
   mc vcsgc 200 1000 500 500 2 Al -2 Ag 0 10000
-  run 1000000
 
 This means
 


### PR DESCRIPTION
* fixed rendering of examples on `dump_exyz` page
* fixed rendering of keywords on for MTTK ensemble documentation
* fixed rendering of examples and small revisions on MC documentation page