### PR TITLE
Small Acceleration by Reduce Local Memory Operators

### DIFF
--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -360,14 +360,27 @@ static __device__ __forceinline__ void find_fn_and_fnp(
 static __device__ __forceinline__ void
 find_fn(const int n_max, const float rcinv, const float d12, const float fc12, float* fn)
 {
+  // float x = 2.0f * (d12 * rcinv - 1.0f) * (d12 * rcinv - 1.0f) - 1.0f;
+  // fn[0] = 1.0f;
+  // fn[1] = x;
+  // for (int m = 2; m <= n_max; ++m) {
+  //   fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
+  // }
+  // for (int m = 0; m <= n_max; ++m) {
+  //   fn[m] = (fn[m] + 1.0f) * 0.5f * fc12;
+  // }
   float x = 2.0f * (d12 * rcinv - 1.0f) * (d12 * rcinv - 1.0f) - 1.0f;
-  fn[0] = 1.0f;
-  fn[1] = x;
+  float half_fc12 = 0.5f * fc12;
+  fn[0] = fc12;
+  fn[1] = (x + 1.0f) * half_fc12;
+  float fn_m_minus_2 = 1.0f;
+  float fn_m_minus_1 = x;
+  float tmp = 0.0f;
   for (int m = 2; m <= n_max; ++m) {
-    fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
-  }
-  for (int m = 0; m <= n_max; ++m) {
-    fn[m] = (fn[m] + 1.0f) * 0.5f * fc12;
+    tmp = 2.0f * x * fn_m_minus_1 - fn_m_minus_2;
+    fn_m_minus_2 = fn_m_minus_1;
+    fn_m_minus_1 = tmp;
+    fn[m] = (tmp + 1.0f) * half_fc12;
   }
 }
 

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -393,62 +393,62 @@ static __device__ __host__ __forceinline__ void find_fn_and_fnp(
   float* fn,
   float* fnp)
 {
-  // float x = 2.0f * (d12 * rcinv - 1.0f) * (d12 * rcinv - 1.0f) - 1.0f;
-  // fn[0] = 1.0f;
-  // fnp[0] = 0.0f;
-  // fn[1] = x;
-  // fnp[1] = 1.0f;
-  // float u0 = 1.0f;
-  // float u1 = 2.0f * x;
-  // float u2;
-  // for (int m = 2; m <= n_max; ++m) {
-  //   fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
-  //   fnp[m] = m * u1;
-  //   u2 = 2.0f * x * u1 - u0;
-  //   u0 = u1;
-  //   u1 = u2;
-  // }
-  // for (int m = 0; m <= n_max; ++m) {
-  //   fn[m] = (fn[m] + 1.0f) * 0.5f;
-  //   fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
-  //   fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
-  //   fn[m] *= fc12;
-  // }
-  float d12_mul_rcinv = d12 * rcinv;
-  float x = 2.0f * (d12_mul_rcinv - 1.0f) * (d12_mul_rcinv - 1.0f) - 1.0f;
-  fn[0] = fc12;
-  // fnp[0] = 0.0f;
-  fnp[0] = fc12 * fcp12;
-  fn[1] = (x + 1.0f) * 0.5f * fc12;
-  // fnp[1] = 1.0f;
-  fnp[1] = 2.0f * (d12_mul_rcinv - 1.0f) * rcinv * fc12 + fn[1] * fcp12;
+  float x = 2.0f * (d12 * rcinv - 1.0f) * (d12 * rcinv - 1.0f) - 1.0f;
+  fn[0] = 1.0f;
+  fnp[0] = 0.0f;
+  fn[1] = x;
+  fnp[1] = 1.0f;
   float u0 = 1.0f;
   float u1 = 2.0f * x;
   float u2;
-  float fn_m_minus_2 = 1.0f;
-  float fn_m_minus_1 = x;
   for (int m = 2; m <= n_max; ++m) {
-    float fn_tmp1 = 2.0f * x * fn_m_minus_1 - fn_m_minus_2;
-    fn_m_minus_2 = fn_m_minus_1;
-    fn_m_minus_1 = fn_tmp1;
-    // fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
-    // fnp[m] = m * u1;
-    float fnp_tmp = m * u1;
+    fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
+    fnp[m] = m * u1;
     u2 = 2.0f * x * u1 - u0;
     u0 = u1;
     u1 = u2;
-
-    float fn_tmp2 = (fn_tmp1 + 1.0f) * 0.5f;
-    fnp[m] = (fnp_tmp * 2.0f * (d12 * rcinv - 1.0f) * rcinv) * fc12 + fn_tmp2 * fcp12;
-    // fnp[m] = fnp[m] * fc12 + fn_tmp2 * fcp12;
-    fn[m] = fn_tmp2 * fc12;
   }
-  // for (int m = 0; m <= n_max; ++m) {
-  //   fn[m] = (fn[m] + 1.0f) * 0.5f;
-  //   fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
-  //   fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
-  //   fn[m] *= fc12;
+  for (int m = 0; m <= n_max; ++m) {
+    fn[m] = (fn[m] + 1.0f) * 0.5f;
+    fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
+    fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
+    fn[m] *= fc12;
+  }
+  // float d12_mul_rcinv = d12 * rcinv;
+  // float x = 2.0f * (d12_mul_rcinv - 1.0f) * (d12_mul_rcinv - 1.0f) - 1.0f;
+  // fn[0] = fc12;
+  // // fnp[0] = 0.0f;
+  // fnp[0] = fc12 * fcp12;
+  // fn[1] = (x + 1.0f) * 0.5f * fc12;
+  // // fnp[1] = 1.0f;
+  // fnp[1] = 2.0f * (d12_mul_rcinv - 1.0f) * rcinv * fc12 + fn[1] * fcp12;
+  // float u0 = 1.0f;
+  // float u1 = 2.0f * x;
+  // float u2;
+  // float fn_m_minus_2 = 1.0f;
+  // float fn_m_minus_1 = x;
+  // for (int m = 2; m <= n_max; ++m) {
+  //   float fn_tmp1 = 2.0f * x * fn_m_minus_1 - fn_m_minus_2;
+  //   fn_m_minus_2 = fn_m_minus_1;
+  //   fn_m_minus_1 = fn_tmp1;
+  //   // fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
+  //   // fnp[m] = m * u1;
+  //   float fnp_tmp = m * u1;
+  //   u2 = 2.0f * x * u1 - u0;
+  //   u0 = u1;
+  //   u1 = u2;
+
+  //   float fn_tmp2 = (fn_tmp1 + 1.0f) * 0.5f;
+  //   fnp[m] = (fnp_tmp * 2.0f * (d12 * rcinv - 1.0f) * rcinv) * fc12 + fn_tmp2 * fcp12;
+  //   // fnp[m] = fnp[m] * fc12 + fn_tmp2 * fcp12;
+  //   fn[m] = fn_tmp2 * fc12;
   // }
+  // // for (int m = 0; m <= n_max; ++m) {
+  // //   fn[m] = (fn[m] + 1.0f) * 0.5f;
+  // //   fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
+  // //   fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
+  // //   fn[m] *= fc12;
+  // // }
 }
 
 static __device__ __forceinline__ void get_f12_4body(

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -360,15 +360,6 @@ static __device__ __forceinline__ void find_fn_and_fnp(
 static __device__ __forceinline__ void
 find_fn(const int n_max, const float rcinv, const float d12, const float fc12, float* fn)
 {
-  // float x = 2.0f * (d12 * rcinv - 1.0f) * (d12 * rcinv - 1.0f) - 1.0f;
-  // fn[0] = 1.0f;
-  // fn[1] = x;
-  // for (int m = 2; m <= n_max; ++m) {
-  //   fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
-  // }
-  // for (int m = 0; m <= n_max; ++m) {
-  //   fn[m] = (fn[m] + 1.0f) * 0.5f * fc12;
-  // }
   float x = 2.0f * (d12 * rcinv - 1.0f) * (d12 * rcinv - 1.0f) - 1.0f;
   float half_fc12 = 0.5f * fc12;
   fn[0] = fc12;
@@ -393,34 +384,11 @@ static __device__ __host__ __forceinline__ void find_fn_and_fnp(
   float* fn,
   float* fnp)
 {
-  // float x = 2.0f * (d12 * rcinv - 1.0f) * (d12 * rcinv - 1.0f) - 1.0f;
-  // fn[0] = 1.0f;
-  // fnp[0] = 0.0f;
-  // fn[1] = x;
-  // fnp[1] = 1.0f;
-  // float u0 = 1.0f;
-  // float u1 = 2.0f * x;
-  // float u2;
-  // for (int m = 2; m <= n_max; ++m) {
-  //   fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
-  //   fnp[m] = m * u1;
-  //   u2 = 2.0f * x * u1 - u0;
-  //   u0 = u1;
-  //   u1 = u2;
-  // }
-  // for (int m = 0; m <= n_max; ++m) {
-  //   fn[m] = (fn[m] + 1.0f) * 0.5f;
-  //   fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
-  //   fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
-  //   fn[m] *= fc12;
-  // }
   float d12_mul_rcinv = d12 * rcinv;
   float x = 2.0f * (d12_mul_rcinv - 1.0f) * (d12_mul_rcinv - 1.0f) - 1.0f;
   fn[0] = fc12;
-  // fnp[0] = 0.0f;
   fnp[0] = fcp12;
   fn[1] = (x + 1.0f) * 0.5f * fc12;
-  // fnp[1] = 1.0f;
   fnp[1] = 2.0f * (d12_mul_rcinv - 1.0f) * rcinv * fc12 + (x + 1.0f) * 0.5f * fcp12;
   float u0 = 1.0f;
   float u1 = 2.0f * x;
@@ -431,8 +399,6 @@ static __device__ __host__ __forceinline__ void find_fn_and_fnp(
     float fn_tmp1 = 2.0f * x * fn_m_minus_1 - fn_m_minus_2;
     fn_m_minus_2 = fn_m_minus_1;
     fn_m_minus_1 = fn_tmp1;
-    // fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
-    // fnp[m] = m * u1;
     float fnp_tmp = m * u1;
     u2 = 2.0f * x * u1 - u0;
     u0 = u1;
@@ -440,15 +406,8 @@ static __device__ __host__ __forceinline__ void find_fn_and_fnp(
 
     float fn_tmp2 = (fn_tmp1 + 1.0f) * 0.5f;
     fnp[m] = (fnp_tmp * 2.0f * (d12 * rcinv - 1.0f) * rcinv) * fc12 + fn_tmp2 * fcp12;
-    // fnp[m] = fnp[m] * fc12 + fn_tmp2 * fcp12;
     fn[m] = fn_tmp2 * fc12;
   }
-  // for (int m = 0; m <= n_max; ++m) {
-  //   fn[m] = (fn[m] + 1.0f) * 0.5f;
-  //   fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
-  //   fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
-  //   fn[m] *= fc12;
-  // }
 }
 
 static __device__ __forceinline__ void get_f12_4body(

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -393,27 +393,62 @@ static __device__ __host__ __forceinline__ void find_fn_and_fnp(
   float* fn,
   float* fnp)
 {
-  float x = 2.0f * (d12 * rcinv - 1.0f) * (d12 * rcinv - 1.0f) - 1.0f;
-  fn[0] = 1.0f;
-  fnp[0] = 0.0f;
-  fn[1] = x;
-  fnp[1] = 1.0f;
+  // float x = 2.0f * (d12 * rcinv - 1.0f) * (d12 * rcinv - 1.0f) - 1.0f;
+  // fn[0] = 1.0f;
+  // fnp[0] = 0.0f;
+  // fn[1] = x;
+  // fnp[1] = 1.0f;
+  // float u0 = 1.0f;
+  // float u1 = 2.0f * x;
+  // float u2;
+  // for (int m = 2; m <= n_max; ++m) {
+  //   fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
+  //   fnp[m] = m * u1;
+  //   u2 = 2.0f * x * u1 - u0;
+  //   u0 = u1;
+  //   u1 = u2;
+  // }
+  // for (int m = 0; m <= n_max; ++m) {
+  //   fn[m] = (fn[m] + 1.0f) * 0.5f;
+  //   fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
+  //   fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
+  //   fn[m] *= fc12;
+  // }
+  float d12_mul_rcinv = d12 * rcinv;
+  float x = 2.0f * (d12_mul_rcinv - 1.0f) * (d12_mul_rcinv - 1.0f) - 1.0f;
+  fn[0] = fc12;
+  // fnp[0] = 0.0f;
+  fnp[0] = fc12 * fcp12;
+  fn[1] = (x + 1.0f) * 0.5f * fc12;
+  // fnp[1] = 1.0f;
+  fnp[1] = 2.0f * (d12_mul_rcinv - 1.0f) * rcinv * fc12 + fn[1] * fcp12;
   float u0 = 1.0f;
   float u1 = 2.0f * x;
   float u2;
+  float fn_m_minus_2 = 1.0f;
+  float fn_m_minus_1 = x;
   for (int m = 2; m <= n_max; ++m) {
-    fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
-    fnp[m] = m * u1;
+    float fn_tmp1 = 2.0f * x * fn_m_minus_1 - fn_m_minus_2;
+    fn_m_minus_2 = fn_m_minus_1;
+    fn_m_minus_1 = fn_tmp1;
+    // fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
+    // fnp[m] = m * u1;
+    float fnp_tmp = m * u1;
     u2 = 2.0f * x * u1 - u0;
     u0 = u1;
     u1 = u2;
+
+    float fn_tmp2 = (fn_tmp1 + 1.0f) * 0.5f;
+    fnp[m] = (fnp_tmp * 2.0f * (d12 * rcinv - 1.0f) * rcinv) * fc12 + fn_tmp2 * fcp12;
+    // fnp[m] = fnp[m] * fc12 + fn_tmp2 * fcp12;
+    fn[m] = fn_tmp2 * fc12;
   }
-  for (int m = 0; m <= n_max; ++m) {
-    fn[m] = (fn[m] + 1.0f) * 0.5f;
-    fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
-    fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
-    fn[m] *= fc12;
-  }
+  // for (int m = 0; m <= n_max; ++m) {
+  //   fn[m] = (fn[m] + 1.0f) * 0.5f;
+  //   fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
+  //   fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
+  //   fn[m] *= fc12;
+  // }
 }
 
 static __device__ __forceinline__ void get_f12_4body(

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -393,62 +393,62 @@ static __device__ __host__ __forceinline__ void find_fn_and_fnp(
   float* fn,
   float* fnp)
 {
-  float x = 2.0f * (d12 * rcinv - 1.0f) * (d12 * rcinv - 1.0f) - 1.0f;
-  fn[0] = 1.0f;
-  fnp[0] = 0.0f;
-  fn[1] = x;
-  fnp[1] = 1.0f;
-  float u0 = 1.0f;
-  float u1 = 2.0f * x;
-  float u2;
-  for (int m = 2; m <= n_max; ++m) {
-    fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
-    fnp[m] = m * u1;
-    u2 = 2.0f * x * u1 - u0;
-    u0 = u1;
-    u1 = u2;
-  }
-  for (int m = 0; m <= n_max; ++m) {
-    fn[m] = (fn[m] + 1.0f) * 0.5f;
-    fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
-    fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
-    fn[m] *= fc12;
-  }
-  // float d12_mul_rcinv = d12 * rcinv;
-  // float x = 2.0f * (d12_mul_rcinv - 1.0f) * (d12_mul_rcinv - 1.0f) - 1.0f;
-  // fn[0] = fc12;
-  // // fnp[0] = 0.0f;
-  // fnp[0] = fc12 * fcp12;
-  // fn[1] = (x + 1.0f) * 0.5f * fc12;
-  // // fnp[1] = 1.0f;
-  // fnp[1] = 2.0f * (d12_mul_rcinv - 1.0f) * rcinv * fc12 + fn[1] * fcp12;
+  // float x = 2.0f * (d12 * rcinv - 1.0f) * (d12 * rcinv - 1.0f) - 1.0f;
+  // fn[0] = 1.0f;
+  // fnp[0] = 0.0f;
+  // fn[1] = x;
+  // fnp[1] = 1.0f;
   // float u0 = 1.0f;
   // float u1 = 2.0f * x;
   // float u2;
-  // float fn_m_minus_2 = 1.0f;
-  // float fn_m_minus_1 = x;
   // for (int m = 2; m <= n_max; ++m) {
-  //   float fn_tmp1 = 2.0f * x * fn_m_minus_1 - fn_m_minus_2;
-  //   fn_m_minus_2 = fn_m_minus_1;
-  //   fn_m_minus_1 = fn_tmp1;
-  //   // fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
-  //   // fnp[m] = m * u1;
-  //   float fnp_tmp = m * u1;
+  //   fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
+  //   fnp[m] = m * u1;
   //   u2 = 2.0f * x * u1 - u0;
   //   u0 = u1;
   //   u1 = u2;
-
-  //   float fn_tmp2 = (fn_tmp1 + 1.0f) * 0.5f;
-  //   fnp[m] = (fnp_tmp * 2.0f * (d12 * rcinv - 1.0f) * rcinv) * fc12 + fn_tmp2 * fcp12;
-  //   // fnp[m] = fnp[m] * fc12 + fn_tmp2 * fcp12;
-  //   fn[m] = fn_tmp2 * fc12;
   // }
-  // // for (int m = 0; m <= n_max; ++m) {
-  // //   fn[m] = (fn[m] + 1.0f) * 0.5f;
-  // //   fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
-  // //   fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
-  // //   fn[m] *= fc12;
-  // // }
+  // for (int m = 0; m <= n_max; ++m) {
+  //   fn[m] = (fn[m] + 1.0f) * 0.5f;
+  //   fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
+  //   fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
+  //   fn[m] *= fc12;
+  // }
+  float d12_mul_rcinv = d12 * rcinv;
+  float x = 2.0f * (d12_mul_rcinv - 1.0f) * (d12_mul_rcinv - 1.0f) - 1.0f;
+  fn[0] = fc12;
+  // fnp[0] = 0.0f;
+  fnp[0] = fcp12;
+  fn[1] = (x + 1.0f) * 0.5f * fc12;
+  // fnp[1] = 1.0f;
+  fnp[1] = 2.0f * (d12_mul_rcinv - 1.0f) * rcinv * fc12 + (x + 1.0f) * 0.5f * fcp12;
+  float u0 = 1.0f;
+  float u1 = 2.0f * x;
+  float u2;
+  float fn_m_minus_2 = 1.0f;
+  float fn_m_minus_1 = x;
+  for (int m = 2; m <= n_max; ++m) {
+    float fn_tmp1 = 2.0f * x * fn_m_minus_1 - fn_m_minus_2;
+    fn_m_minus_2 = fn_m_minus_1;
+    fn_m_minus_1 = fn_tmp1;
+    // fn[m] = 2.0f * x * fn[m - 1] - fn[m - 2];
+    // fnp[m] = m * u1;
+    float fnp_tmp = m * u1;
+    u2 = 2.0f * x * u1 - u0;
+    u0 = u1;
+    u1 = u2;
+
+    float fn_tmp2 = (fn_tmp1 + 1.0f) * 0.5f;
+    fnp[m] = (fnp_tmp * 2.0f * (d12 * rcinv - 1.0f) * rcinv) * fc12 + fn_tmp2 * fcp12;
+    // fnp[m] = fnp[m] * fc12 + fn_tmp2 * fcp12;
+    fn[m] = fn_tmp2 * fc12;
+  }
+  // for (int m = 0; m <= n_max; ++m) {
+  //   fn[m] = (fn[m] + 1.0f) * 0.5f;
+  //   fnp[m] *= 2.0f * (d12 * rcinv - 1.0f) * rcinv;
+  //   fnp[m] = fnp[m] * fc12 + fn[m] * fcp12;
+  //   fn[m] *= fc12;
+  // }
 }
 
 static __device__ __forceinline__ void get_f12_4body(


### PR DESCRIPTION
# Use temporary variables to reduce local memory loading and storing in `find_fn` and `find_fn_and_fnp` functions

## Analysis
When I check code in `nep_utilities.cuh` file, I find `find_fn` takes a lot of time. Detail shows below:
![image](https://github.com/user-attachments/assets/8622d871-0b5e-4349-ac0d-11bd517ee593)
The right panel shows that the memory operators is complicated.
* the gray bar means `long scoreboard`, usually caused by global memory operators.
* the blue bar means instructions executed.

This memory chart shows memory requests and other information for `find_descriptor_angular` function.
![image](https://github.com/user-attachments/assets/39acfc0c-79eb-47b3-81d9-2401951c3b36)

## Modification
Use some temporary variables to save these local variables to make sure there is only one storing operator.
![image](https://github.com/user-attachments/assets/d9caf2f3-a0a6-4575-82b9-6139cfb776d3)

This memory chart is also for `find_descriptor_angular` function, setting non-modified as the baseline. Although L2 cache storing is also the peek, requests are nearly half.
![image](https://github.com/user-attachments/assets/06e2790c-c649-4a98-96a6-1f0a647bb3ee)

## Because I modify two important functions, so maybe It needs be checked carefully

I have tested the code in some examples. It will take less time about **10%** to **16%**.