### PR TITLE
Use binary search to find matched neighbor faster when find many body force

### DIFF
--- a/src/force/potential.cu
+++ b/src/force/potential.cu
@@ -208,7 +208,6 @@ static __global__ void gpu_find_force_many_body(
     for (int i1 = 0; i1 < neighbor_number; ++i1) {
       int index = i1 * number_of_particles + n1;
       int n2 = g_neighbor_list[index];
-      int neighbor_number_2 = g_neighbor_number[n2];
 
       double x12double = g_x[n2] - x1;
       double y12double = g_y[n2] - y1;
@@ -221,14 +220,30 @@ static __global__ void gpu_find_force_many_body(
       float f12x = g_f12x[index];
       float f12y = g_f12y[index];
       float f12z = g_f12z[index];
-      int offset = 0;
-      for (int k = 0; k < neighbor_number_2; ++k) {
-        if (n1 == g_neighbor_list[n2 + number_of_particles * k]) {
-          offset = k;
+      // int offset = 0;
+
+      int l = 0;
+      int r = g_neighbor_number[n2];
+      int m = 0;
+      int tmp_value = 0;
+      while (l < r) {
+        m = (l + r) >> 1;
+        tmp_value = g_neighbor_list[n2 + number_of_particles * m];
+        if (tmp_value < n1) {
+          l = m + 1;
+        } else if (tmp_value > n1) {
+          r = m - 1;
+        } else {
           break;
         }
       }
-      index = offset * number_of_particles + n2;
+      // for (int k = 0; k < neighbor_number_2; ++k) {
+      //   if (n1 == g_neighbor_list[n2 + number_of_particles * k]) {
+      //     offset = k;
+      //     break;
+      //   }
+      // }
+      index = ((l + r) >> 1) * number_of_particles + n2;
       float f21x = g_f12x[index];
       float f21y = g_f12y[index];
       float f21z = g_f12z[index];


### PR DESCRIPTION

I find the kernel will loop the neighbor list to check if matched when reduce the many body force to atoms. This algorithm is O(n). However, the neighbor list will be sorted before, so actually we could use **binary search**, with time complexity O(log n). Although this place is not the bottleneck of the program (find descriptor and force part: O(mn)), this small change could also speed it up a little. :laughing: hhh
I test example 1 (thermal conductivity) and example 8. The results show **4%** reduction in computation time.
[gpumd.out.e8.compare.txt](https://github.com/user-attachments/files/17934678/gpumd.out.e8.compare.txt)
[gpumd.out.e8.modify.txt](https://github.com/user-attachments/files/17934680/gpumd.out.e8.modify.txt)
[gpumd.out.e1.compare.txt](https://github.com/user-attachments/files/17934682/gpumd.out.e1.compare.txt)
[gpumd.out.e1.modify.txt](https://github.com/user-attachments/files/17934705/gpumd.out.e1.modify.txt)
