### PR TITLE
Removed explicit linux tags from CI jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,14 +24,10 @@ before_script:
 
 build:linux:
   extends: .build
-  tags:
-    - linux
 
 #------------------- test stage -------------------
 
 .documentation:
-  tags:
-    - linux
   needs:
     - build:linux
   artifacts:


### PR DESCRIPTION
This PR removes the `linux` tag from jobs in the GitLab CI, which prevented the jobs to run on untagged runners on GitLab.