### PR TITLE
fixed a bug and brought compile workflows for GPUMD

### DIFF
--- a/.github/workflows/cuda-build.yml
+++ b/.github/workflows/cuda-build.yml
@@ -1,0 +1,24 @@
+name: CUDA CI
+
+on:
+  pull_request:
+    branches:
+      - master  # 你可以根据需要调整分支
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: 
+      image: nvidia/cuda:11.2.2-devel-ubuntu20.04  # 使用适合你的CUDA版本的官方NVIDIA容器
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y build-essential
+
+      - name: Build with Make
+        run: cd src && make

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -13,8 +13,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2      
       
-    # - name: Set up MSVC environment
-    #   uses: ilammy/msvc-dev-cmd@v1.4.1
+    - name: Set up MSVC environment
+      uses: ilammy/msvc-dev-cmd@v1.13.0
+      with:
+        arch: x64
+        vsversion: "2019"
       
     - name: Install CUDA      
       run: |

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v2      
       
     - name: Set up MSVC environment
-      uses: ilammy/msvc-dev-cmd@v1.13.0
+      uses: ilammy/msvc-dev-cmd@v1.12.0
       with:
         arch: x64
         vsversion: "2019"

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v2      
       
     - name: Set up MSVC environment
-      uses: ilammy/msvc-dev-cmd@v1.12.0
+      uses: ilammy/msvc-dev-cmd@vs-version
       with:
         arch: x64
         vsversion: "2019"

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -11,8 +11,9 @@ jobs:
 
     steps:
     - name: Checkout code
-    - uses: actions/checkout@v2
-    - uses: ilammy/msvc-dev-cmd@v1.4.1
+      uses: actions/checkout@v2      
+    - name: Set up MSVC environment
+      uses: ilammy/msvc-dev-cmd@v1.4.1
       
     - name: Install CUDA
       run: |

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -17,7 +17,7 @@ jobs:
       
     - name: Install CUDA
       run: |
-        choco install cuda --version=11.2
+        choco install cuda --version=11.2.2.46133
 
     - name: Build project
       run: |

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -10,26 +10,25 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v2
 
-      - name: Set up MSVC
-        run: |
-          & "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+    - name: Install Visual Studio 2019
+      run: |
+        choco install visualstudio2019community --package-parameters "--add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended --includeOptional"
 
-      - name: Install Chocolatey
-        run: |
-          Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+    - name: Install CUDA
+      run: |
+        choco install cuda --version=11.2
 
-      - name: Install CUDA
-        run: |
-          choco install cuda -y
+    - name: Set up environment
+      shell: cmd.exe
+      run: |
+        SET "PATH=%PATH%;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin"
 
-      - name: Verify CUDA installation
-        run: nvcc --version
-
-      - name: Build with Make
-        run: |
-          choco install make -y
-          cd src && make
+    - name: Build project
+      shell: cmd.exe
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+        cd src && make
 

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -21,8 +21,9 @@ jobs:
         choco install cuda --version=11.2.2.46133
         
     - name: Build project
+      shell: cmd
       run: |
-        $env:Path += ";C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin"
+        set PATH=%PATH%;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin
         nvcc --version
         cd src && make
 

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -22,7 +22,8 @@ jobs:
         
     - name: add CUDA to path
       run: |
-        "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin"\nvcc -v
+        $env:Path += ";C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin"
+        nvcc -v
         
     - name: Build project
       run: |

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -13,8 +13,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2      
       
-    - name: Set up MSVC environment
-      uses: ilammy/msvc-dev-cmd@v1.4.1
+    # - name: Set up MSVC environment
+    #   uses: ilammy/msvc-dev-cmd@v1.4.1
       
     - name: Install CUDA      
       run: |

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         echo 'export PATH="/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.2/bin:$PATH"' >> $GITHUB_ENV
     - name: check CUDA version
