### PR TITLE
nep5

### DIFF
--- a/src/force/force.cu
+++ b/src/force/force.cu
@@ -90,16 +90,16 @@ void Force::parse_potential(
     potential.reset(new FCP(fid_potential, num_types, number_of_atoms, box));
     is_fcp = true;
   } else if (
-    strcmp(potential_name, "nep") == 0 || strcmp(potential_name, "nep_zbl") == 0 ||
-    strcmp(potential_name, "nep_dipole") == 0 ||
-    strcmp(potential_name, "nep_polarizability") == 0 || strcmp(potential_name, "nep3") == 0 ||
-    strcmp(potential_name, "nep3_zbl") == 0 || strcmp(potential_name, "nep4") == 0 ||
-    strcmp(potential_name, "nep4_zbl") == 0 || strcmp(potential_name, "nep3_dipole") == 0 ||
+    strcmp(potential_name, "nep5") == 0 || 
+    strcmp(potential_name, "nep5_zbl") == 0 ||
+    strcmp(potential_name, "nep3") == 0 ||
+    strcmp(potential_name, "nep3_zbl") == 0 || 
+    strcmp(potential_name, "nep4") == 0 ||
+    strcmp(potential_name, "nep4_zbl") == 0 || 
+    strcmp(potential_name, "nep3_dipole") == 0 ||
     strcmp(potential_name, "nep3_polarizability") == 0 ||
     strcmp(potential_name, "nep4_dipole") == 0 ||
     strcmp(potential_name, "nep4_polarizability") == 0 ||
-    strcmp(potential_name, "nep_temperature") == 0 ||
-    strcmp(potential_name, "nep_zbl_temperature") == 0 ||
     strcmp(potential_name, "nep3_temperature") == 0 ||
     strcmp(potential_name, "nep3_zbl_temperature") == 0 ||
     strcmp(potential_name, "nep4_temperature") == 0 ||

--- a/src/force/nep3_small_box.cuh
+++ b/src/force/nep3_small_box.cuh
@@ -326,8 +326,29 @@ static __global__ void find_descriptor_small_box(
       }
     }
 
-    apply_ann_one_layer(
-      annmb.dim, annmb.num_neurons1, annmb.w0[t1], annmb.b0[t1], annmb.w1[t1], annmb.b1, q, F, Fp);
+    if (paramb.version == 5) {
+      apply_ann_one_layer_nep5(
+        annmb.dim,
+        annmb.num_neurons1,
+        annmb.w0[t1],
+        annmb.b0[t1],
+        annmb.w1[t1],
+        annmb.b1,
+        q,
+        F,
+        Fp);
+    } else {
+      apply_ann_one_layer(
+        annmb.dim,
+        annmb.num_neurons1,
+        annmb.w0[t1],
+        annmb.b0[t1],
+        annmb.w1[t1],
+        annmb.b1,
+        q,
+        F,
+        Fp);
+    }
     g_pe[n1] += F;
 
     for (int d = 0; d < annmb.dim; ++d) {

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -270,6 +270,12 @@ void Fitness::write_nep_txt(FILE* fid_nep, Parameters& para, float* elite)
       } else {
         fprintf(fid_nep, "nep4 %d ", para.num_types);
       }
