### PR TITLE
sort big ilp nl to get the same results

### DIFF
--- a/src/force/neighbor.cu
+++ b/src/force/neighbor.cu
@@ -499,6 +499,10 @@ void find_neighbor_ilp(
   const int MN = NL.size() / NN.size();
   gpu_sort_neighbor_list_ilp<<<N, min(1024, MN), MN * sizeof(int)>>>(N, NN.data(), NL.data());
   GPU_CHECK_KERNEL
+  
+  const int big_ilp_MN = big_ilp_NL.size() / big_ilp_NN.size();
+  gpu_sort_neighbor_list<<<N, big_ilp_MN, big_ilp_MN * sizeof(int)>>>(N, big_ilp_NN.data(), big_ilp_NL.data());
+  GPU_CHECK_KERNEL
 }
 
 static __global__ void gpu_find_neighbor_ON1_SW(


### PR DESCRIPTION
**Summary**
ILP has other neighbor list. **Sort** it for the same results to debug.
**Modification**
Add sort neighbor list function in **neighbor.cu** file.
**Test**
I test three potential: ILP+SW, ILP+NEP, ILP+NEP(table). Here is the results:
![image](https://github.com/user-attachments/assets/fc120828-78fc-437e-bd2b-a1c9df3b2f56)

**Others**
None