+      run: |
         nvcc -v
     - name: Build project
       run: |

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -1,0 +1,35 @@
+name: CUDA CI on Windows
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up MSVC
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+
+      - name: Install Chocolatey
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+      - name: Install CUDA
+        run: |
+          choco install cuda -y
+
+      - name: Verify CUDA installation
+        run: nvcc --version
+
+      - name: Build with Make
+        run: |
+          choco install make -y
+          cd src && make
+

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Set up MSVC
         run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          & "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
 
       - name: Install Chocolatey
         run: |

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -12,18 +12,17 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2      
+      
     - name: Set up MSVC environment
       uses: ilammy/msvc-dev-cmd@v1.4.1
       
     - name: Install CUDA
-      run: |
-        choco install cuda --version=11.2.2.46133
-    - name: add CUDA to path
-      run: |
-        echo 'export PATH="/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.2/bin:$PATH"' >> $GITHUB_ENV
+      uses: nvidia/setup-cuda@v12
+      
     - name: check CUDA version
       run: |
         nvcc -v
+        
     - name: Build project
       run: |
         cd src && make

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -11,24 +11,14 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Install Visual Studio 2019
-      run: |
-        choco install visualstudio2019community --package-parameters "--add Microsoft.VisualStudio.Workload.NativeDesktop --includeRecommended --includeOptional"
-
+    - uses: actions/checkout@v2
+    - uses: ilammy/msvc-dev-cmd@v1.4.1
+      
     - name: Install CUDA
       run: |
         choco install cuda --version=11.2
 
-    - name: Set up environment
-      shell: cmd.exe
-      run: |
-        SET "PATH=%PATH%;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin"
-
     - name: Build project
-      shell: cmd.exe
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
         cd src && make
 

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -22,8 +22,7 @@ jobs:
         
     - name: add CUDA to path
       run: |
-        SET "PATH=%PATH%;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin"
-        nvcc -v
+        "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin"\nvcc -v
         
     - name: Build project
       run: |

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -23,7 +23,7 @@ jobs:
     - name: add CUDA to path
       run: |
         $env:Path += ";C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin"
-        nvcc -v
+        nvcc --version
         
     - name: Build project
       run: |

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -18,7 +18,11 @@ jobs:
     - name: Install CUDA
       run: |
         choco install cuda --version=11.2.2.46133
-
+    - name: add CUDA to path
+      run: |
+        echo 'export PATH="/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.2/bin:$PATH"' >> $GITHUB_ENV
+    - name: check CUDA version
+        nvcc -v
     - name: Build project
       run: |
         cd src && make

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -16,8 +16,13 @@ jobs:
     - name: Set up MSVC environment
       uses: ilammy/msvc-dev-cmd@v1.4.1
       
-    - name: Install CUDA
-      uses: nvidia/setup-cuda@v12
+    - name: Install CUDA      
+      run: |
+        choco install cuda --version=11.2.2.46133
+        
+    - name: add CUDA to path
+      run: |
+        SET "PATH=%PATH%;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin"
       
     - name: check CUDA version
       run: |

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -11,8 +11,8 @@ jobs:
 
     steps:
     - name: Checkout code
-    - uses: actions/checkout@v2
-    - uses: ilammy/msvc-dev-cmd@v1.4.1
+      uses: actions/checkout@v2
+      uses: ilammy/msvc-dev-cmd@v1.4.1
       
     - name: Install CUDA
       run: |

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -23,9 +23,6 @@ jobs:
     - name: add CUDA to path
       run: |
         SET "PATH=%PATH%;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin"
-      
-    - name: check CUDA version
-      run: |
         nvcc -v
         
     - name: Build project

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v2      
       
     - name: Set up MSVC environment
-      uses: ilammy/msvc-dev-cmd@vs-version
+      uses: ilammy/msvc-dev-cmd@v1.13.0
       with:
         arch: x64
         vsversion: "2019"

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -11,8 +11,8 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
-      uses: ilammy/msvc-dev-cmd@v1.4.1
+    - uses: actions/checkout@v2
+    - uses: ilammy/msvc-dev-cmd@v1.4.1
       
     - name: Install CUDA
       run: |

