### PR TITLE
Better default NEP hyperparameters

### DIFF
--- a/doc/nep/input_files/nep_in.rst
+++ b/doc/nep/input_files/nep_in.rst
@@ -83,7 +83,7 @@ Here is an example :attr:`nep.in` file using all the default parameters::
   version       4       # default
   cutoff     	8 4     # default
   n_max      	4 4     # default
-  basis_size	12 12   # default
+  basis_size	8 8     # default
   l_max      	4 2 0   # default
   neuron     	30      # default
   lambda_e      1.0     # default

--- a/doc/nep/input_parameters/basis_size.rst
+++ b/doc/nep/input_parameters/basis_size.rst
@@ -14,6 +14,6 @@ The syntax is::
 where :attr:`<N_bas_R>` and :attr:`<N_bas_A>` set :math:`N_\mathrm{bas}^\mathrm{R}` and :math:`N_\mathrm{bas}^\mathrm{A}`, respectively.
 The parameters must satisfy :math:`0 \leq N_\mathrm{bas}^\mathrm{R},N_\mathrm{bas}^\mathrm{A} \leq 19`.
 
-The default values of :math:`N_\mathrm{bas}^\mathrm{R}=12` and :math:`N_\mathrm{bas}^\mathrm{A}=12` are usually sufficient.
+The default values of :math:`N_\mathrm{bas}^\mathrm{R}=8` and :math:`N_\mathrm{bas}^\mathrm{A}=8` are usually sufficient.
 
 **Note:** These parameters should not be confused with :math:`n_\mathrm{max}^\mathrm{R}` and :math:`n_\mathrm{max}^\mathrm{A}`, which are set via the :ref:`n_max keyword <kw_n_max>`.

--- a/doc/nep/input_parameters/lambda_1.rst
+++ b/doc/nep/input_parameters/lambda_1.rst
@@ -11,4 +11,4 @@ The syntax is::
   lambda_1 <weight>
 
 Here, :attr:`<weight>` represents :math:`\lambda_1`, which can be set to any non-negative values. 
-The default value is :math:`\lambda_1 = \sqrt{N}/1000`, where :math:`N` is the total number of training parameters.
+The default value is 0, which means that :math:`\mathcal{L}_1` regularization is not used by default.

--- a/doc/nep/input_parameters/lambda_1.rst
+++ b/doc/nep/input_parameters/lambda_1.rst
@@ -11,4 +11,4 @@ The syntax is::
   lambda_1 <weight>
 
 Here, :attr:`<weight>` represents :math:`\lambda_1`, which can be set to any non-negative values. 
-The default value is 0, which means that :math:`\mathcal{L}_1` regularization is not used by default.
+The default value is :math:`\lambda_1 = \sqrt{N}/1000`, where :math:`N` is the total number of training parameters.

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -192,7 +192,7 @@ void Parameters::calculate_parameters()
   }
 
   if (!is_lambda_1_set) {
-    lambda_1 = 0.0f;
+    lambda_1 = sqrt(number_of_variables * 1.0e-6f);
   }
   if (!is_lambda_2_set) {
     lambda_2 = sqrt(number_of_variables * 1.0e-6f);

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -77,8 +77,8 @@ void Parameters::set_default_parameters()
   version = 4;                 // NEP4 is the best
   rc_radial = 8.0f;            // large enough for vdw/coulomb
   rc_angular = 4.0f;           // large enough in most cases
-  basis_size_radial = 12;      // large enough in most cases
-  basis_size_angular = 12;     // large enough in most cases
+  basis_size_radial = 8;       // large enough in most cases
+  basis_size_angular = 8;      // large enough in most cases
   n_max_radial = 4;            // a relatively small value to achieve high speed
   n_max_angular = 4;           // a relatively small value to achieve high speed
   L_max = 4;                   // the only supported value
@@ -192,7 +192,7 @@ void Parameters::calculate_parameters()
   }
 
   if (!is_lambda_1_set) {
-    lambda_1 = sqrt(number_of_variables * 1.0e-6f);
+    lambda_1 = 0.0f;
   }
   if (!is_lambda_2_set) {
     lambda_2 = sqrt(number_of_variables * 1.0e-6f);


### PR DESCRIPTION
We should expose the *best* default hyperparameters to the users.

* Based on our recent tests, $L_1$ regularization is not needed. $L_1$ regularization can totally kill some parameters, which makes new training restarting from old one(s) difficult. It takes a long time to bring the dead parameters alive.
* Set the default values for $N_{\rm bas}^{\rm R/A}$ from (12, 12) back to (8, 8), which are actually more than enough. Using (12,12) leads to too many trainable parameters for large models with many species.