### PR TITLE
mini-batch training

### DIFF
--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -51,16 +51,19 @@ Fitness::Fitness(Parameters& para)
   for (int batch_id = 0; batch_id < num_batches; ++batch_id) {
     train_set[batch_id].resize(deviceCount);
   }
+  int count = 0;
   for (int batch_id = 0; batch_id < num_batches; ++batch_id) {
-    int n1 = batch_id * para.batch_size;
-    int n2 = std::min(int(structures_train.size()), n1 + para.batch_size);
+    const int batch_size_minimal = structures_train.size() / num_batches;
+    const bool is_larger_batch = batch_id + batch_size_minimal * num_batches < structures_train.size();
+    const int batch_size = is_larger_batch ? batch_size_minimal + 1 : batch_size_minimal;
+    count += batch_size;
     printf("\nBatch %d:\n", batch_id);
-    printf("Number of configurations = %d.\n", n2 - n1);
+    printf("Number of configurations = %d.\n", batch_size);
     for (int device_id = 0; device_id < deviceCount; ++device_id) {
       print_line_1();
       printf("Constructing train_set in device  %d.\n", device_id);
       CHECK(cudaSetDevice(device_id));
-      train_set[batch_id][device_id].construct(para, structures_train, n1, n2, device_id);
+      train_set[batch_id][device_id].construct(para, structures_train, count - batch_size, count, device_id);
       print_line_2();
     }
   }

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -193,17 +193,17 @@ void Parameters::calculate_parameters()
 
   if (version == 4) {
     if (!is_lambda_1_set) {
-      lambda_1 = sqrt(number_of_variables * 1.0e-7f / num_types);
+      lambda_1 = sqrt(number_of_variables * 1.0e-6f / num_types);
     }
     if (!is_lambda_2_set) {
-      lambda_2 = sqrt(number_of_variables * 1.0e-7f / num_types);
+      lambda_2 = sqrt(number_of_variables * 1.0e-6f / num_types);
     }
   } else {
     if (!is_lambda_1_set) {
-      lambda_1 = sqrt(number_of_variables * 1.0e-7f);
+      lambda_1 = sqrt(number_of_variables * 1.0e-6f);
     }
     if (!is_lambda_2_set) {
-      lambda_2 = sqrt(number_of_variables * 1.0e-7f);
+      lambda_2 = sqrt(number_of_variables * 1.0e-6f);
     }
   }
 

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -96,6 +96,7 @@ void Parameters::set_default_parameters()
   population_size = 50;        // almost optimal
   maximum_generation = 100000; // a good starting point
   initial_para = 1.0f;
+  sigma0 = 0.1f;
 
   type_weight_cpu.resize(NUM_ELEMENTS);
   zbl_para.resize(550); // Maximum number of zbl parameters
@@ -458,6 +459,8 @@ void Parameters::parse_one_keyword(std::vector<std::string>& tokens)
     parse_zbl(param, num_param);
   } else if (strcmp(param[0], "initial_para") == 0) {
     parse_initial_para(param, num_param);
+  } else if (strcmp(param[0], "sigma0") == 0) {
+    parse_sigma0(param, num_param);
   } else {
     PRINT_KEYWORD_ERROR(param[0]);
   }
@@ -938,5 +941,22 @@ void Parameters::parse_initial_para(const char** param, int num_param)
 
   if (initial_para < 0.1f || initial_para > 1.0f) {
     PRINT_INPUT_ERROR("initial_para should be within [0.1, 1].");
+  }
+}
+
+void Parameters::parse_sigma0(const char** param, int num_param)
+{
+  if (num_param != 2) {
+    PRINT_INPUT_ERROR("sigma0 should have 1 parameter.\n");
+  }
+
+  double sigma0_tmp = 0.0;
+  if (!is_valid_real(param[1], &sigma0_tmp)) {
+    PRINT_INPUT_ERROR("sigma0 should be a number.\n");
+  }
+  sigma0 = sigma0_tmp;
+
+  if (sigma0 < 0.01f || sigma0 > 0.1f) {
+    PRINT_INPUT_ERROR("sigma0 should be within [0.01, 0.1].");
   }
 }

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -54,6 +54,7 @@ public:
   int train_mode; // 0=potential, 1=dipole, 2=polarizability, 3=temperature-dependent free energy
   int prediction; // 0=no, 1=yes
   float initial_para;
+  float sigma0;
 
   // check if a parameter has been set:
   bool is_train_mode_set;
@@ -127,4 +128,5 @@ private:
   void parse_population(const char** param, int num_param);
   void parse_generation(const char** param, int num_param);
   void parse_initial_para(const char** param, int num_param);
+  void parse_sigma0(const char** param, int num_param);
 };

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -532,7 +532,7 @@ static __global__ void gpu_update_mu_and_sigma(
     }
     const float sigma = g_sigma[v];
     g_mu[v] += sigma * gradient_mu;
