### PR TITLE
Init Struct Energy for Train Mode 1 and 2

### DIFF
--- a/src/main_nep/structure.cuh
+++ b/src/main_nep/structure.cuh
@@ -24,7 +24,7 @@ struct Structure {
   int has_virial;
   int has_temperature;
   float weight;
-  float energy;
+  float energy = 0.0f;
   float virial[6];
   float box_original[9];
   float volume;


### PR DESCRIPTION
# This PR is for #763 

There is no initialization for energy if `train_mode` equals to 1 or 2.
![image](https://github.com/user-attachments/assets/b54fe218-050e-49c4-a423-8b68618a15a5)

When I fix it, the `Total Loss` is not `nan`.
![image](https://github.com/user-attachments/assets/a70f07b2-23b4-439b-bb66-fc6d9e4be246)

## DIfferent Results (?
I use `-DDEBUG` flag to compile and compare the `loss.out` file from initialized and non initialized code. It shows that other columns are also different. The `loss.out` files are below: (I have removed nep.restart file each time)
[loss.out.raw.txt](https://github.com/user-attachments/files/17506277/loss.out.raw.txt)
[loss.out.fix.txt](https://github.com/user-attachments/files/17506279/loss.out.fix.txt)

## One More Thing
There are many ways to solve this bug. I recommend that initialize it in struct definition. And if it's allowed, make sure all variables will be initialized. This work will not make the code slower but will make it more robust.