### PR TITLE
Fix a bug of ilp_tmd_sw potential

### DIFF
--- a/src/force/ilp_tmd_sw.cu
+++ b/src/force/ilp_tmd_sw.cu
@@ -1447,6 +1447,10 @@ void ILP_TMD_SW::compute_ilp(
   ilp_data.f12y.fill(0);
   ilp_data.f12z.fill(0);
 
+  sw2_data.f12x.fill(0);
+  sw2_data.f12y.fill(0);
+  sw2_data.f12z.fill(0);
+
   double *g_fx = force_per_atom.data();
   double *g_fy = force_per_atom.data() + number_of_atoms;
   double *g_fz = force_per_atom.data() + number_of_atoms * 2;


### PR DESCRIPTION
`f12x`, `f12y`, `f12z` should be set to `0` in each step.