### PR TITLE
output descriptor

### DIFF
--- a/doc/nep/input_parameters/index.rst
+++ b/doc/nep/input_parameters/index.rst
@@ -34,3 +34,4 @@ Below you can find a listing of keywords for the ``nep.in`` input file.
    batch
    population
    generation
+   output_descriptor

--- a/doc/nep/input_parameters/output_descriptor.rst
+++ b/doc/nep/input_parameters/output_descriptor.rst
@@ -1,0 +1,21 @@
+.. _kw_output_descriptor:
+.. index::
+   single: output_descriptor (keyword in nep.in)
+
+:attr:`output_descriptor`
+=========================
+
+This keyword instructs :program:`nep` to output the (normalized) descriptors for all the atoms in the ``train.xyz`` file.
+It is only in effect for the prediction mode (see the :ref:`prediction keyword <kw_prediction>`).
+The syntax is::
+
+  output_descriptor <mode>
+
+where :attr:`<mode>` must be an integer that can assume one of the following values.
+
+=====  =====================================================
+Value  Mode 
+-----  -----------------------------------------------------
+0      not to output descriptors during prediction (default)
+1      output descriptors during prediction
+=====  =====================================================

--- a/doc/nep/input_parameters/prediction.rst
+++ b/doc/nep/input_parameters/prediction.rst
@@ -6,7 +6,7 @@
 ==================
 
 This keyword instructs :program:`nep` to evaluate a model against a set of structures without starting an optimization.
-This requires a ``nep.txt`` file to be present.
+This requires a ``nep.txt`` file, in addition to the ``nep.in`` file, to be present.
 Note that only the structures in ``train.xyz`` are included in the prediction.
 The syntax is::
 

--- a/doc/nep/output_files/descriptor_out.rst
+++ b/doc/nep/output_files/descriptor_out.rst
@@ -3,7 +3,7 @@
    single: descriptor.out (output file)
 
 ``descriptor.out``
-========================
+==================
 
 The ``descriptor.out`` file contains the descriptor values for the atoms in the input ``train.xyz`` file.
 
@@ -11,4 +11,4 @@ There are :math:`N` rows and :math:`N_{\rm des}` columns, where :math:`N` is the
 
 The row index is consitent with the global atom index in the ``train.xyz`` file.
 
-For each row, there are :math:`N_{\rm des}` descriptor components, arranged in a particular order (radial components, three-body angular components, four-boty angular components, five-body angular components).
+For each row, there are :math:`N_{\rm des}` descriptor components, arranged in a particular order (radial components, three-body angular components, four-body angular components, five-body angular components).

--- a/doc/nep/output_files/descriptor_out.rst
+++ b/doc/nep/output_files/descriptor_out.rst
@@ -1,0 +1,14 @@
+.. _nep_descriptor_out:
+.. index::
+   single: descriptor.out (output file)
+
+``descriptor.out``
+========================
+
+The ``descriptor.out`` file contains the descriptor values for the atoms in the input ``train.xyz`` file.
+
+There are :math:`N` rows and :math:`N_{\rm des}` columns, where :math:`N` is the number of atoms in ``train.xyz`` and :math:`N_{\rm des}` is the dimension for the descriptor vector.
+
+The row index is consitent with the global atom index in the ``train.xyz`` file.
+
+For each row, there are :math:`N_{\rm des}` descriptor components, arranged in a particular order (radial components, three-body angular components, four-boty angular components, five-body angular components).

--- a/doc/nep/output_files/descriptor_out.rst
+++ b/doc/nep/output_files/descriptor_out.rst
@@ -9,6 +9,6 @@ The ``descriptor.out`` file contains the descriptor values for the atoms in the 
 
 There are :math:`N` rows and :math:`N_{\rm des}` columns, where :math:`N` is the number of atoms in ``train.xyz`` and :math:`N_{\rm des}` is the dimension for the descriptor vector.
 
-The row index is consitent with the global atom index in the ``train.xyz`` file.
+The row index is consistent with the global atom index in the ``train.xyz`` file.
 
 For each row, there are :math:`N_{\rm des}` descriptor components, arranged in a particular order (radial components, three-body angular components, four-body angular components, five-body angular components).

--- a/doc/nep/output_files/index.rst
+++ b/doc/nep/output_files/index.rst
@@ -49,6 +49,8 @@ All the files are plain text files.
      - target and predicted polarizability values for training data set
    * - :ref:`polarizability_test.out <nep_polarizability_out>`
      - target and predicted polarizability values for test data set