+    } else if (para.version == 5) {
+      if (para.enable_zbl) {
+        fprintf(fid_nep, "nep5_zbl %d ", para.num_types);
+      } else {
+        fprintf(fid_nep, "nep5 %d ", para.num_types);
+      }
     }
   } else if (para.train_mode == 1) { // dipole model
     if (para.version == 3) {

--- a/src/main_nep/nep3.cu
+++ b/src/main_nep/nep3.cu
@@ -334,9 +334,7 @@ void NEP3::update_potential(Parameters& para, float* parameters, ANN& ann)
     ann.w1[t] = pointer;
     pointer += ann.num_neurons1;
     if (para.version == 5) {
-      pointer += ann.num_neurons1 + 1; // one extra bias for NEP5 stored in ann.w1[t]
-    } else {
-      pointer += ann.num_neurons1;
+      pointer += 1; // one extra bias for NEP5 stored in ann.w1[t]
     }
   }
   ann.b1 = pointer;

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -156,6 +156,9 @@ void Parameters::read_zbl_in()
 
 void Parameters::calculate_parameters()
 {
+  if (version == 5 && train_mode != 0) {
+    PRINT_INPUT_ERROR("Can only use NEP5 for potential model.");
+  }
 
   if (train_mode != 0 && train_mode != 3) {
     // take virial as dipole or polarizability
@@ -184,7 +187,13 @@ void Parameters::calculate_parameters()
   }
 #endif
 
-  number_of_variables_ann = (dim + 2) * num_neurons1 * (version == 4 ? num_types : 1) + 1;
+  if (version == 3) {
+    number_of_variables_ann = (dim + 2) * num_neurons1 + 1;
+  } else if (version == 4) {
+    number_of_variables_ann = (dim + 2) * num_neurons1 * num_types + 1;
+  } else if (version == 5) {
+    number_of_variables_ann = ((dim + 2) * num_neurons1 + 1) * num_types + 1;
+  }
 
   number_of_variables_descriptor =
     num_types * num_types *
@@ -195,7 +204,7 @@ void Parameters::calculate_parameters()
     number_of_variables += number_of_variables_ann;
   }
 
-  if (version == 4) {
+  if (version != 3) {
     if (!is_lambda_1_set) {
       lambda_1 = sqrt(number_of_variables * 1.0e-6f / num_types);
     }
@@ -528,8 +537,8 @@ void Parameters::parse_version(const char** param, int num_param)
   if (!is_valid_int(param[1], &version)) {
     PRINT_INPUT_ERROR("version should be an integer.\n");
   }
-  if (version < 3 || version > 4) {
-    PRINT_INPUT_ERROR("version should = 3 or 4.");
+  if (version < 3 || version > 5) {
+    PRINT_INPUT_ERROR("version should = 3 or 4 or 5.");
   }
 }
 

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -24,7 +24,7 @@ public:
   Parameters();
 
   // parameters to be read in
-  int version;            // nep version, can be 3 or 4
+  int version;            // nep version, can be 3 or 4 or 5
   int batch_size;         // number of configurations in one batch
   int use_full_batch;     // 1 for effective full-batch even though batch_size is not full-batch
   int num_types;          // number of atom types

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -46,7 +46,7 @@ SNES::SNES(Parameters& para, Fitness* fitness_function)
   population_size = para.population_size;
   const int N = population_size * number_of_variables;
   int num = number_of_variables;
-  if (para.version == 4) {
+  if (para.version != 3) {
     num /= para.num_types;
   }
   eta_sigma = (3.0f + std::log(num * 1.0f)) / (5.0f * sqrt(num * 1.0f)) / 2.0f;
@@ -128,14 +128,15 @@ void SNES::find_type_of_variable(Parameters& para)
   int offset = 0;
 
   // NN part
-  if (para.version == 4) {
+  if (para.version != 3) {
     int num_ann = (para.train_mode == 2) ? 2 : 1;
+    int num_extra_bias = (para.version == 5) ? 1 : 0;
     for (int ann = 0; ann < num_ann; ++ann) {
       for (int t = 0; t < para.num_types; ++t) {
-        for (int n = 0; n < (para.dim + 2) * para.num_neurons1; ++n) {
+        for (int n = 0; n < (para.dim + 2) * para.num_neurons1 + num_extra_bias; ++n) {
           type_of_variable[n + offset] = t;
         }
-        offset += (para.dim + 2) * para.num_neurons1;
+        offset += (para.dim + 2) * para.num_neurons1 + num_extra_bias;
       }
       ++offset; // the bias
     }

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -215,7 +215,7 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
       create_population(para);
       fitness_function->compute(n, para, population.data(), fitness.data());
 
-      if (para.version == 4) {
+      if (para.version != 3) {
         regularize_NEP4(para);
       } else {
         regularize(para);

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -76,6 +76,33 @@ static __device__ void apply_ann_one_layer(
   energy -= b1[0];
 }
 
+static __device__ void apply_ann_one_layer_nep5(
+  const int N_des,
+  const int N_neu,
+  const float* w0,
+  const float* b0,
+  const float* w1,
+  const float* b1,
+  float* q,
+  float& energy,
+  float* energy_derivative)
+{
+  for (int n = 0; n < N_neu; ++n) {
+    float w0_times_q = 0.0f;
+    for (int d = 0; d < N_des; ++d) {
+      w0_times_q += w0[n * N_des + d] * q[d];
+    }
+    float x1 = tanh(w0_times_q - b0[n]);
+    float tanh_der = 1.0f - x1 * x1;
+    energy += w1[n] * x1;
+    for (int d = 0; d < N_des; ++d) {
+      float y1 = tanh_der * w0[n * N_des + d];
+      energy_derivative[d] += w1[n] * y1;
+    }
+  }
+  energy -= w1[N_neu] + b1[0]; // typewise bias + common bias
+}
+
 static __device__ __forceinline__ void find_fc(float rc, float rcinv, float d12, float& fc)
 {
   if (d12 < rc) {

--- a/tools/for_coding/nep4nep5/change_nep_restart.m
+++ b/tools/for_coding/nep4nep5/change_nep_restart.m
@@ -1,0 +1,42 @@
+clear; close all;
+
+% old file
+load nep.restart;
+
+% inputs
+num_species=89;
+neuron=80;
+n_max=[6,4];
+l_max=[4,2,0];
+
+% calculated
+num_angular=l_max(1)+(l_max(2)>0)+(l_max(3)>0);
+dim=(n_max(1)+1) + (n_max(2)+1)*num_angular;
+num_ann_para=(dim+2)*neuron;
+num_total=size(nep,1);
+
+
+% new file
+fid=fopen('nep_new.restart','w');
+
+offset=1;
+for n=1:num_species
+    for m=1:num_ann_para
+        fprintf(fid,'%15.7e %15.7e\n',nep(offset,:));
+        offset=offset+1;
+    end
+    if n==10
+        fprintf(fid,'%15.7e%15.7e\n',-83.3701 +0.0301684,0.01); 
+    elseif n==18
+        fprintf(fid,'%15.7e%15.7e\n',-83.3701 +0.0587795,0.01); 
+    else
+        fprintf(fid,'%15.7e%15.7e\n',0,0.01); 
+    end
+end
+
+for n=offset:num_total
+    fprintf(fid,"%15.7e %15.7e\n",nep(n,:));
+end
+
+fclose(fid);
+


### PR DESCRIPTION
# Idea

* It seems that each species needs a separate bias for large NEP models (e.g. for the periodic table).
* This is also needed to accept the `nep.txt` files as trained by using `PWMLFF` (https://github.com/LonxunQuantum/PWMLFF)

# Usage

Usage of NEP5 in `nep.in`:
```
version 5 # default is 4
```

# `nep.txt` file

* The trainable parameters for NEP5 are arranged as folllows:
```
(N_des + 2) * N_neu + 1 for species 0 # (with bias)
(N_des + 2) * N_neu + 1 for species 1 # (with bias)
(N_des + 2) * N_neu + 1 for species 2 # (with bias)
...
The common bias for all species # There is still a common bias that is tuned by hand at each step 
Descriptor parameters
Normalization parameters
```

* For NEP4 they are:
```
(N_des + 2) * N_neu for species 0 # (no bias)
(N_des + 2) * N_neu for species 1 # (no bias)
(N_des + 2) * N_neu for species 2 # (no bias)
...
The common bias for all species
Descriptor parameters
Normalization parameters
```

* For NEP3 they are:
```
(N_des + 2) * N_neu + 1 for all species
Descriptor parameters
Normalization parameters
```

# Status and TODOs:
* NEP training is ready
* MD with `gpumd` is ready
* TODO: manual to be updated
* TODO: `NEP_CPU` repo to be extended

