### PR TITLE
output stress as well as virial during NEP training/predicting

### DIFF
--- a/doc/nep/output_files/index.rst
+++ b/doc/nep/output_files/index.rst
@@ -7,7 +7,7 @@ Output files
 The ``nep`` executable produces several output files.
 The :ref:`loss.out file <loss_out>` is written in "append mode", while all other files are continuously overwritten.
 
-The contents of the :ref:`energy_train.out <energy_out>`, :ref:`force_train.out <force_out_nep>`, :ref:`virial_train.out <virial_out>`, :ref:`dipole_train.out <dipole_out>`, and :ref:`polarizability_train.out <polarizability_out>` files are updated every 1000 steps, while the contents of the other output files are updated every 100 steps.
+The contents of the :ref:`energy_train.out <energy_out>`, :ref:`force_train.out <force_out_nep>`, :ref:`virial_train.out <virial_out>`, :ref:`stress_train.out <stress_out>`, :ref:`dipole_train.out <dipole_out>`, and :ref:`polarizability_train.out <polarizability_out>` files are updated every 1000 steps, while the contents of the other output files are updated every 100 steps.
 
 With the exception of the :ref:`nep.txt file <nep_txt>`, the output files contain only numbers (no text) in matrix form.
 All the files are plain text files.
@@ -37,6 +37,10 @@ All the files are plain text files.
      - target and predicted virials for training data set
    * - :ref:`virial_test.out <virial_out>`
      - target and predicted virials for test data set
+   * - :ref:`stress_train.out <stress_out>`
+     - target and predicted stress values for training data set
+   * - :ref:`stress_test.out <stress_out>`
+     - target and predicted stress values for test data set
    * - :ref:`dipole_train.out <dipole_out>`
      - target and predicted dipole values for training data set
    * - :ref:`dipole_test.out <dipole_out>`
@@ -56,5 +60,6 @@ All the files are plain text files.
    energy_out
    force_out
    virial_out
+   stress_out
    dipole_out
    polarizability_out

--- a/doc/nep/output_files/stress_out.rst
+++ b/doc/nep/output_files/stress_out.rst
@@ -1,0 +1,17 @@
+.. _stress_out:
+.. index::
+   single: stress_train.out (output file)
+   single: stress_test.out (output file)
+
+``stress_*.out``
+================
+
+The ``stress_train.out`` and ``stress_test.out`` files contain the predicted and target stress components.
+
+There are :math:`N_\mathrm{c}` rows, where :math:`N_\mathrm{c}` is the number of configurations in the :ref:`train.xyz and test.xyz input files <train_test_xyz>`.
+
+There are 12 columns.
+The first 6 columns give the :math:`xx`, :math:`yy`, :math:`zz`, :math:`xy`, :math:`yz`, and :math:`zx` stress components calculated using the :term:`NEP` model.
+The last 6 columns give the corresponding target stress components.
+
+The stress values are in units of GPa.

--- a/src/main_nep/dataset.cu
+++ b/src/main_nep/dataset.cu
@@ -32,6 +32,7 @@ void Dataset::copy_structures(std::vector<Structure>& structures_input, int n1, 
     structures[n].energy = structures_input[n_input].energy;
     structures[n].has_temperature = structures_input[n_input].has_temperature;
     structures[n].temperature = structures_input[n_input].temperature;
+    structures[n].volume = structures_input[n_input].volume;
     for (int k = 0; k < 6; ++k) {
       structures[n].virial[k] = structures_input[n_input].virial[k];
     }

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -233,6 +233,9 @@ void Fitness::output(
         fprintf(fid, "%g ", reference[n * dataset.Nc + nc]);
       }
     }
