### PR TITLE
option for fixing descriptor scaler

### DIFF
--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -132,12 +132,20 @@ void Fitness::compute(
   int population_iter = (para.population_size - 1) / deviceCount + 1;
 
   if (generation == 0) {
-
     std::vector<float> dummy_solution(para.number_of_variables * deviceCount, 1.0f);
     for (int n = 0; n < num_batches; ++n) {
-      potential->find_force(para, dummy_solution.data(), train_set[n], true, true, deviceCount);
+      potential->find_force(
+        para, 
+        dummy_solution.data(), 
+        train_set[n], 
+#ifdef USE_FIXED_SCALER
+        false, 
+#else
+        true,
+#endif
+        true, 
+        deviceCount);
     }
-
   } else {
     int batch_id = generation % num_batches;
     bool calculate_neighbor = (num_batches > 1) || (generation % 100 == 0);

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -168,6 +168,12 @@ void Parameters::calculate_parameters()
     dim += 1; // concatenate temeprature with descriptors
   }
   q_scaler_cpu.resize(dim, 1.0e10f);
+#ifdef USE_FIXED_SCALER
+  for (int n = 0; n < q_scaler_cpu.size(); ++n) {
+    q_scaler_cpu[n] = 0.01f;
+  }
+#endif
+
 
   number_of_variables_ann = (dim + 2) * num_neurons1 * (version == 4 ? num_types : 1) + 1;
 


### PR DESCRIPTION
This is needed for the separate-and-combine training approach. Only for developers who is dealingh with the periodic table.