### PR TITLE
Change keywords for NELM check

### DIFF
--- a/tools/vasp2xyz/outcar2xyz/multipleFrames-outcars2nep-exyz.sh
+++ b/tools/vasp2xyz/outcar2xyz/multipleFrames-outcars2nep-exyz.sh
@@ -41,7 +41,7 @@ for file in $(find "$read_dire" -name "OUTCAR"); do
         continue
     fi
     
-    NELM=$(grep "NELM" "$file" | awk '{print $3}' | tr -d ';')
+    NELM=$(grep "of ELM steps" "$file" | awk '{print $3}' | tr -d ';')
     actual_steps=$(grep -c "Iteration" "$file")
 
     if grep -q "aborting loop because EDIFF is reached" "$file"; then


### PR DESCRIPTION
VASP6 versions (tested in 6.3 and 6.4) will repeat the INCAR parameters in OUTCAR, causing problems with the old keywords. 

VASP5.4
![image](https://github.com/user-attachments/assets/69acd049-7859-4cd2-9f47-8c640507d207)

VASP6.3 & VASP6.4
![image](https://github.com/user-attachments/assets/f0709300-27d3-419b-a2a1-966601038f9a)
