### PR TITLE
enable periodic table for multi-layer

### DIFF
--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -333,12 +333,12 @@ void Fitness::write_nep_txt(FILE* fid_nep, Parameters& para, float* elite)
   fprintf(fid_nep, "basis_size %d %d\n", para.basis_size_radial, para.basis_size_angular);
   fprintf(fid_nep, "l_max %d %d %d\n", para.L_max, para.L_max_4body, para.L_max_5body);
 
-  if (para.num_neurons3 != 0) {
-    fprintf(fid_nep, "ANN %d %d %d %d\n", para.num_neurons1, para.num_neurons2, para.num_neurons3, 0);
-  } else if (para.num_neurons2 != 0) {
-    fprintf(fid_nep, "ANN %d %d %d\n", para.num_neurons1, para.num_neurons2, 0);
-  } else {
-    fprintf(fid_nep, "ANN %d %d\n", para.num_neurons1, 0);
+  if (para.num_hidden_layers == 3) {
+    fprintf(fid_nep, "ANN %d %d %d\n", para.num_neurons[0], para.num_neurons[1], para.num_neurons[2]);
+  } else if (para.num_hidden_layers == 2) {
+    fprintf(fid_nep, "ANN %d %d %d\n", para.num_neurons[0], para.num_neurons[1], 0);
+  } else if (para.num_hidden_layers == 1) {
+    fprintf(fid_nep, "ANN %d %d\n", para.num_neurons[0], 0);
   }
   for (int m = 0; m < para.number_of_variables; ++m) {
     fprintf(fid_nep, "%15.7e\n", elite[m]);

--- a/src/main_nep/nep3.cuh
+++ b/src/main_nep/nep3.cuh
@@ -69,14 +69,13 @@ public:
     int num_hidden_layers = 1; // number of hidden layers (1 to 3)
     int num_neurons[3] = {0, 0, 0}; // number of neurons in the hidden layer
     int num_para = 0;     // number of parameters
-    const float* w[50][3]; // weights for each layer
-    const float* b[50][3]; // biases for each layer
-    const float* w_out[50]; // weight from the hidden layer to the output layer
+    int num_para_one_ann_without_bias = 0; // number of parameters for one ann without the output bias
+    int offset_w[4];
+    int offset_b[3];
+    const float* para[NUM_ELEMENTS]; // weight and bias parameters for the hidden layers
     const float* b_out;      // bias for the output layer
     // for the scalar part of polarizability
-    const float* w_pol[10][3]; // weight from the input layer to the hidden layer
-    const float* b_pol[10][3]; // bias for the hidden layer
-    const float* w_out_pol[10]; // weight from the hidden layer to the output layer
+    const float* para_pol[NUM_ELEMENTS]; // weight and bias parameters for the hidden layers
     const float* b_out_pol;     // bias for the output layer
     // for elements in descriptor
     const float* c;

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -798,6 +798,10 @@ void Parameters::parse_neuron(const char** param, int num_param)
       PRINT_INPUT_ERROR("number of neurons should <= 200.");
     }
   }
+
+  if (num_neurons[0] + num_neurons[1] + num_neurons[2] > 200) {
+    PRINT_INPUT_ERROR("total number of neurons should <= 200.\n");
+  }
 }
 
 void Parameters::parse_lambda_1(const char** param, int num_param)

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -88,9 +88,9 @@ void Parameters::set_default_parameters()
   L_max_4body = 2;             // default is to include 4body
   L_max_5body = 0;             // default is not to include 5body
   num_hidden_layers = 1;       // default is to have one hidden layer
-  num_neurons1 = 30;           // a relatively small value to achieve high speed
-  num_neurons2 = 0;            // default is not to have the 2nd hidden layer
-  num_neurons3 = 0;            // default is not to have the 3rd hidden layer
+  num_neurons[0] = 30;         // a relatively small value to achieve high speed
+  num_neurons[1] = 0;          // default is not to have the 2nd hidden layer
+  num_neurons[2] = 0;          // default is not to have the 3rd hidden layer
   lambda_1 = lambda_2 = -1.0f; // automatic regularization
   lambda_e = lambda_f = 1.0f;  // energy and force are more important
   lambda_v = 0.1f;             // virial is less important
@@ -189,11 +189,11 @@ void Parameters::calculate_parameters()
 #endif
 
   if (num_hidden_layers == 1) {
-    number_of_variables_ann = (dim + 2) * num_neurons1 * (version == 4 ? num_types : 1) + 1;
+    number_of_variables_ann = (dim + 2) * num_neurons[0] * (version == 4 ? num_types : 1) + 1;
   } else if (num_hidden_layers == 2) {
-    number_of_variables_ann = ((dim + 1) * num_neurons1 + (num_neurons1 + 2) * num_neurons2) * (version == 4 ? num_types : 1) + 1;
+    number_of_variables_ann = ((dim + 1) * num_neurons[0] + (num_neurons[0] + 2) * num_neurons[1]) * (version == 4 ? num_types : 1) + 1;
   } else {
-    number_of_variables_ann = ((dim + 1) * num_neurons1 + (num_neurons1 + 1) * num_neurons2 + (num_neurons2 + 2) * num_neurons3) * (version == 4 ? num_types : 1) + 1;
+    number_of_variables_ann = ((dim + 1) * num_neurons[0] + (num_neurons[0] + 1) * num_neurons[1] + (num_neurons[1] + 2) * num_neurons[2]) * (version == 4 ? num_types : 1) + 1;
   }
 
   number_of_variables_descriptor =
