### PR TITLE
allow for tune normalization

### DIFF
--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -132,7 +132,7 @@ void Fitness::compute(
   int population_iter = (para.population_size - 1) / deviceCount + 1;
 
   if (generation == 0) {
-    std::vector<float> dummy_solution(para.number_of_variables * deviceCount, 1.0f);
+    std::vector<float> dummy_solution(para.number_of_variables * deviceCount, para.initial_para);
     for (int n = 0; n < num_batches; ++n) {
       potential->find_force(
         para, 

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -95,6 +95,8 @@ void Parameters::set_default_parameters()
   use_full_batch = 0;          // default is not to enable effective full-batch
   population_size = 50;        // almost optimal
   maximum_generation = 100000; // a good starting point
+  initial_para = 1.0f;
+
   type_weight_cpu.resize(NUM_ELEMENTS);
   zbl_para.resize(550); // Maximum number of zbl parameters
   for (int n = 0; n < NUM_ELEMENTS; ++n) {
@@ -454,6 +456,8 @@ void Parameters::parse_one_keyword(std::vector<std::string>& tokens)
     parse_force_delta(param, num_param);
   } else if (strcmp(param[0], "zbl") == 0) {
     parse_zbl(param, num_param);
+  } else if (strcmp(param[0], "initial_para") == 0) {
+    parse_initial_para(param, num_param);
   } else {
     PRINT_KEYWORD_ERROR(param[0]);
   }
@@ -917,5 +921,22 @@ void Parameters::parse_generation(const char** param, int num_param)
     PRINT_INPUT_ERROR("maximum number of generations should >= 0.");
   } else if (maximum_generation > 10000000) {
     PRINT_INPUT_ERROR("maximum number of generations should <= 10000000.");
+  }
+}
+
+void Parameters::parse_initial_para(const char** param, int num_param)
+{
+  if (num_param != 2) {
+    PRINT_INPUT_ERROR("initial_para should have 1 parameter.\n");
+  }
+
+  double initial_para_tmp = 0.0;
+  if (!is_valid_real(param[1], &initial_para_tmp)) {
+    PRINT_INPUT_ERROR("initial_para should be a number.\n");
+  }
+  initial_para = initial_para_tmp;
+
+  if (initial_para < 0.1f || initial_para > 1.0f) {
+    PRINT_INPUT_ERROR("initial_para should be within [0.1, 1].");
   }
 }

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -53,6 +53,7 @@ public:
   float zbl_rc_outer;     // outer cutoff for the universal ZBL potential
   int train_mode; // 0=potential, 1=dipole, 2=polarizability, 3=temperature-dependent free energy
   int prediction; // 0=no, 1=yes
+  float initial_para;
 
   // check if a parameter has been set:
   bool is_train_mode_set;
@@ -125,4 +126,5 @@ private:
   void parse_batch(const char** param, int num_param);
   void parse_population(const char** param, int num_param);
   void parse_generation(const char** param, int num_param);
+  void parse_initial_para(const char** param, int num_param);
 };


### PR DESCRIPTION
Add this keyword in nep.in:

```
initial_para <value>
```

`value` can be within [0.1, 1], defaulting to 1 (as in previous master).

Reducing this value will make higher-body correlations more important and also increases the overall values of the descriptors. Therefore, one might need to increase the regularization weights (one can check the default values from screen output) after reducing `value`.

