### PR TITLE
update convergence check

### DIFF
--- a/tools/vasp2xyz/outcar2xyz/multipleFrames-outcars2nep-exyz.sh
+++ b/tools/vasp2xyz/outcar2xyz/multipleFrames-outcars2nep-exyz.sh
@@ -34,8 +34,14 @@ converged_files=()
 non_converged_files=()
 
 for file in $(find "$read_dire" -name "OUTCAR"); do
+    NELM=$(grep "NELM" "$file" | awk '{print $3}' | tr -d ';')
+    actual_steps=$(grep -c "Iteration" "$file")
     if grep -q "aborting loop because EDIFF is reached" "$file"; then
-        converged_files+=("$file")
+        if [ "$actual_steps" -lt "$NELM" ]; then
+            converged_files+=("$file")
+        else
+            non_converged_files+=("$file")
+        fi
     else
         non_converged_files+=("$file")
     fi


### PR DESCRIPTION
NELM is read from OUTCAR to determine whether the self-consistent calculations converge. Avoid the problem of automatic termination when the electronic step reaches NELM.