@@ -352,15 +352,9 @@ void Parameters::report_inputs()
   }
 
   if (is_neuron_set) {
-    printf("    (input)   number of hiden layers = %d.\n", num_hidden_layers);
-    printf("    (input-1st)   number of neurons = %d.\n", num_neurons1);
-    printf("    (input-2nd)   number of neurons = %d.\n", num_neurons2);
-    printf("    (input-3rd)   number of neurons = %d.\n", num_neurons3);
+    printf("    (input)   number of neurons = (%d, %d, %d).\n", num_neurons[0], num_neurons[1], num_neurons[2]);
   } else {
-    printf("    (default) number of hiden layers = %d.\n", num_hidden_layers);
-    printf("    (default-1st) number of neurons = %d.\n", num_neurons1);
-    printf("    (default-2nd)   number of neurons = %d.\n", num_neurons2);
-    printf("    (default-3rd)   number of neurons = %d.\n", num_neurons3);
+    printf("    (default) number of neurons = (%d, %d, %d).\n", num_neurons[0], num_neurons[1], num_neurons[2]);
   }
 
   if (is_lambda_1_set) {
@@ -431,12 +425,12 @@ void Parameters::report_inputs()
   printf("    number of radial descriptor components = %d.\n", dim_radial);
   printf("    number of angular descriptor components = %d.\n", dim_angular);
   printf("    total number of descriptor components = %d.\n", dim);
-  if (num_neurons3 != 0) {
-    printf("    NN architecture = %d-%d-%d-%d-1.\n", dim, num_neurons1, num_neurons2, num_neurons3);
-  } else if (num_neurons2 != 0) {
-    printf("    NN architecture = %d-%d-%d-1.\n", dim, num_neurons1, num_neurons2);
+  if (num_hidden_layers == 3) {
+    printf("    NN architecture = %d-%d-%d-%d-1.\n", dim, num_neurons[0], num_neurons[1], num_neurons[2]);
+  } else if (num_hidden_layers == 2) {
+    printf("    NN architecture = %d-%d-%d-1.\n", dim, num_neurons[0], num_neurons[1]);
   } else {
-    printf("    NN architecture = %d-%d-1.\n", dim, num_neurons1);
+    printf("    NN architecture = %d-%d-1.\n", dim, num_neurons[0]);
   }
   printf(
     "    number of NN parameters to be optimized = %d.\n",
@@ -774,33 +768,33 @@ void Parameters::parse_neuron(const char** param, int num_param)
 
   num_hidden_layers = num_param - 1;
 
-  if (!is_valid_int(param[1], &num_neurons1)) {
+  if (!is_valid_int(param[1], &num_neurons[0])) {
     PRINT_INPUT_ERROR("number of neurons should be an integer.\n");
   }
-  if (num_neurons1 < 1) {
+  if (num_neurons[0] < 1) {
     PRINT_INPUT_ERROR("number of neurons should >= 1.");
-  } else if (num_neurons1 > 200) {
+  } else if (num_neurons[0] > 200) {
     PRINT_INPUT_ERROR("number of neurons should <= 200.");
   }
 
   if (num_param > 2) {
-    if (!is_valid_int(param[2], &num_neurons2)) {
+    if (!is_valid_int(param[2], &num_neurons[1])) {
       PRINT_INPUT_ERROR("number of neurons should be an integer.\n");
     }
-    if (num_neurons2 < 1) {
+    if (num_neurons[1] < 1) {
       PRINT_INPUT_ERROR("number of neurons should >= 1.");
-    } else if (num_neurons2 > 200) {
+    } else if (num_neurons[1] > 200) {
       PRINT_INPUT_ERROR("number of neurons should <= 200.");
     }
   }
 
   if (num_param > 3) {
-    if (!is_valid_int(param[3], &num_neurons3)) {
+    if (!is_valid_int(param[3], &num_neurons[2])) {
       PRINT_INPUT_ERROR("number of neurons should be an integer.\n");
     }
-    if (num_neurons3 < 1) {
+    if (num_neurons[2] < 1) {
       PRINT_INPUT_ERROR("number of neurons should >= 1.");
-    } else if (num_neurons3 > 200) {
+    } else if (num_neurons[2] > 200) {
       PRINT_INPUT_ERROR("number of neurons should <= 200.");
     }
   }

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -31,9 +31,7 @@ public:
   int population_size;    // population size for SNES
   int maximum_generation; // maximum number of generations for SNES;
   int num_hidden_layers;  // number of hidden layers
-  int num_neurons1;       // number of nuerons in the 1st hidden layer
-  int num_neurons2;       // number of nuerons in the 2st hidden layer
-  int num_neurons3;       // number of nuerons in the 3st hidden layer
+  int num_neurons[3];     // number of nuerons in the three hidden layers
   int basis_size_radial;  // for nep3
   int basis_size_angular; // for nep3
   int n_max_radial;       // maximum order of the radial Chebyshev polynomials

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -137,31 +137,31 @@ void SNES::find_type_of_variable(Parameters& para)
     for (int ann = 0; ann < num_ann; ++ann) {
       for (int t = 0; t < para.num_types; ++t) {
         if (para.num_hidden_layers == 1) {
-          for (int n = 0; n < (para.dim + 2) * para.num_neurons1; ++n) {
+          for (int n = 0; n < (para.dim + 2) * para.num_neurons[0]; ++n) {
             type_of_variable[n + offset] = t;
           }
-          offset += (para.dim + 2) * para.num_neurons1;
+          offset += (para.dim + 2) * para.num_neurons[0];
         } else if (para.num_hidden_layers == 2) {
-          for (int n = 0; n < ((para.dim + 1) * para.num_neurons1 + (para.num_neurons1 + 2) * para.num_neurons2); ++n) {
+          for (int n = 0; n < (para.dim + 1) * para.num_neurons[0] + (para.num_neurons[0] + 2) * para.num_neurons[1]; ++n) {
             type_of_variable[n + offset] = t;
           }
-          offset += (para.dim + 1) * para.num_neurons1 + (para.num_neurons1 + 2) * para.num_neurons2;
+          offset += (para.dim + 1) * para.num_neurons[0] + (para.num_neurons[0] + 2) * para.num_neurons[1];
         } else {
-          for (int n = 0; n < ((para.dim + 1) * para.num_neurons1 + (para.num_neurons1 + 1) * para.num_neurons2 + (para.num_neurons2 + 2) * para.num_neurons3); ++n) {
+          for (int n = 0; n < (para.dim + 1) * para.num_neurons[0] + (para.num_neurons[0] + 1) * para.num_neurons[1] + (para.num_neurons[1] + 2) * para.num_neurons[2]; ++n) {
             type_of_variable[n + offset] = t;
           }
-          offset += (para.dim + 1) * para.num_neurons1 + (para.num_neurons1 + 1) * para.num_neurons2 + (para.num_neurons2 + 2) * para.num_neurons3;
+          offset += (para.dim + 1) * para.num_neurons[0] + (para.num_neurons[0] + 1) * para.num_neurons[1] + (para.num_neurons[1] + 2) * para.num_neurons[2];
         }
       }
       ++offset; // the bias
     }
   } else {
     if (para.num_hidden_layers == 1) {
-      offset += (para.dim + 2) * para.num_neurons1 + 1;
+      offset += (para.dim + 2) * para.num_neurons[0] + 1;
     } else if (para.num_hidden_layers == 2) {
-      offset += (para.dim + 1) * para.num_neurons1 + (para.num_neurons1 + 2) * para.num_neurons2 + 1;
+      offset += (para.dim + 1) * para.num_neurons[0] + (para.num_neurons[0] + 2) * para.num_neurons[1] + 1;
     } else {
-      offset += (para.dim + 1) * para.num_neurons1 + (para.num_neurons1 + 1) * para.num_neurons2 + (para.num_neurons2 + 2) * para.num_neurons3 + 1;
+      offset += (para.dim + 1) * para.num_neurons[0] + (para.num_neurons[0] + 1) * para.num_neurons[1] + (para.num_neurons[1] + 2) * para.num_neurons[2] + 1;
     }    
   }
 


### PR DESCRIPTION
Small improvements based on the multi-layer (up to 3 hidden layers) version by Hongfu Huang (#702) 
* Support for the periodic table, again.
* Fix NEP3.

Could you review this PR? @hfood02

* Usage:
```
neuron <num_neurons_1> # 1 hidden layer, as before
neuron <num_neurons_1 num_neurons_2> # 2 hidden layers
neuron <num_neurons_1 num_neurons_2 num_neurons_3> # 3 hidden layers
```

* Restrictions:
```
1 <= num_neurons_1 <= 200
0 <= num_neurons_2 <= 200
0 <= num_neurons_3 <= 200
num_neurons_1 + num_neurons_2 + num_neurons_3 <= 200
```

* Status:
  - NEP training finished and to be optimized
  - GPUMD part to be done
  - NEP_CPU to be done

* The following inputs have comparable numbers of parameters (assuming the descriptor vector is of dimension ~ 40) but a deeper network might lead to higher accuracy:
```
neuron 30
neuron 20 20
neuron 15 15 15
```