### PR TITLE
fix a bug of nonequilibrium TI

### DIFF
--- a/src/integrate/ensemble_ti.cuh
+++ b/src/integrate/ensemble_ti.cuh
@@ -53,7 +53,7 @@ protected:
   double lambda = 0;
   double pe, espring;
   // spring constants
-  std::map<std::string, int> spring_map;
+  std::map<std::string, double> spring_map;
   GPU_Vector<double> gpu_k;
   std::vector<double> cpu_k;
   GPU_Vector<double> gpu_espring;

--- a/src/integrate/ensemble_ti_spring.cuh
+++ b/src/integrate/ensemble_ti_spring.cuh
@@ -57,7 +57,7 @@ protected:
   int t_equil = -1, t_switch = -1;
   double pe, espring;
   // spring constants
-  std::map<std::string, int> spring_map;
+  std::map<std::string, double> spring_map;
   GPU_Vector<double> gpu_k;
   std::vector<double> cpu_k;
   GPU_Vector<double> gpu_espring;


### PR DESCRIPTION
The spring constants were mistakenly converted to `int`, but this error has now been corrected.