### PR TITLE
Fix warnings in documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,9 +50,7 @@ todo_include_todos = True
 html_logo = "_static/logo.png"
 html_favicon = "_static/logo.ico"
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_static_path = ['_static']
-html_theme_options = {'display_version': True}
 html_context = {
     'current_version': version,
     'versions':

--- a/doc/gpumd/output_files/dipole_out.rst
+++ b/doc/gpumd/output_files/dipole_out.rst
@@ -1,4 +1,4 @@
-.. _dipole_out:
+.. _gpumd_dipole_out:
 .. index::
    single: dipole.out (output file)
 

--- a/doc/gpumd/output_files/index.rst
+++ b/doc/gpumd/output_files/index.rst
@@ -45,11 +45,11 @@ Output files
      - :ref:`active <kw_active>`
      - Simulation time and uncertainty during active learning.
      - Append
-   * - :ref:`dipole.out <dipole_out>`
+   * - :ref:`dipole.out <gpumd_dipole_out>`
      - :ref:`dump_dipole <kw_dump_dipole>`
      - Predicted dipole.
      - Append
-   * - :ref:`polarizability.out <polarizability_out>`
+   * - :ref:`polarizability.out <gpumd_polarizability_out>`
      - :ref:`dump_polarizability <kw_dump_polarizability>`
      - Predicted polarizability.
      - Append

--- a/doc/gpumd/output_files/polarizability_out.rst
+++ b/doc/gpumd/output_files/polarizability_out.rst
@@ -1,4 +1,4 @@
-.. _polarizability_out:
+.. _gpumd_polarizability_out:
 .. index::
    single: polarizability.out (output file)
 

--- a/doc/nep/output_files/dipole_out.rst
+++ b/doc/nep/output_files/dipole_out.rst
@@ -1,4 +1,4 @@
-.. _dipole_out:
+.. _nep_dipole_out:
 .. index::
    single: dipole_train.out (output file)
    single: dipole_test.out (output file)

--- a/doc/nep/output_files/index.rst
+++ b/doc/nep/output_files/index.rst
@@ -7,7 +7,7 @@ Output files
 The ``nep`` executable produces several output files.
 The :ref:`loss.out file <loss_out>` is written in "append mode", while all other files are continuously overwritten.
 
-The contents of the :ref:`energy_train.out <energy_out>`, :ref:`force_train.out <force_out_nep>`, :ref:`virial_train.out <virial_out>`, :ref:`stress_train.out <stress_out>`, :ref:`dipole_train.out <dipole_out>`, and :ref:`polarizability_train.out <polarizability_out>` files are updated every 1000 steps, while the contents of the other output files are updated every 100 steps.
+The contents of the :ref:`energy_train.out <energy_out>`, :ref:`force_train.out <force_out_nep>`, :ref:`virial_train.out <virial_out>`, :ref:`stress_train.out <stress_out>`, :ref:`dipole_train.out <nep_dipole_out>`, and :ref:`polarizability_train.out <nep_polarizability_out>` files are updated every 1000 steps, while the contents of the other output files are updated every 100 steps.
 
 With the exception of the :ref:`nep.txt file <nep_txt>`, the output files contain only numbers (no text) in matrix form.
 All the files are plain text files.
@@ -41,13 +41,13 @@ All the files are plain text files.
      - target and predicted stress values for training data set
    * - :ref:`stress_test.out <stress_out>`
      - target and predicted stress values for test data set
-   * - :ref:`dipole_train.out <dipole_out>`
+   * - :ref:`dipole_train.out <nep_dipole_out>`
      - target and predicted dipole values for training data set
-   * - :ref:`dipole_test.out <dipole_out>`
+   * - :ref:`dipole_test.out <nep_dipole_out>`
      - target and predicted dipole values for test data set
-   * - :ref:`polarizability_train.out <polarizability_out>`
+   * - :ref:`polarizability_train.out <nep_polarizability_out>`
      - target and predicted polarizability values for training data set
-   * - :ref:`polarizability_test.out <polarizability_out>`
+   * - :ref:`polarizability_test.out <nep_polarizability_out>`
      - target and predicted polarizability values for test data set
 
 .. toctree::

--- a/doc/nep/output_files/polarizability_out.rst
+++ b/doc/nep/output_files/polarizability_out.rst
@@ -1,4 +1,4 @@
-.. _polarizability_out:
+.. _nep_polarizability_out:
 .. index::
    single: polarizability_train.out (output file)
    single: polarizability_test.out (output file)

--- a/doc/publications.bib
+++ b/doc/publications.bib
@@ -998,19 +998,19 @@ doi = {10.1021/acsami.4c06055}
 }
 
 @article{RosFraMil23,
-  title = {Anharmonicity of the antiferrodistortive soft mode in barium zirconate ${\mathrm{BaZrO}}_{3}$},
+  title = {Anharmonicity of the antiferrodistortive soft mode in barium zirconate BaZrO$_3$},
   author = {Rosander, Petter and Fransson, Erik and Milesi-Brault, Cosme and Toulouse, Constance and Bourdarot, Fr\'ed\'eric and Piovano, Andrea and Bossak, Alexei and Guennou, Mael and Wahnstr\"om, G\"oran},
   journal = {Phys. Rev. B},
   volume = {108},
   pages = {014309},
   year = {2023},
-  doi = {10.1103/PhysRevB.108.014309}
+  doi = {10.1103/PhysRevB.108.014309},
 }
 
 @article{RuQiSun24,
 author = {Ru, Guoliang and Qi, Weihong and Sun, Shu and Tang, Kewei and Du, Chengfeng and Liu, Weimin},
 title = {Interlayer Friction and Adhesion Effects in Penta-PdSe2-Based van der Waals Heterostructures},
-year = {2024}
+year = {2024},
 journal = {Advanced Science},
 volume = {11},
 number = {34},
@@ -1025,7 +1025,7 @@ doi = {10.1002/advs.202400395},
   journal = {Diamond and Related Materials},
   volume = {129},
   pages = {109341},
-  doi = {10.1016/j.diamond.2022.109341}
+  doi = {10.1016/j.diamond.2022.109341},
 }
 
 @article{ShaDaiChe23,


### PR DESCRIPTION
This PR fixes errors and warnings in the compilation of the documentation that cause the updating of the homepage to fail.

* fixed to the format of the `doc/publications.bib` file
* removed deprecated functionality from  the RTD style
* fixed duplicated labels