### PR TITLE
Update singleFrame-outcars2nep-exyz.sh

### DIFF
--- a/tools/vasp2xyz/singleFrame-outcars2nep-exyz.sh
+++ b/tools/vasp2xyz/singleFrame-outcars2nep-exyz.sh
@@ -28,7 +28,7 @@ do
              ener=$(grep "free  energy   TOTEN" $i | tail -1 | awk '{printf "%.6f\n", $5 - '$syst_numb_atom' * '$isol_ener'}')
              if [[ $viri_logi -eq 1 ]]
              then
-                   viri=$(grep -A 20 "FORCE on cell =-STRESS" $i | grep "Total" | tail -n 1 | awk '{print $2,$5,$7,$5,$3,$6,$7,$6,$4}')
+                   viri=$(grep -A 20 "FORCE on cell =-STRESS" $i | grep "Total " | tail -n 1 | awk '{print $2,$5,$7,$5,$3,$6,$7,$6,$4}')
                    echo "Config_type=$configuration Weight=1.0 Lattice=\"$latt\" Energy=$ener Virial=\"$viri\" Properties=species:S:1:pos:R:3:force:R:3" >> $writ_dire/$writ_file
              else
                    echo "Config_type=$configuration Weight=1.0 Lattice=\"$latt\" Energy=$ener Properties=species:S:1:pos:R:3:force:R:3" >> $writ_dire/$writ_file


### PR DESCRIPTION
It is used to determine that the stress read by the shell is the Total line rather than the Total+kin line.
![20231223112003](https://github.com/brucefan1983/GPUMD/assets/30561696/f584e988-4e8b-44e0-abfc-761b34005c99)
