### PR TITLE
Fix a bug

### DIFF
--- a/src/integrate/ensemble_ti_spring.cu
+++ b/src/integrate/ensemble_ti_spring.cu
@@ -235,7 +235,7 @@ void Ensemble_TI_Spring::find_lambda()
     find_thermo();
     fprintf(
       output_file,
-      "%f,%f,%f,%f\n",
+      "%e,%e,%e,%e\n",
       lambda,
       dlambda,
       pe / atom->number_of_atoms,


### PR DESCRIPTION
The output file of TI-spring do not have enough precision, when there is a large number of steps and dlambda becomes extremely small. I have fixed the problem.