-    g_sigma[v] = max(0.001f, min(0.01f, sigma * exp(eta_sigma * gradient_sigma)));
+    g_sigma[v] = max(0.000f, min(0.01f, sigma * exp(eta_sigma * gradient_sigma)));
   }
 }
 

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -97,7 +97,7 @@ void SNES::initialize_mu_and_sigma(Parameters& para)
     std::uniform_real_distribution<float> r1(0, 1);
     for (int n = 0; n < number_of_variables; ++n) {
       mu[n] = (r1(rng) - 0.5f) * 2.0f;
-      sigma[n] = 0.01f;
+      sigma[n] = para.sigma0;
     }
   } else {
     for (int n = 0; n < number_of_variables; ++n) {
@@ -260,7 +260,7 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
         fitness_L2,
         population.data() + number_of_variables * best_index);
 
-      update_mu_and_sigma();
+      update_mu_and_sigma(para);
       if (0 == (n + 1) % 100) {
         output_mu_and_sigma(para);
       }
@@ -508,6 +508,7 @@ static __global__ void gpu_update_mu_and_sigma(
   const int population_size,
   const int number_of_variables,
   const float eta_sigma,
+  const float simga0,
   const int* g_type_of_variable,
   const int* g_index,
   const float* g_utility,
@@ -528,11 +529,11 @@ static __global__ void gpu_update_mu_and_sigma(
     }
     const float sigma = g_sigma[v];
     g_mu[v] += sigma * gradient_mu;
-    g_sigma[v] = min(0.01f, sigma * exp(eta_sigma * gradient_sigma));
+    g_sigma[v] = min(simga0, sigma * exp(eta_sigma * gradient_sigma));
   }
 }
 
-void SNES::update_mu_and_sigma()
+void SNES::update_mu_and_sigma(Parameters& para)
 {
   cudaSetDevice(0); // normally use GPU-0
   gpu_type_of_variable.copy_from_host(type_of_variable.data());
@@ -542,6 +543,7 @@ void SNES::update_mu_and_sigma()
     population_size,
     number_of_variables,
     eta_sigma,
+    para.sigma0,
     gpu_type_of_variable.data(),
     gpu_index.data(),
     gpu_utility.data(),

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -532,7 +532,7 @@ static __global__ void gpu_update_mu_and_sigma(
     }
     const float sigma = g_sigma[v];
     g_mu[v] += sigma * gradient_mu;
-    g_sigma[v] = max(0.000f, min(0.01f, sigma * exp(eta_sigma * gradient_sigma)));
+    g_sigma[v] = max(0.001f, min(0.01f, sigma * exp(eta_sigma * gradient_sigma)));
   }
 }
 

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -532,7 +532,7 @@ static __global__ void gpu_update_mu_and_sigma(
     }
     const float sigma = g_sigma[v];
     g_mu[v] += sigma * gradient_mu;
-    g_sigma[v] = min(0.01f, sigma * exp(eta_sigma * gradient_sigma) * 0.99999f);
+    g_sigma[v] = max(0.001f, min(0.01f, sigma * exp(eta_sigma * gradient_sigma)));
   }
 }
 

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -101,7 +101,7 @@ void SNES::initialize_mu_and_sigma(Parameters& para)
       if (para.version == 4) {
         num /= para.num_types;
       }
-      sigma[n] =  (3.0f + std::log(num * 1.0f)) / (5.0f * sqrt(num * 1.0f));
+      sigma[n] = 0.01f;
     }
   } else {
     for (int n = 0; n < number_of_variables; ++n) {
@@ -532,7 +532,7 @@ static __global__ void gpu_update_mu_and_sigma(
     }
     const float sigma = g_sigma[v];
     g_mu[v] += sigma * gradient_mu;
-    g_sigma[v] = sigma * exp(eta_sigma * gradient_sigma);
+    g_sigma[v] = sigma * exp(eta_sigma * gradient_sigma) * 0.99999f;
   }
 }
 

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -97,10 +97,6 @@ void SNES::initialize_mu_and_sigma(Parameters& para)
     std::uniform_real_distribution<float> r1(0, 1);
     for (int n = 0; n < number_of_variables; ++n) {
       mu[n] = (r1(rng) - 0.5f) * 2.0f;
-      int num = number_of_variables;
-      if (para.version == 4) {
-        num /= para.num_types;
-      }
       sigma[n] = 0.01f;
     }
   } else {
@@ -532,7 +528,7 @@ static __global__ void gpu_update_mu_and_sigma(
     }
     const float sigma = g_sigma[v];
     g_mu[v] += sigma * gradient_mu;
-    g_sigma[v] = max(0.000f, min(0.01f, sigma * exp(eta_sigma * gradient_sigma)));
+    g_sigma[v] = min(0.01f, sigma * exp(eta_sigma * gradient_sigma));
   }
 }
 

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -532,7 +532,7 @@ static __global__ void gpu_update_mu_and_sigma(
     }
     const float sigma = g_sigma[v];
     g_mu[v] += sigma * gradient_mu;
-    g_sigma[v] = sigma * exp(eta_sigma * gradient_sigma) * 0.99999f;
+    g_sigma[v] = min(0.01f, sigma * exp(eta_sigma * gradient_sigma) * 0.99999f);
   }
 }
 

--- a/src/main_nep/snes.cuh
+++ b/src/main_nep/snes.cuh
@@ -63,6 +63,6 @@ protected:
   void regularize(Parameters&);
   void regularize_NEP4(Parameters& para);
   void sort_population(Parameters& para);
-  void update_mu_and_sigma();
+  void update_mu_and_sigma(Parameters& para);
   void output_mu_and_sigma(Parameters& para);
 };

--- a/src/main_nep/structure.cu:Zone.Identifier
+++ b/src/main_nep/structure.cu:Zone.Identifier
@@ -1,2 +1,0 @@
-[ZoneTransfer]
-ZoneId=3

--- a/src/main_nep/structure.cu:Zone.Identifier
+++ b/src/main_nep/structure.cu:Zone.Identifier
@@ -1,0 +1,2 @@
+[ZoneTransfer]
+ZoneId=3


### PR DESCRIPTION
This PR aims to improve the training results when using mini-batches, based on the following tricks:
* Increase the default regularization by a factor of $\sqrt{10}$.
* Set up an upper limit of the learning rate: $\sigma_{\rm max}=0.01$, which is also the initial learning rate $\sigma_0$.
* Prepare the mini-batches according to energy/atom values, maximizing the diversity for each batch.