+   * - :ref:`descriptor.out <descriptor_out>`
+     - descriptor values for training data set in prediction mode
 
 .. toctree::
    :maxdepth: 0
@@ -63,3 +65,4 @@ All the files are plain text files.
    stress_out
    dipole_out
    polarizability_out
+   descriptor_out

--- a/src/main_nep/nep.cu
+++ b/src/main_nep/nep.cu
@@ -835,6 +835,19 @@ void NEP::find_force(
       nep_data[device_id].sum_fxyz.data());
     GPU_CHECK_KERNEL
 
+    if (para.prediction == 1 && para.output_descriptor == 1) {
+      FILE* fid_descriptor = my_fopen("descriptor.out", "a");
+      std::vector<float> descriptor_cpu(nep_data[device_id].descriptors.size());
+      nep_data[device_id].descriptors.copy_to_host(descriptor_cpu.data());
+      for (int n = 0; n < dataset[device_id].N; ++ n) {
+        for (int d = 0; d < annmb[device_id].dim; ++ d) {
+          fprintf(fid_descriptor, "%g ", descriptor_cpu[n + d * dataset[device_id].N] * para.q_scaler_cpu[d]);
+        }
+        fprintf(fid_descriptor, "\n");
+      }
+      fclose(fid_descriptor);
+    }
+
     if (calculate_q_scaler) {
       find_max_min<<<annmb[device_id].dim, 1024>>>(
         dataset[device_id].N,

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -494,6 +494,8 @@ void Parameters::parse_one_keyword(std::vector<std::string>& tokens)
     parse_use_typewise_cutoff(param, num_param);
   } else if (strcmp(param[0], "use_typewise_cutoff_zbl") == 0) {
     parse_use_typewise_cutoff_zbl(param, num_param);
+  } else if (strcmp(param[0], "output_descriptor") == 0) {
+    parse_output_descriptor(param, num_param);
   } else {
     PRINT_KEYWORD_ERROR(param[0]);
   }

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -104,6 +104,7 @@ void Parameters::set_default_parameters()
   typewise_cutoff_radial_factor = -1.0f;
   typewise_cutoff_angular_factor = -1.0f;
   typewise_cutoff_zbl_factor = -1.0f;
+  output_descriptor = false;
 
   type_weight_cpu.resize(NUM_ELEMENTS);
   zbl_para.resize(550); // Maximum number of zbl parameters
@@ -1052,5 +1053,20 @@ void Parameters::parse_use_typewise_cutoff_zbl(const char** param, int num_param
 
   if (typewise_cutoff_zbl_factor < 0.5f) {
     PRINT_INPUT_ERROR("typewise_cutoff_zbl_factor must >= 0.5.\n");
+  }
+}
+
+void Parameters::parse_output_descriptor(const char** param, int num_param)
+{
+  output_descriptor = true;
+
+  if (num_param != 2) {
+    PRINT_INPUT_ERROR("output_descriptor should have 1 parameter.\n");
+  }
+  if (!is_valid_int(param[1], &output_descriptor)) {
+    PRINT_INPUT_ERROR("output_descriptor should be an integer.\n");
+  }
+  if (output_descriptor != 0 && output_descriptor != 1) {
+    PRINT_INPUT_ERROR("output_descriptor should = 0 or 1.");
   }
 }

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -60,6 +60,7 @@ public:
   float typewise_cutoff_radial_factor;
   float typewise_cutoff_angular_factor;
   float typewise_cutoff_zbl_factor;
+  int output_descriptor;
 
   // check if a parameter has been set:
   bool is_train_mode_set;
@@ -138,4 +139,5 @@ private:
   void parse_sigma0(const char** param, int num_param);
   void parse_use_typewise_cutoff(const char** param, int num_param);
   void parse_use_typewise_cutoff_zbl(const char** param, int num_param);
+  void parse_output_descriptor(const char** param, int num_param);
 };


### PR DESCRIPTION
# New feature

Add option to output descriptor during prediction.

# Usage


```
# Both should be 1 to enable this feature:
prediction        1 
output_descriptor 1 
```

Results will be output to `descriptor.out` (with appending mode). The number of rows is the number of atoms in `train.xyz`, with the same order. The number of columns is the dimension of the descriptor. 

