### PR TITLE
Initialize species count to zero also for restarts

### DIFF
--- a/src/mc/mc.cu
+++ b/src/mc/mc.cu
@@ -313,6 +313,7 @@ void MC::parse_mc(const char** param, int num_param, std::vector<Group>& groups,
 
   types.resize(num_types_mc);
   num_atoms_species.resize(num_types_mc, 0);
+  std::fill(num_atoms_species.begin(), num_atoms_species.end(), 0);
   if (mc_ensemble_type == 0) {
     check_species_canonical(groups, atom);
     mc_ensemble.reset(new MC_Ensemble_Canonical(param, num_param, num_steps_mc));


### PR DESCRIPTION
This PR fixes a bug that occurs when the `mc` command is used more than once in a job script, e.g., when alternating between different ensembles.

The counter for the number of species is set up by `resize`, which initializes the elements of the vector to zero for the *first* call. When calling the `mc` command repeatedly before this PR, this caused the species counter to be incremented with every additional `mc` command, leading to incorrect species counts and concentrations. To prevent this behavior this PR inserts one line after the `resize` command that resets the counter.