### PR TITLE
better hyperparameters in snes

### DIFF
--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -193,17 +193,17 @@ void Parameters::calculate_parameters()
 
   if (version == 4) {
     if (!is_lambda_1_set) {
-      lambda_1 = sqrt(number_of_variables * 1.0e-6f / num_types);
+      lambda_1 = sqrt(number_of_variables * 1.0e-8f / num_types);
     }
     if (!is_lambda_2_set) {
-      lambda_2 = sqrt(number_of_variables * 1.0e-6f / num_types);
+      lambda_2 = sqrt(number_of_variables * 1.0e-8f / num_types);
     }
   } else {
     if (!is_lambda_1_set) {
-      lambda_1 = sqrt(number_of_variables * 1.0e-6f);
+      lambda_1 = sqrt(number_of_variables * 1.0e-8f);
     }
     if (!is_lambda_2_set) {
-      lambda_2 = sqrt(number_of_variables * 1.0e-6f);
+      lambda_2 = sqrt(number_of_variables * 1.0e-8f);
     }
   }
 

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -93,8 +93,12 @@ void SNES::initialize_mu_and_sigma(Parameters& para)
   if (fid_restart == NULL) {
     std::uniform_real_distribution<float> r1(0, 1);
     for (int n = 0; n < number_of_variables; ++n) {
-      mu[n] = r1(rng) - 0.5f;
-      sigma[n] = 0.1f;
+      mu[n] = (r1(rng) - 0.5f) * 2.0f;
+      int num = number_of_variables;
+      if (para.version == 4) {
+        num /= para.num_types;
+      }
+      sigma[n] =  (3.0f + std::log(num * 1.0f)) / (5.0f * sqrt(num * 1.0f));
     }
   } else {
     for (int n = 0; n < number_of_variables; ++n) {


### PR DESCRIPTION
* Increasing initial means $\mu$ from the interval [0.5, 0.5] to the interval [-1, 1], which might be a more optimal starting point.
* Reducing initial searching variances $\sigma$ from 0.1 to $(3 + \ln N) / (5 \sqrt{N})$, which might make the training smoother, particularly in the beginning.
* Reducing the default regularization strength by 10 times, in accordance with the reduced $\sigma$. Now a good regularization parameter is of the order of 0.005. 


Now I understand why SNES needs so large regularization previously. It was due to the too large initial searching variance (learning rates for the parameters).