--- a/.github/workflows/cuda_build_windows.yml
+++ b/.github/workflows/cuda_build_windows.yml
@@ -20,12 +20,9 @@ jobs:
       run: |
         choco install cuda --version=11.2.2.46133
         
-    - name: add CUDA to path
+    - name: Build project
       run: |
         $env:Path += ";C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.2\bin"
         nvcc --version
-        
-    - name: Build project
-      run: |
         cd src && make
 

--- a/src/main_nep/structure.cu
+++ b/src/main_nep/structure.cu
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <iterator>
 #include <random>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/makefile
+++ b/src/makefile
@@ -16,10 +16,11 @@
 # some flags
 ###########################################################
 CC = nvcc
+CUDA_ARCH=-arch=sm_60
 ifdef OS # For Windows with the cl.exe compiler
-CFLAGS = -O3 -arch=sm_60 -Xcompiler "/wd 4819"
+CFLAGS = -O3 $(CUDA_ARCH) -Xcompiler "/wd 4819"
 else # For linux
-CFLAGS = -std=c++14 -O3 -arch=sm_60
+CFLAGS = -std=c++14 -O3 $(CUDA_ARCH)
 endif
 INC = -I./
 LDFLAGS = 

--- a/src/makefile
+++ b/src/makefile
@@ -18,7 +18,7 @@
 CC = nvcc
 CUDA_ARCH=-arch=sm_60
 ifdef OS # For Windows with the cl.exe compiler
-CFLAGS = -O3 $(CUDA_ARCH) -Xcompiler="/wd 4819"
+CFLAGS = -O3 $(CUDA_ARCH) -Xcompiler="/wd4819"
 else # For linux
 CFLAGS = -std=c++14 -O3 $(CUDA_ARCH)
 endif

--- a/src/makefile
+++ b/src/makefile
@@ -18,7 +18,7 @@
 CC = nvcc
 CUDA_ARCH=-arch=sm_60
 ifdef OS # For Windows with the cl.exe compiler
-CFLAGS = -O3 $(CUDA_ARCH) -Xcompiler "/wd 4819"
+CFLAGS = -O3 $(CUDA_ARCH) -Xcompiler="/wd 4819"
 else # For linux
 CFLAGS = -std=c++14 -O3 $(CUDA_ARCH)
 endif

--- a/src/makefile
+++ b/src/makefile
@@ -18,7 +18,7 @@
 CC = nvcc
 CUDA_ARCH=-arch=sm_60
 ifdef OS # For Windows with the cl.exe compiler
-CFLAGS = -O3 $(CUDA_ARCH) -Xcompiler="/wd4819"
+CFLAGS = -O3 $(CUDA_ARCH)
 else # For linux
 CFLAGS = -std=c++14 -O3 $(CUDA_ARCH)
 endif


### PR DESCRIPTION
[bug]
我测试了一下，gcc可以用random或numeric任意头文件包含iota，MSVC只能numeric
![84632a5909259aa6f423ae3b26c4df07](https://github.com/brucefan1983/GPUMD/assets/44524468/aac715b5-9d10-4445-a9aa-f83192c3fbc1)
![a4b97c756bf0df0dd9d91085604bef2f](https://github.com/brucefan1983/GPUMD/assets/44524468/4d3de694-f0f2-4936-bd1c-bf4d49b85b0a)
![948eeb9572e891e46b2a5b822af70253](https://github.com/brucefan1983/GPUMD/assets/44524468/71b90d4a-5c4d-49d9-9e62-10c4e542b4ff)
![image](https://github.com/brucefan1983/GPUMD/assets/44524468/d962ab30-2948-4885-a522-e53d66e1b5b9)

[update makefile]
Using the variable CUDA-ARCH instead of hard coding

[workflows]
When a new pull request create, github will check if the code can be compiled successfully at first.
