### PR TITLE
Add momentum to documentation of compute.out file

### DIFF
--- a/doc/gpumd/output_files/compute_out.rst
+++ b/doc/gpumd/output_files/compute_out.rst
@@ -22,6 +22,7 @@ Assuming that the system is divided into :math:`M` groups according to the group
   * if virial is computed, there are :math:`3M` columns of group virials (in units of eV) from left to right in a form similar to that for force
   * if the potential part of the heat current is computed, there are :math:`3M` columns of group potential heat currents (in units of eV\ :math:`^{3/2}` amu\ :math:`^{-1/2}`) from left to right in a form similar to that for force
   * if the kinetic part of the heat current is computed, there are :math:`3M` columns of group kinetic heat currents (in units of eV\ :math:`^{3/2}` amu\ :math:`^{-1/2}`) from left to right in a form similar to that for force
+  * if momentum is computed, there are :math:`3M` columns of momenta (in units of amu\ :math:`^{1/2}` eV\ :math:`^{1/2}`) from left to right in a form similar to that for force
   * if temperature is computed, the last second column is the total energy of the thermostat coupling to the heat source region (in units of eV) and the last column is the total energy of the thermostat coupling to the heat sink region (in units of eV)
 
 Note that regardless of the order of properties in the :ref:`compute keyword <kw_compute>`, the order of the output data is fixed as given above.

--- a/doc/gpumd/output_files/compute_out.rst
+++ b/doc/gpumd/output_files/compute_out.rst
@@ -22,7 +22,7 @@ Assuming that the system is divided into :math:`M` groups according to the group
   * if virial is computed, there are :math:`3M` columns of group virials (in units of eV) from left to right in a form similar to that for force
   * if the potential part of the heat current is computed, there are :math:`3M` columns of group potential heat currents (in units of eV\ :math:`^{3/2}` amu\ :math:`^{-1/2}`) from left to right in a form similar to that for force
   * if the kinetic part of the heat current is computed, there are :math:`3M` columns of group kinetic heat currents (in units of eV\ :math:`^{3/2}` amu\ :math:`^{-1/2}`) from left to right in a form similar to that for force
-  * if momentum is computed, there are :math:`3M` columns of momenta (in units of amu\ :math:`^{1/2}` eV\ :math:`^{1/2}`) from left to right in a form similar to that for force
+  * if momentum is computed, there are :math:`3M` columns of group momenta (in units of amu\ :math:`^{1/2}` eV\ :math:`^{1/2}`) from left to right in a form similar to that for force
   * if temperature is computed, the last second column is the total energy of the thermostat coupling to the heat source region (in units of eV) and the last column is the total energy of the thermostat coupling to the heat sink region (in units of eV)
 
 Note that regardless of the order of properties in the :ref:`compute keyword <kw_compute>`, the order of the output data is fixed as given above.


### PR DESCRIPTION
This PR adds momentum to the documentation of the `compute.out` file. Fixes #782. 

@brucefan1983 based on your answer in #782, I confirmed the order of the momentum output, as well as the units (which I have called amu^(1/2) eV^(1/2) in the documentation instead of Dalton^(1/2) eV^(1/2), to match the other units on the page).

Furthermore, I checked the order in which the computed properties are printed in the `compute.out` file, and momentum seems to come after the kinetic part of the heat current, so this is where I added the bullet point for momentum to comply with the final note "regardless of the order of properties in the compute keyword, the order of the output data is fixed as given above". 