### PR TITLE
add threshold_lo_ & threshold_hi_

### DIFF
--- a/src/measure/active.cuh
+++ b/src/measure/active.cuh
@@ -44,7 +44,8 @@ private:
   int check_interval_ = 1;
   int has_velocity_ = 0;
   int has_force_ = 0;
-  double threshold_ = 0.0;
+  double threshold_lo_ = 0.0;
+  double threshold_hi_ = 0.0;
   FILE* exyz_file_;
   FILE* out_file_;
   std::vector<double> cpu_force_per_atom_;


### PR DESCRIPTION
fix the issue "If the system has exploded, unphysical structures may be saved since no upper bound is set on the uncertainty  threshold."

**Summary**
The active learning workflow can be used with `active <interval> <has_velocity> <has_force> <threshold_lo> <threshold_hi>`

**Modification**
Rename `threshold_` to `threshold_lo_`, and add `threshold_hi`

**Others**
