### PR TITLE
fix compile bug in structure.cu

### DIFF
--- a/src/main_nep/structure.cu
+++ b/src/main_nep/structure.cu
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <iterator>
 #include <random>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
我测试了一下，gcc可以用random或numeric任意头文件包含iota，MSVC只能numeric
![84632a5909259aa6f423ae3b26c4df07](https://github.com/brucefan1983/GPUMD/assets/44524468/aac715b5-9d10-4445-a9aa-f83192c3fbc1)
![a4b97c756bf0df0dd9d91085604bef2f](https://github.com/brucefan1983/GPUMD/assets/44524468/4d3de694-f0f2-4936-bd1c-bf4d49b85b0a)
![948eeb9572e891e46b2a5b822af70253](https://github.com/brucefan1983/GPUMD/assets/44524468/71b90d4a-5c4d-49d9-9e62-10c4e542b4ff)
