### PR TITLE
For abacus change the virial information in the second line to the stress information

### DIFF
--- a/tools/abacus2xyz/multipleFrames-abacus2nep-exyz.sh
+++ b/tools/abacus2xyz/multipleFrames-abacus2nep-exyz.sh
@@ -2,15 +2,13 @@
 ### HOW TO USE #################################################################################
 ### SYNTAX: ./multipleFrames-abacus2nep-exyz.sh dire_name
 ###     NOTE: 1).'dire_name' is the directory containing running_md.log and MD_dump file.
-### Email: yanzhowang@gmail.com if any questions
-### Modified by Yuwen Zhang
-### Modified by Shunda Chen
-### Modified by Zihan Yan
+### Email: tang070205@proton.me if any questions
+### Modified by Yuwen Zhang, Shunda Chen, Zihan Yan
 ### Modified by Benrui Tang
 ################################################################################################
 #--- DEFAULT ASSIGNMENTS ---------------------------------------------------------------------
 isol_ener=0     # Shifted energy, specify the value?
-viri_logi=0     # Logical value for virial, true=1, false=0
+stress_logi=0     # Logical value for virial, true=1, false=0
 #--------------------------------------------------------------------------------------------
 read_dire=$1
 if [ -z "$read_dire" ]; then
@@ -24,12 +22,11 @@ rm -rf $writ_dire; mkdir $writ_dire
 configuration=$(pwd | awk -F'/' '{print $(NF-2)"/"$(NF-1)"/"$NF}')
 syst_numb_atom=$(grep "TOTAL ATOM NUMBER" running_md.log |awk '{print $5}')
 ener_values=($(grep 'etot' running_md.log |awk '{print $4}'))
-if [[ $viri_logi -eq 1 ]]; then
+if [[ $stress_logi -eq 1 ]]; then
     mdstep_lines=($(grep -n 'MDSTEP' MD_dump | awk -F: '{print $1+12+'$syst_numb_atom'}'))
 else
     mdstep_lines=($(grep -n 'MDSTEP' MD_dump | awk -F: '{print $1+9+'$syst_numb_atom'}'))
 fi
-conversion_value=$(grep "Volume (A^3)" running_md.log |awk '{print $4/1602.1766208}')
 N_counts=$(( ${#mdstep_lines[@]} - 1 ))
 
 
@@ -41,9 +38,9 @@ for ((i=1; i<${#mdstep_lines[@]}; i++)); do
     sed -n "${start_line},${end_line}p" MD_dump > temp.file
     echo "$syst_numb_atom" >> "$writ_dire/$writ_file"
     latt=$(grep -A 3 "LATTICE_VECTORS" temp.file | tail -n 3 | awk '{for (i = 1; i <= NF; i++) {printf "%.8f ", $i}}' |xargs)
-    if [[ $viri_logi -eq 1 ]]; then
-        viri=$(grep -A 3 "VIRIAL (kbar)" temp.file | tail -n 3 | awk '{for (i = 1; i <= NF; i++) {printf "%.8f ", $i * '$conversion_value'}}' |xargs)
-        echo "Config_type=$configuration Weight=1.0 Lattice=\"$latt\" Energy=$ener Virial=\"$viri\" pbc=\"T T T\" Properties=species:S:1:pos:R:3:forces:R:3" >> "$writ_dire/$writ_file"
+    if [[ $stress_logi -eq 1 ]]; then
+        stress=$(grep -A 3 "VIRIAL (kbar)" temp.file | tail -n 3 | awk '{for (i = 1; i <= NF; i++) {printf "%.8f ", $i * 0.1}}' |xargs)
+        echo "Config_type=$configuration Weight=1.0 Lattice=\"$latt\" Energy=$ener Stress=\"$stress\" pbc=\"T T T\" Properties=species:S:1:pos:R:3:forces:R:3" >> "$writ_dire/$writ_file"
     else
         echo "Config_type=$configuration Weight=1.0 Lattice=\"$latt\" Energy=$ener Properties=species:S:1:pos:R:3:forces:R:3 pbc=\"T T T\"" >> "$writ_dire/$writ_file"
     fi

--- a/tools/abacus2xyz/singleFrame-abacus2nep-exyz.sh
+++ b/tools/abacus2xyz/singleFrame-abacus2nep-exyz.sh
@@ -3,8 +3,7 @@
 ### SYNTAX: ./singleFrame-abacus2nep-exyz.sh dire_name   
 ###     NOTE: 1).'dire_name' is the directory containing running_scf.logs
 ### Email: tang070205@proton.me if have questions
-### Modified by Yanzhou Wang 
-### Modified by Shunda Chen 
+### Modified by Yanzhou Wang Shunda Chen 
 ### Modified by Benrui Tang
 ################################################################################################
 #--- DEFAULT ASSIGNMENTSts ---------------------------------------------------------------------

--- a/tools/abacus2xyz/singleFrame-abacus2nep-exyz.sh
+++ b/tools/abacus2xyz/singleFrame-abacus2nep-exyz.sh
@@ -9,7 +9,7 @@
 ################################################################################################
 #--- DEFAULT ASSIGNMENTSts ---------------------------------------------------------------------
 isol_ener=0     # Shifted energy, specify the value?
-viri_logi=1     # Logical value for virial, true=1, false=0
+stress_logi=1     # Logical value for virial, true=1, false=0
 #--------------------------------------------------------------------------------------------
 read_dire=$1
 if [ -z $read_dire ]; then
@@ -28,11 +28,10 @@ do
              echo $syst_numb_atom >> $writ_dire/$writ_file
              latt=$(grep -A 3 "Lattice vectors" $i | tail -n 3 | sed 's/+//g' | awk '{ for (i=1; i<=NF; i++) printf "%.8f ", $i}')
              ener=$(grep "FINAL_ETOT_IS" $i | awk '{printf "%.6f\n", $2 - '$syst_numb_atom' * '$isol_ener'}')
-             if [ $viri_logi -eq 1 ]
+             if [ $stress_logi -eq 1 ]
              then
-                   conversion_value=$(grep "Volume (A^3)" $i |awk '{print $4/1602.1766208}')
-                   viri=$(grep -A 4 "TOTAL-STRESS" $i | tail -n 3 | awk '{for (i = 1; i <= NF; i++) {printf "%.8f ", $i * '$conversion_value'}}' |xargs)
-                   echo Energy=$ener Lattice=\"$latt\" Virial=\"$viri\" "Config_type=$configuration Weight=1.0 Properties=species:S:1:pos:R:3:forces:R:3" >> $writ_dire/$writ_file
+                   stress=$(grep -A 4 "TOTAL-STRESS" $i | tail -n 3 | awk '{for (i = 1; i <= NF; i++) {printf "%.8f ", $i * 0.1}}' |xargs)
+                   echo Energy=$ener Lattice=\"$latt\" Stress=\"$stress\" "Config_type=$configuration Weight=1.0 Properties=species:S:1:pos:R:3:forces:R:3" >> $writ_dire/$writ_file
              else
                    echo Energy=$ener Lattice=\"$latt\" "Config_type=$configuration Weight=1.0 Properties=species:S:1:pos:R:3:forces:R:3" >> $writ_dire/$writ_file
              fi


### PR DESCRIPTION
Since NEP can now use the stress information instead of the virial information, and abacus doesn't output the virial information directly like vasp does, it's more concise to just use the stress.