### PR TITLE
better default regularization strength

### DIFF
--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -184,6 +184,13 @@ void Parameters::calculate_parameters()
     number_of_variables += number_of_variables_ann;
   }
 
+  if (!is_lambda_1_set) {
+    lambda_1 = sqrt(number_of_variables * 1.0e-6f);
+  }
+  if (!is_lambda_2_set) {
+    lambda_2 = sqrt(number_of_variables * 1.0e-6f);
+  }
+
   int deviceCount;
   CHECK(cudaGetDeviceCount(&deviceCount));
   for (int device_id = 0; device_id < deviceCount; device_id++) {

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -268,26 +268,6 @@ void SNES::create_population(Parameters& para)
 
 void SNES::regularize(Parameters& para)
 {
-  float lambda_1 = para.lambda_1;
-  float lambda_2 = para.lambda_2;
-  if (para.lambda_1 < 0.0f || para.lambda_2 < 0.0f) {
-    float auto_reg = 1.0e30f;
-    for (int p = 0; p < population_size; ++p) {
-      float temp = fitness[p + (6 * para.num_types + 3) * population_size] +
-                   fitness[p + (6 * para.num_types + 4) * population_size] +
-                   fitness[p + (6 * para.num_types + 5) * population_size];
-      if (auto_reg > temp) {
-        auto_reg = temp;
-      }
-    }
-    if (para.lambda_1 < 0.0f) {
-      lambda_1 = auto_reg;
-    }
-    if (para.lambda_2 < 0.0f) {
-      lambda_2 = auto_reg;
-    }
-  }
-
   for (int p = 0; p < population_size; ++p) {
     float cost_L1 = 0.0f, cost_L2 = 0.0f;
     for (int v = 0; v < number_of_variables; ++v) {
@@ -296,8 +276,8 @@ void SNES::regularize(Parameters& para)
       cost_L2 += population[pv] * population[pv];
     }
 
-    cost_L1 *= lambda_1 / number_of_variables;
-    cost_L2 = lambda_2 * sqrt(cost_L2 / number_of_variables);
+    cost_L1 *= para.lambda_1 / number_of_variables;
+    cost_L2 = para.lambda_2 * sqrt(cost_L2 / number_of_variables);
 
     for (int t = 0; t <= para.num_types; ++t) {
       fitness[p + (6 * t + 0) * population_size] =


### PR DESCRIPTION
The original default regularization weight parameters $\lambda_1$ and $\lambda_2$ are set equal to the combined physical RMSE, which is not always optimal. Particularly, when the initial RMSE is large, the training will simply get stuck due to too strong regularization. Based on many tests we have seen so far, it seems a good default value is $\lambda_1=\lambda_2=\sqrt{N}/1000$, where $N$ is the total number of training parameters.