### PR TITLE
allow compute SHC for all group IDs except group ID 0 in a given grouping method

### DIFF
--- a/doc/gpumd/input_parameters/compute_shc.rst
+++ b/doc/gpumd/input_parameters/compute_shc.rst
@@ -36,7 +36,8 @@ The angular frequency data will be :attr:`max_omega/num_omega, 2*max_omega/num_o
 
 This means that :math:`K(t)` will be calculated for atoms in group :attr:`group_id` of grouping method :attr:`grouping_method`.
 Usually, :attr:`group_id` should be :math:`\geq 0` and smaller than the number of groups in grouping method :attr:`grouping_method`.
-If :attr:`grouping_method` is 0 and :attr:`group_id` is -1, it means to calculate the :math:`K(t)` for every group.
+If :attr:`grouping_method` is assigned and :attr:`group_id` is -1, it means to calculate the :math:`K(t)` for every :attr:`group_id` except :attr:`group_id` 0 in the assigned :attr:`grouping_method`.
+Since it is very time and memory consuming to calculate the all group :math:`K(t)` for a large system, so one can assign the part that don't want to calculate to :attr:`group_id` 0.
 Also, grouping method :attr:`grouping_method` must be defined in the :ref:`simulation model input file <model_xyz>`.
 If this option is missing, it means computing :math:`K(t)` for the whole system.
 
@@ -69,6 +70,22 @@ The command::
 means that
 
 * you want to calculate :math:`K(t)` for atoms in group :attr:`4` defined in grouping method :attr:`0`
+* the sampling interval is 1 (sample the data at each time step)
+* the maximum number of correlation steps is 500
+* the transport direction is :math:`y`
+* you want to consider 500 frequency points
+* the maximum angular frequency is 200 THz
+
+Example 3
+^^^^^^^^^
+
+The command::
+
+  compute_shc 1 500 1 500 200.0 group 1 -1
+
+means that
+
+* you want to calculate :math:`K(t)` for all :attr:`group_id` except :attr:`group_id` 0 defined in grouping method :attr:`1`
 * the sampling interval is 1 (sample the data at each time step)
 * the maximum number of correlation steps is 500
 * the transport direction is :math:`y`

--- a/doc/gpumd/output_files/shc_out.rst
+++ b/doc/gpumd/output_files/shc_out.rst
@@ -32,3 +32,5 @@ In the next :attr:`num_omega` rows:
 :math:`J_q^{\rm in}(\omega) + J_q^{\rm out}(\omega) = J_q(\omega)` is exactly the left expression in Eq. (20) of [Fan2019]_.
 
 Only the potential part of the heat current has been included.
+
+If :attr: 'group_id' is -1, then the file follows the above rules and will contain :math:`K(t)` and :math:`J_q(\omega)` for each group id except group id 0. And the contents of the :attr: 'group_id' are arranged from smallest to largest.

--- a/src/measure/parse_utilities.cu
+++ b/src/measure/parse_utilities.cu
@@ -54,9 +54,6 @@ void parse_group(
   if (group_id < 0 && !allow_all_groups) {
     PRINT_INPUT_ERROR("group ID should >= 0.\n");
   }
-  if (group_id < -1 && allow_all_groups) {
-    PRINT_INPUT_ERROR("group ID should >= -1 for computing SHC.\n");   // Only for computing all group_id's SHC
-  }
 
   printf("    grouping method is %d and group ID is %d.\n", grouping_method, group_id);
 

--- a/src/measure/parse_utilities.cu
+++ b/src/measure/parse_utilities.cu
@@ -54,6 +54,9 @@ void parse_group(
   if (group_id < 0 && !allow_all_groups) {
     PRINT_INPUT_ERROR("group ID should >= 0.\n");
   }
+  if (group_id < -1 && allow_all_groups) {
+    PRINT_INPUT_ERROR("group ID should >= -1 for computing SHC.\n");   // Only for computing all group_id's SHC
+  }
 
   printf("    grouping method is %d and group ID is %d.\n", grouping_method, group_id);
 

--- a/src/measure/shc.cu
+++ b/src/measure/shc.cu
@@ -41,7 +41,7 @@ void SHC::preprocess(const int N, const std::vector<Group>& group)
     group_size = N;
     group_num = 1;
   } else {
-    if (group_method == 0 && group_id == -1) {
+    if (group_id == -1) {
       group_size = N;
       group_num = group[group_method].number;
     } else {
@@ -185,7 +185,7 @@ void SHC::process(
     CHECK(cudaMemcpy(vy.data() + offset, vy_tmp, sizeof(double) * N, cudaMemcpyDeviceToDevice));
     CHECK(cudaMemcpy(vz.data() + offset, vz_tmp, sizeof(double) * N, cudaMemcpyDeviceToDevice));
   } else {
-    if (group_method == 0 && group_id == -1) {
+    if (group_id == -1) {
       for (int n = 0; n < group_num; ++n) {
         int offset_s = Nc * group[group_method].cpu_size_sum[n] + 
                        correlation_step * group[group_method].cpu_size[n];
@@ -231,7 +231,7 @@ void SHC::process(
   if (sample_step >= Nc - 1) {
     ++num_time_origins;
 
-    if (group_method == 0 && group_id == -1) {
+    if (group_id == -1) {
       for (int n = 0; n < group_num; ++n) {
         int offset_s = Nc * group[group_method].cpu_size_sum[n];
         int offset_e = offset_s + correlation_step * group[group_method].cpu_size[n];
@@ -303,7 +303,7 @@ void SHC::average_k()
   ko_positive.copy_to_host(ko_positive_cpu.data());
 
   const double scalar = 1000.0 / TIME_UNIT_CONVERSION / num_time_origins;
-  if (group_method == 0 && group_id == -1) {
+  if (group_id == -1) {
     for (int n = 0; n < group_num; ++n) {
       const int offset_k = (Nc * 2 - 1) * n;
       const int offset_n = Nc * n;
@@ -331,7 +331,7 @@ void SHC::average_k()
 
 void SHC::find_shc(const double dt_in_ps, const double d_omega)
 {
-  if (group_method == 0 && group_id == -1) {
+  if (group_id == -1) {
     for (int n = 0; n < group_num; ++n) {
       const int offset_k = (Nc * 2 - 1) * n;
       for (int nc = 0; nc < Nc * 2 - 1; ++nc) {
@@ -390,7 +390,7 @@ void SHC::postprocess(const double time_step)
 
   average_k();
   find_shc(dt_in_ps, d_omega);
-  if (group_method == 0 && group_id == -1) {
+  if (group_id == -1) {
     for (int n = 0; n < group_num; ++n) {
       const int offset_k = (Nc * 2 - 1) * n;
       // ki and ko are in units of A*eV/ps


### PR DESCRIPTION
It was modified based on Dr. Xuke's version. In the original version, only the SHC of all group IDs in the grouping method 0 could be calculated. Grouping method 0 is already occupied by the heat source and sink when using NEMD. In this case, the group IDs in group method 0 cannot be divided arbitrarily.

In the PR version, there is no limit to grouping method 0. All possible group methods can be specified. **In addition, the SHC output group ID 0 is skipped**. Because when using NEMD, users tend not to output fix groups and heat sink and source groups. This means that when regrouping, the user can assign this part to group ID 0, thereby avoiding wasting computation time and memory to compute all the other remaining group IDs. Of course, when the user still wants to compute all group time for all systems, they can do so without assigning atoms to group ID 0. This provides some flexibility.

In this PR, the main modification is **shc.cu**. The corresponding user manual and output instructions have also been modified accordingly.