### PR TITLE
add cstring header

### DIFF
--- a/src/force/eam.cu
+++ b/src/force/eam.cu
@@ -22,6 +22,7 @@ The EAM potential. Currently two analytical versions:
 #include "eam.cuh"
 #include "neighbor.cuh"
 #include "utilities/error.cuh"
+#include <cstring>
 #define BLOCK_SIZE_FORCE 64
 
 EAM::EAM(FILE* fid, char* name, int num_types, const int number_of_atoms)

--- a/src/force/fcp.cu
+++ b/src/force/fcp.cu
@@ -19,6 +19,7 @@ The force constant potential (FCP)
 
 #include "fcp.cuh"
 #include "utilities/error.cuh"
+#include <cstring>
 #include <vector>
 
 FCP::FCP(FILE* fid, const int num_types, const int N, const Box& box)

--- a/src/force/force.cu
+++ b/src/force/force.cu
@@ -28,6 +28,7 @@ The driver class calculating force and related quantities.
 #include "utilities/common.cuh"
 #include "utilities/error.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 #include <iostream>
 #include <vector>
 

--- a/src/integrate/ensemble_msst.cu
+++ b/src/integrate/ensemble_msst.cu
@@ -18,6 +18,7 @@ The NVE ensemble integrator.
 ------------------------------------------------------------------------------*/
 
 #include "ensemble_msst.cuh"
+#include <cstring>
 
 namespace
 {

--- a/src/integrate/ensemble_mttk.cu
+++ b/src/integrate/ensemble_mttk.cu
@@ -21,6 +21,7 @@ P and T are both set -> NPT ensemable
 ------------------------------------------------------------------------------*/
 
 #include "ensemble_mttk.cuh"
+#include <cstring>
 
 namespace
 {

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -18,6 +18,7 @@
 #include "utilities/error.cuh"
 #include "utilities/read_file.cuh"
 #include <cmath>
+#include <cstring>
 #include <iostream>
 
 const std::string ELEMENTS[NUM_ELEMENTS] = {

--- a/src/mc/mc.cu
+++ b/src/mc/mc.cu
@@ -23,6 +23,7 @@ The driver class for the various MC ensembles.
 #include "model/atom.cuh"
 #include "utilities/common.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 
 void MC::initialize(void)
 {

--- a/src/measure/compute.cu
+++ b/src/measure/compute.cu
@@ -21,6 +21,7 @@ Compute block (space) averages of various per-atom quantities.
 #include "utilities/common.cuh"
 #include "utilities/error.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 #include <vector>
 
 #define DIM 3

--- a/src/measure/dos.cu
+++ b/src/measure/dos.cu
@@ -30,6 +30,7 @@ Reference for DOS:
 #include "utilities/common.cuh"
 #include "utilities/error.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 
 namespace
 {

--- a/src/measure/dump_force.cu
+++ b/src/measure/dump_force.cu
@@ -23,6 +23,7 @@ Dump force data to a file at a given interval.
 #include "utilities/error.cuh"
 #include "utilities/gpu_vector.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 #include <vector>
 
 void Dump_Force::parse(const char** param, int num_param, const std::vector<Group>& groups)

--- a/src/measure/dump_piston.cu
+++ b/src/measure/dump_piston.cu
@@ -14,6 +14,7 @@
 */
 
 #include "dump_piston.cuh"
+#include <cstring>
 
 namespace
 {

--- a/src/measure/dump_velocity.cu
+++ b/src/measure/dump_velocity.cu
@@ -24,6 +24,7 @@ Dump velocity data to a file at a given interval.
 #include "utilities/error.cuh"
 #include "utilities/gpu_vector.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 #include <vector>
 
 void Dump_Velocity::parse(const char** param, int num_param, const std::vector<Group>& groups)

--- a/src/measure/hac.cu
+++ b/src/measure/hac.cu
@@ -21,6 +21,7 @@ Calculate the heat current autocorrelation (HAC) function.
 #include "hac.cuh"
 #include "utilities/common.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 #include <vector>
 
 #define NUM_OF_HEAT_COMPONENTS 5

--- a/src/measure/lsqt.cu
+++ b/src/measure/lsqt.cu
@@ -21,6 +21,7 @@
 #include "utilities/read_file.cuh"
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 
 /*----------------------------------------------------------------------------80
     This file implements the linear-scaling quantum transport (LSQT) method

--- a/src/measure/measure.cu
+++ b/src/measure/measure.cu
@@ -21,6 +21,7 @@ The driver class dealing with measurement.
 #include "model/atom.cuh"
 #include "utilities/error.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 #define NUM_OF_HEAT_COMPONENTS 5
 
 void Measure::initialize(

--- a/src/measure/modal_analysis.cu
+++ b/src/measure/modal_analysis.cu
@@ -31,6 +31,7 @@ GPUMD Contributing author: Alexander Gabourie (Stanford University)
 
 #include "modal_analysis.cuh"
 #include "utilities/error.cuh"
+#include <cstring>
 
 #define NUM_OF_HEAT_COMPONENTS 5
 #define BLOCK_SIZE 128

--- a/src/measure/msd.cu
+++ b/src/measure/msd.cu
@@ -25,6 +25,7 @@ Calculate:
 #include "utilities/common.cuh"
 #include "utilities/error.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 
 namespace
 {

--- a/src/measure/parse_utilities.cu
+++ b/src/measure/parse_utilities.cu
@@ -20,6 +20,7 @@ A function parsing the "group" option in some keywords
 #include "model/group.cuh"
 #include "parse_utilities.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 
 void parse_group(
   const char** param,

--- a/src/measure/rdf.cu
+++ b/src/measure/rdf.cu
@@ -27,6 +27,7 @@ Calculate:
 #include "utilities/common.cuh"
 #include "utilities/error.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 
 namespace
 {

--- a/src/measure/sdc.cu
+++ b/src/measure/sdc.cu
@@ -25,6 +25,7 @@ Calculate:
 #include "utilities/common.cuh"
 #include "utilities/error.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 
 namespace
 {

--- a/src/measure/shc.cu
+++ b/src/measure/shc.cu
@@ -26,6 +26,7 @@ with many-body potentials, Phys. Rev. B 99, 064308 (2019).
 #include "utilities/common.cuh"
 #include "utilities/error.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 
 const int BLOCK_SIZE_SHC = 128;
 

--- a/src/minimize/minimize.cu
+++ b/src/minimize/minimize.cu
@@ -23,6 +23,7 @@ The driver class for minimizers.
 #include "minimizer_sd.cuh"
 #include "utilities/error.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 #include <memory>
 
 void Minimize::parse_minimize(

--- a/src/utilities/error.cu
+++ b/src/utilities/error.cu
@@ -14,6 +14,7 @@
 */
 
 #include "error.cuh"
+#include <cstring>
 #include <errno.h>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
Testing on a particular platform reveals the absence of `<cstring>` header in some files. 