### PR TITLE
Add separated parameter for dump_exyz

### DIFF
--- a/doc/gpumd/input_parameters/dump_exyz.rst
+++ b/doc/gpumd/input_parameters/dump_exyz.rst
@@ -15,12 +15,14 @@ Syntax
    dump_exyz <interval> <has_velocity>
    dump_exyz <interval> <has_velocity> <has_force>
    dump_exyz <interval> <has_velocity> <has_force> <has_potential>
+   dump_exyz <interval> <has_velocity> <has_force> <has_potential> <separated>
 
 Here, the :attr:`interval` parameter is the output interval (number of steps) of the data.
 :attr:`has_velocity` can be 1 or 0, which means the velocities will or will not be included in the output.
 :attr:`has_force` can be 1 or 0, which means the forces will or will not be included in the output.
 :attr:`has_potential` can be 1 or 0, which means the atomic potential energies will or will not be included in the output.
 The atomic positions will always be included in the output.
+:attr:`separated` can be 1 or 0, which means the output will or will not be separated into individual frames.
 
 Examples
 --------
@@ -32,6 +34,7 @@ Examples
     dump_exyz 1000 1 1    # dump positions, velocities, and forces
     dump_exyz 1000 1 1 1  # dump positions, velocities, forces, and potentials
     dump_exyz 1000 0 1 1  # dump positions, forces and potentials
+    dump_exyz 100 0 1 1 1 # dump positions, forces and potentials into dump.100.xyz, dump.200.xyz and so on
 
 Caveats
 -------

--- a/src/measure/dump_exyz.cuh
+++ b/src/measure/dump_exyz.cuh
@@ -40,6 +40,7 @@ private:
   int has_velocity_ = 0;
   int has_force_ = 0;
   int has_potential_ = 0;
+  int separated_ = 0;
   FILE* fid_;
   char filename_[200];
   void output_line2(


### PR DESCRIPTION
This PR adds a parameter in dump_exyz to generate separated frames to fix issue #605 . The documentation is also updated.