+
+    if (!is_stress) return;
+    
     // columns 13-24: stress in units of GPa
     for (int n = 0; n < num_components; ++n) {
       int offset = n * dataset.N + dataset.Na_sum_cpu[nc];

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -217,37 +217,23 @@ void Fitness::output(
   Dataset& dataset)
 {
   for (int nc = 0; nc < dataset.Nc; ++nc) {
-    // columns 1-12: virial in units of eV/atom
     for (int n = 0; n < num_components; ++n) {
       int offset = n * dataset.N + dataset.Na_sum_cpu[nc];
       float data_nc = 0.0f;
       for (int m = 0; m < dataset.Na_cpu[nc]; ++m) {
         data_nc += prediction[offset + m];
       }
-      fprintf(fid, "%g ", data_nc / dataset.Na_cpu[nc]);
-    }
-    for (int n = 0; n < num_components; ++n) {
-      if (n == num_components - 1) {
-        fprintf(fid, "%g\n", reference[n * dataset.Nc + nc]);
+      if (!is_stress) {
+        fprintf(fid, "%g ", data_nc / dataset.Na_cpu[nc]);
       } else {
-        fprintf(fid, "%g ", reference[n * dataset.Nc + nc]);
+        fprintf(fid, "%g ", data_nc / dataset.structures[nc].volume * PRESSURE_UNIT_CONVERSION);
       }
-    }
-
-    if (!is_stress) return;
-    
-    // columns 13-24: stress in units of GPa
-    for (int n = 0; n < num_components; ++n) {
-      int offset = n * dataset.N + dataset.Na_sum_cpu[nc];
-      float data_nc = 0.0f;
-      for (int m = 0; m < dataset.Na_cpu[nc]; ++m) {
-        data_nc += prediction[offset + m];
-      }
-      fprintf(fid, "%g ", data_nc / dataset.structures[nc].volume * PRESSURE_UNIT_CONVERSION);
     }
     for (int n = 0; n < num_components; ++n) {
       float ref_value = reference[n * dataset.Nc + nc];
-      ref_value *= dataset.Na_cpu[nc] / dataset.structures[nc].volume * PRESSURE_UNIT_CONVERSION;
+      if (is_stress) {
+        ref_value *= dataset.Na_cpu[nc] / dataset.structures[nc].volume * PRESSURE_UNIT_CONVERSION;
+      }
       if (n == num_components - 1) {
         fprintf(fid, "%g\n", ref_value);
       } else {
@@ -470,10 +456,12 @@ void Fitness::report_error(
         FILE* fid_force = my_fopen("force_test.out", "w");
         FILE* fid_energy = my_fopen("energy_test.out", "w");
         FILE* fid_virial = my_fopen("virial_test.out", "w");
-        update_energy_force_virial(fid_energy, fid_force, fid_virial, test_set[0]);
+        FILE* fid_stress = my_fopen("stress_test.out", "w");
+        update_energy_force_virial(fid_energy, fid_force, fid_virial, fid_stress, test_set[0]);
         fclose(fid_energy);
         fclose(fid_force);
         fclose(fid_virial);
+        fclose(fid_stress);
       } else if (para.train_mode == 1) {
         FILE* fid_dipole = my_fopen("dipole_test.out", "w");
         update_dipole(fid_dipole, test_set[0]);
@@ -492,7 +480,7 @@ void Fitness::report_error(
 }
 
 void Fitness::update_energy_force_virial(
-  FILE* fid_energy, FILE* fid_force, FILE* fid_virial, Dataset& dataset)
+  FILE* fid_energy, FILE* fid_force, FILE* fid_virial, FILE* fid_stress, Dataset& dataset)
 {
   dataset.energy.copy_to_host(dataset.energy_cpu.data());
   dataset.virial.copy_to_host(dataset.virial_cpu.data());
@@ -515,7 +503,8 @@ void Fitness::update_energy_force_virial(
   }
 
   output(false, 1, fid_energy, dataset.energy_cpu.data(), dataset.energy_ref_cpu.data(), dataset);
-  output(true, 6, fid_virial, dataset.virial_cpu.data(), dataset.virial_ref_cpu.data(), dataset);
+  output(false, 6, fid_virial, dataset.virial_cpu.data(), dataset.virial_ref_cpu.data(), dataset);
+  output(true, 6, fid_stress, dataset.virial_cpu.data(), dataset.virial_ref_cpu.data(), dataset);
 }
 
 void Fitness::update_dipole(FILE* fid_dipole, Dataset& dataset)
@@ -536,13 +525,15 @@ void Fitness::predict(Parameters& para, float* elite)
     FILE* fid_force = my_fopen("force_train.out", "w");
     FILE* fid_energy = my_fopen("energy_train.out", "w");
     FILE* fid_virial = my_fopen("virial_train.out", "w");
+    FILE* fid_stress = my_fopen("stress_train.out", "w");
     for (int batch_id = 0; batch_id < num_batches; ++batch_id) {
       potential->find_force(para, elite, train_set[batch_id], false, true, 1);
-      update_energy_force_virial(fid_energy, fid_force, fid_virial, train_set[batch_id][0]);
+      update_energy_force_virial(fid_energy, fid_force, fid_virial, fid_stress, train_set[batch_id][0]);
     }
     fclose(fid_energy);
     fclose(fid_force);
     fclose(fid_virial);
+    fclose(fid_stress);
   } else if (para.train_mode == 1) {
     FILE* fid_dipole = my_fopen("dipole_train.out", "w");
     for (int batch_id = 0; batch_id < num_batches; ++batch_id) {

--- a/src/main_nep/fitness.cuh
+++ b/src/main_nep/fitness.cuh
@@ -55,7 +55,8 @@ protected:
     float* reference, 
     Dataset& dataset);
   void
-  update_energy_force_virial(FILE* fid_energy, FILE* fid_force, FILE* fid_virial, Dataset& dataset);
+  update_energy_force_virial(
+    FILE* fid_energy, FILE* fid_force, FILE* fid_virial, FILE* fid_stress, Dataset& dataset);
   void update_dipole(FILE* fid_dipole, Dataset& dataset);
   void update_polarizability(FILE* fid_polarizability, Dataset& dataset);
   void write_nep_txt(FILE* fid_nep, Parameters& para, float* elite);

--- a/src/main_nep/fitness.cuh
+++ b/src/main_nep/fitness.cuh
@@ -47,7 +47,13 @@ protected:
   std::unique_ptr<Potential> potential;
   std::vector<std::vector<Dataset>> train_set;
   std::vector<Dataset> test_set;
-  void output(int num_components, FILE* fid, float* prediction, float* reference, Dataset& dataset);
+  void output(
+    bool is_stress, 
+    int num_components, 
+    FILE* fid, 
+    float* prediction, 
+    float* reference, 
+    Dataset& dataset);
   void
   update_energy_force_virial(FILE* fid_energy, FILE* fid_force, FILE* fid_virial, Dataset& dataset);
   void update_dipole(FILE* fid_dipole, Dataset& dataset);

--- a/src/main_nep/structure.cu
+++ b/src/main_nep/structure.cu
@@ -48,10 +48,10 @@ static void change_box(const Parameters& para, Structure& structure)
   float b[3] = {structure.box_original[1], structure.box_original[4], structure.box_original[7]};
   float c[3] = {structure.box_original[2], structure.box_original[5], structure.box_original[8]};
   float det = get_det(structure.box_original);
-  float volume = abs(det);
-  structure.num_cell[0] = int(ceil(2.0f * para.rc_radial / (volume / get_area(b, c))));
-  structure.num_cell[1] = int(ceil(2.0f * para.rc_radial / (volume / get_area(c, a))));
-  structure.num_cell[2] = int(ceil(2.0f * para.rc_radial / (volume / get_area(a, b))));
+  structure.volume = abs(det);
+  structure.num_cell[0] = int(ceil(2.0f * para.rc_radial / (structure.volume / get_area(b, c))));
+  structure.num_cell[1] = int(ceil(2.0f * para.rc_radial / (structure.volume / get_area(c, a))));
+  structure.num_cell[2] = int(ceil(2.0f * para.rc_radial / (structure.volume / get_area(a, b))));
 
   structure.box[0] = structure.box_original[0] * structure.num_cell[0];
   structure.box[3] = structure.box_original[3] * structure.num_cell[0];
@@ -451,6 +451,7 @@ static void reorder(std::vector<Structure>& structures)
     structures_copy[nc].energy = structures[nc].energy;
     structures_copy[nc].has_temperature = structures[nc].has_temperature;
     structures_copy[nc].temperature = structures[nc].temperature;
+    structures_copy[nc].volume = structures[nc].volume;
     for (int k = 0; k < 6; ++k) {
       structures_copy[nc].virial[k] = structures[nc].virial[k];
     }
@@ -488,6 +489,7 @@ static void reorder(std::vector<Structure>& structures)
     structures[nc].energy = structures_copy[configuration_id[nc]].energy;
     structures[nc].has_temperature = structures_copy[configuration_id[nc]].has_temperature;
     structures[nc].temperature = structures_copy[configuration_id[nc]].temperature;
+    structures[nc].volume = structures_copy[configuration_id[nc]].volume;
     for (int k = 0; k < 6; ++k) {
       structures[nc].virial[k] = structures_copy[configuration_id[nc]].virial[k];
     }

--- a/src/main_nep/structure.cuh
+++ b/src/main_nep/structure.cuh
@@ -27,6 +27,7 @@ struct Structure {
   float energy;
   float virial[6];
   float box_original[9];
+  float volume;
   float box[18];
   float temperature;
   std::vector<int> type;


### PR DESCRIPTION
* Users want to have stress as well as virial data output to file during training/predicting. 

* `stress_train.out` and `stress_test.out` will be created. 

* volume of a box (assumed to be periodic) is taken to be that in the input file. 

* Existing features are not affected, particularly, virial data are written out as before.

* TODO: update doc

