### PR TITLE
xnet

### DIFF
--- a/src/main_nep/nep.cuh
+++ b/src/main_nep/nep.cuh
@@ -41,6 +41,7 @@ class NEP : public Potential
 {
 public:
   struct ParaMB {
+    bool use_xnet = false;
     bool use_typewise_cutoff = false;
     bool use_typewise_cutoff_zbl = false;
     float typewise_cutoff_radial_factor = 2.5f;

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -74,6 +74,7 @@ void Parameters::set_default_parameters()
   is_force_delta_set = false;
   is_use_typewise_cutoff_set = false;
   is_use_typewise_cutoff_zbl_set = false;
+  is_use_xnet_set = false;
 
   train_mode = 0;              // potential
   prediction = 0;              // not prediction mode
@@ -104,6 +105,7 @@ void Parameters::set_default_parameters()
   typewise_cutoff_radial_factor = -1.0f;
   typewise_cutoff_angular_factor = -1.0f;
   typewise_cutoff_zbl_factor = -1.0f;
+  use_xnet = false;
 
   type_weight_cpu.resize(NUM_ELEMENTS);
   zbl_para.resize(550); // Maximum number of zbl parameters
@@ -190,10 +192,19 @@ void Parameters::calculate_parameters()
 
   if (version == 3) {
     number_of_variables_ann = (dim + 2) * num_neurons1 + 1;
+    if (use_xnet) {
+      number_of_variables_ann += num_neurons1 * 3;
+    }
   } else if (version == 4) {
     number_of_variables_ann = (dim + 2) * num_neurons1 * num_types + 1;
+    if (use_xnet) {
+      number_of_variables_ann += num_neurons1 * 3 * num_types;
+    }
   } else if (version == 5) {
     number_of_variables_ann = ((dim + 2) * num_neurons1 + 1) * num_types + 1;
+    if (use_xnet) {
+      number_of_variables_ann += num_neurons1 * 3 * num_types;
+    }
   }
 
   number_of_variables_descriptor =
@@ -359,6 +370,12 @@ void Parameters::report_inputs()
     printf("    (default) number of neurons = %d.\n", num_neurons1);
   }
 
+  if (is_use_xnet_set) {
+    printf("    (input)   use XNet with Cauchy activation function.\n");
+  } else {
+    printf("    (default) use tanh activation function.\n");
+  }
+
   if (is_lambda_1_set) {
     printf("    (input)   lambda_1 = %g.\n", lambda_1);
   } else {
@@ -493,6 +510,8 @@ void Parameters::parse_one_keyword(std::vector<std::string>& tokens)
     parse_use_typewise_cutoff(param, num_param);
   } else if (strcmp(param[0], "use_typewise_cutoff_zbl") == 0) {
     parse_use_typewise_cutoff_zbl(param, num_param);
+  } else if (strcmp(param[0], "use_xnet") == 0) {
+    parse_use_xnet(param, num_param);
   } else {
     PRINT_KEYWORD_ERROR(param[0]);
   }
@@ -1053,4 +1072,13 @@ void Parameters::parse_use_typewise_cutoff_zbl(const char** param, int num_param
   if (typewise_cutoff_zbl_factor < 0.5f) {
     PRINT_INPUT_ERROR("typewise_cutoff_zbl_factor must >= 0.5.\n");
   }
+}
+
+void Parameters::parse_use_xnet(const char** param, int num_param)
+{
+  if (num_param != 1) {
+    PRINT_INPUT_ERROR("use_xnet should have 0 parameter.\n");
+  }
+  use_xnet = true;
+  is_use_xnet_set = true;
 }

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -60,6 +60,7 @@ public:
   float typewise_cutoff_radial_factor;
   float typewise_cutoff_angular_factor;
   float typewise_cutoff_zbl_factor;
+  bool use_xnet;
 
   // check if a parameter has been set:
   bool is_train_mode_set;
@@ -85,6 +86,7 @@ public:
   bool is_zbl_set;
   bool is_use_typewise_cutoff_set;
   bool is_use_typewise_cutoff_zbl_set;
+  bool is_use_xnet_set;
 
   // other parameters
   int dim;                            // dimension of the descriptor vector
@@ -138,4 +140,5 @@ private:
   void parse_sigma0(const char** param, int num_param);
   void parse_use_typewise_cutoff(const char** param, int num_param);
   void parse_use_typewise_cutoff_zbl(const char** param, int num_param);
+  void parse_use_xnet(const char** param, int num_param);
 };

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -131,18 +131,22 @@ void SNES::find_type_of_variable(Parameters& para)
   // NN part
   if (para.version != 3) {
     int num_ann = (para.train_mode == 2) ? 2 : 1;
-    int num_extra_bias = (para.version == 5) ? 1 : 0;
+    int num_extra_para = (para.version == 5) ? 1 : 0;
+    num_extra_para += (para.use_xnet) ? para.num_neurons1 * 3 : 0;
     for (int ann = 0; ann < num_ann; ++ann) {
       for (int t = 0; t < para.num_types; ++t) {
-        for (int n = 0; n < (para.dim + 2) * para.num_neurons1 + num_extra_bias; ++n) {
+        for (int n = 0; n < (para.dim + 2) * para.num_neurons1 + num_extra_para; ++n) {
           type_of_variable[n + offset] = t;
         }
-        offset += (para.dim + 2) * para.num_neurons1 + num_extra_bias;
+        offset += (para.dim + 2) * para.num_neurons1 + num_extra_para;
       }
       ++offset; // the bias
     }
   } else {
     offset += (para.dim + 2) * para.num_neurons1 + 1;
+    if (para.use_xnet) {
+      offset += para.num_neurons1 * 3;
+    }
   }
 
   // descriptor part

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -187,7 +187,7 @@ static __device__ void apply_ann_one_layer_xnet(
     float lambda1 = w1[n + N_neu * 1];
     float lambda2 = w1[n + N_neu * 2];
     float d = w1[n + N_neu * 3];
-    float x2d2_factor = 1.0f / (1.0f + x * x + d * d);
+    float x2d2_factor = 1.0f / (0.01f + x * x + d * d);
     float x1 = (lambda1 * x + lambda2) * x2d2_factor;
     float der = (lambda1 - 2.0f * x * x1) * x2d2_factor;
     energy += w1[n] * x1;
@@ -246,7 +246,7 @@ static __device__ void apply_ann_one_layer_nep5_xnet(
     float lambda1 = w1[n + N_neu * 1];
     float lambda2 = w1[n + N_neu * 2];
     float d = w1[n + N_neu * 3];
-    float x2d2_factor = 1.0f / (1.0f + x * x + d * d);
+    float x2d2_factor = 1.0f / (0.01f + x * x + d * d);
     float x1 = (lambda1 * x + lambda2) * x2d2_factor;
     float der = (lambda1 - 2.0f * x * x1) * x2d2_factor;
     energy += w1[n] * x1;


### PR DESCRIPTION
usage in `nep.in`:

```
use_xnet # change to use the Cauchy activation function instead of tanh
```

Original activation in the paper is $f(x) = \frac{\lambda_1 x + \lambda_2}{x^2 + d^2}$, where $\lambda_1$, $\lambda_2$, and $d$ are trainable parameters.

I modified it to $f(x) = \frac{\lambda_1 x + \lambda_2}{x^2 + d^2 + 0.01}$ to avoid singularity. Is this necessary?

Ref:  [Cauchy activation function and XNet](https://doi.org/10.48550/arXiv.2409.19221)

Does not seem to be useful, will give up soon...
