### PR TITLE
add NSW check for AIMD simulations

### DIFF
--- a/tools/vasp2xyz/outcar2xyz/multipleFrames-outcars2nep-exyz.sh
+++ b/tools/vasp2xyz/outcar2xyz/multipleFrames-outcars2nep-exyz.sh
@@ -34,8 +34,16 @@ converged_files=()
 non_converged_files=()
 
 for file in $(find "$read_dire" -name "OUTCAR"); do
+    NSW=$(grep "NSW" "$file" | awk '{print $3}')
+    
+    if [ "$NSW" -ne 0 ]; then
+        converged_files+=("$file")
+        continue
+    fi
+    
     NELM=$(grep "NELM" "$file" | awk '{print $3}' | tr -d ';')
     actual_steps=$(grep -c "Iteration" "$file")
+
     if grep -q "aborting loop because EDIFF is reached" "$file"; then
         if [ "$actual_steps" -lt "$NELM" ]; then
             converged_files+=("$file")

--- a/tools/vasp2xyz/outcar2xyz/multipleFrames-outcars2nep-exyz.sh
+++ b/tools/vasp2xyz/outcar2xyz/multipleFrames-outcars2nep-exyz.sh
@@ -34,7 +34,7 @@ converged_files=()
 non_converged_files=()
 
 for file in $(find "$read_dire" -name "OUTCAR"); do
-    NSW=$(grep "NSW" "$file" | awk '{print $3}')
+    NSW=$(grep "number of steps for IOM" "$file" | awk '{print $3}')
     
     if [ "$NSW" -ne 0 ]; then
         converged_files+=("$file")


### PR DESCRIPTION
Hi Dr.Yanzhou,

I've received a feedback regarding a minor bug in the previous script, which arose after I added the NELM check. As a result, the OUTCARs from AIMD simulations were incorrectly flagged as non-convergent.

To address this issue, I have now included an NSW check:

- If NSW is 0, it indicates a self-consistent field (SCF) calculation, following the original logic.
- If NSW is not 0, the script will directly judge the file as being from an AIMD calculation, assuming convergence.

Best,
Zihan