### PR TITLE
fix energy bug for multi-gpu

### DIFF
--- a/src/force/nep3_multigpu.cu
+++ b/src/force/nep3_multigpu.cu
@@ -1004,7 +1004,7 @@ static __global__ void find_descriptor(
 
     apply_ann_one_layer(
       annmb.dim, annmb.num_neurons1, annmb.w0[t1], annmb.b0[t1], annmb.w1[t1], annmb.b1, q, F, Fp);
-    g_pe[n1] += F;
+    g_pe[n1] = F;
 
     for (int d = 0; d < annmb.dim; ++d) {
       g_Fp[d * N + n1] = Fp[d] * paramb.q_scaler[d];


### PR DESCRIPTION
Fix a bug introduced after adding dipole/polarizability prediction.

The energy for NEP part should be `=` instead of `+=`.