### PR TITLE
Local relaxation

### DIFF
--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -36,7 +36,6 @@ Run simulation according to the inputs in the run.in file.
 #include "utilities/gpu_macro.cuh"
 #include "utilities/read_file.cuh"
 #include "velocity.cuh"
-#include <cstring>
 
 static __global__ void gpu_find_largest_v2(
   int N, int number_of_rounds, double* g_vx, double* g_vy, double* g_vz, double* g_v2_max)
@@ -480,7 +479,14 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
   } else if (strcmp(param[0], "add_efield") == 0) {
     add_efield.parse(param, num_param, group);
   } else if (strcmp(param[0], "mc") == 0) {
-    mc.parse_mc(param, num_param, group, atom);
+    if (strcmp(param[1], "local_minimize") == 0)
+    {
+      mc.parse_mc_local(param, num_param, group, atom, box, force);
+    }
+    else
+    {
+      mc.parse_mc(param, num_param, group, atom);
+    }
   } else if (strcmp(param[0], "dftd3") == 0) {
     // nothing here; will be handled elsewhere
   } else if (strcmp(param[0], "compute_lsqt") == 0) {
@@ -625,7 +631,7 @@ void Run::parse_run(const char** param, int num_param)
   perform_a_run();
 }
 
-static __global__ void gpu_deform_atom(
+static __global__ void gpu_pressure_triclinic(
   int N,
   double mu0,
   double mu1,
@@ -674,6 +680,9 @@ void Run::parse_change_box(const char** param, int num_param)
   }
 
   if (num_param == 7) {
+    if (box.triclinic == 0) {
+      PRINT_INPUT_ERROR("Cannot use orthogonal box with shear deformation.");
+    }
     if (!is_valid_real(param[4], &deformation_matrix[1][2])) {
       PRINT_INPUT_ERROR("box change parameter in yz should be a number.");
     }
@@ -697,8 +706,12 @@ void Run::parse_change_box(const char** param, int num_param)
   printf("    in xy and yz by strain %g.\n", deformation_matrix[0][1]);
 
   for (int d = 0; d < 3; ++d) {
-    deformation_matrix[d][d] =
-      (box.cpu_h[d * 3 + d] + deformation_matrix[d][d]) / box.cpu_h[d * 3 + d];
+    if (box.triclinic == 0) {
+      deformation_matrix[d][d] = (box.cpu_h[d] + deformation_matrix[d][d]) / box.cpu_h[d];
+    } else {
+      deformation_matrix[d][d] =
+        (box.cpu_h[d * 3 + d] + deformation_matrix[d][d]) / box.cpu_h[d * 3 + d];
+    }
   }
 
   printf("    Deformation matrix =\n");
@@ -710,33 +723,47 @@ void Run::parse_change_box(const char** param, int num_param)
     printf("\n");
   }
 
-  printf("    Original box h = [a, b, c] is\n");
-  for (int d1 = 0; d1 < 3; ++d1) {
-    printf("        ");
-    for (int d2 = 0; d2 < 3; ++d2) {
-      printf("%g ", box.cpu_h[d1 * 3 + d2]);
-    }
-    printf("\n");
-  }
-
-  double h_old[9];
-  for (int i = 0; i < 9; ++i) {
-    h_old[i] = box.cpu_h[i];
-  }
-
-  for (int r = 0; r < 3; ++r) {
-    for (int c = 0; c < 3; ++c) {
-      double tmp = 0.0;
-      for (int k = 0; k < 3; ++k) {
-        tmp += deformation_matrix[r][k] * h_old[k * 3 + c];
+  if (box.triclinic == 0) {
+    printf("    Original box lengths are\n");
+    printf("        Lx = %g A\n", box.cpu_h[0]);
+    printf("        Ly = %g A\n", box.cpu_h[1]);
+    printf("        Lz = %g A\n", box.cpu_h[2]);
+  } else {
+    printf("    Original box h = [a, b, c] is\n");
+    for (int d1 = 0; d1 < 3; ++d1) {
+      printf("        ");
+      for (int d2 = 0; d2 < 3; ++d2) {
+        printf("%g ", box.cpu_h[d1 * 3 + d2]);
       }
-      box.cpu_h[r * 3 + c] = tmp;
+      printf("\n");
     }
   }
-  box.get_inverse();
+
+  if (box.triclinic == 0) {
+    for (int d = 0; d < 3; ++d) {
+      box.cpu_h[d] *= deformation_matrix[d][d];
+      box.cpu_h[d + 3] = box.cpu_h[d] * 0.5;
+    }
+  } else {
+    double h_old[9];
+    for (int i = 0; i < 9; ++i) {
+      h_old[i] = box.cpu_h[i];
+    }
+
+    for (int r = 0; r < 3; ++r) {
+      for (int c = 0; c < 3; ++c) {
+        double tmp = 0.0;
+        for (int k = 0; k < 3; ++k) {
+          tmp += deformation_matrix[r][k] * h_old[k * 3 + c];
+        }
+        box.cpu_h[r * 3 + c] = tmp;
+      }
+    }
+    box.get_inverse();
+  }
 
   const int number_of_atoms = atom.position_per_atom.size() / 3;
-  gpu_deform_atom<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
+  gpu_pressure_triclinic<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
     number_of_atoms,
     deformation_matrix[0][0],
     deformation_matrix[0][1],
@@ -752,12 +779,19 @@ void Run::parse_change_box(const char** param, int num_param)
     atom.position_per_atom.data() + number_of_atoms * 2);
   GPU_CHECK_KERNEL
 
-  printf("    Changed box h = [a, b, c] is\n");
-  for (int d1 = 0; d1 < 3; ++d1) {
-    printf("        ");
-    for (int d2 = 0; d2 < 3; ++d2) {
-      printf("%g ", box.cpu_h[d1 * 3 + d2]);
+  if (box.triclinic == 0) {
+    printf("    Changed box lengths are\n");
+    printf("        Lx = %g A\n", box.cpu_h[0]);
+    printf("        Ly = %g A\n", box.cpu_h[1]);
+    printf("        Lz = %g A\n", box.cpu_h[2]);
+  } else {
+    printf("    Changed box h = [a, b, c] is\n");
+    for (int d1 = 0; d1 < 3; ++d1) {
+      printf("        ");
+      for (int d2 = 0; d2 < 3; ++d2) {
+        printf("%g ", box.cpu_h[d1 * 3 + d2]);
+      }
+      printf("\n");
     }
-    printf("\n");
   }
 }

--- a/src/mc/mc.cu
+++ b/src/mc/mc.cu
@@ -331,3 +331,36 @@ void MC::parse_mc(const char** param, int num_param, std::vector<Group>& groups,
 
   do_mcmd = true;
 }
+
+
+void MC::parse_mc_local(const char** param, int num_param, std::vector<Group>& group, Atom& atom, Box& box, Force& force)
+{
+  printf("Perform simple MC with local relaxation:\n");
+  int num_param_before_group = 7;
+  if (num_param > num_param_before_group)
+  {
+    parse_group(param, num_param, group, num_param_before_group);
+    printf("    only for atoms in group %d of grouping method %d.\n", group_id, grouping_method);
+  }
+  is_valid_int(param[2], &num_steps_mc);
+  MC_Ensemble_Canonical mc_local_relax(param, num_param, num_steps_mc);
+  double scale_factor;
+  double temperature;
+  double force_tolerance;
+  int max_relaxation_steps;
+  is_valid_real(param[3], &temperature);
+  is_valid_real(param[4], &scale_factor);
+  is_valid_real(param[5], &force_tolerance);
+  is_valid_int(param[6], &max_relaxation_steps);
+  mc_local_relax.compute_local(
+    scale_factor,
+    temperature,
+    force,
+    max_relaxation_steps,
+    force_tolerance,
+    atom,
+    box,
+    group,
+    grouping_method,
+    group_id);
+}

--- a/src/mc/mc.cuh
+++ b/src/mc/mc.cuh
@@ -34,6 +34,9 @@ public:
 
   void parse_mc(const char** param, int num_param, std::vector<Group>& group, Atom& atom);
 
+  void parse_mc_local(const char** param, int num_param, std::vector<Group>& group, Atom& atom, Box& box, Force& force);
+
+
 private:
   bool do_mcmd = false;
   int num_steps_md = 0;

--- a/src/mc/mc_ensemble.cuh
+++ b/src/mc/mc_ensemble.cuh
@@ -18,6 +18,7 @@
 #include "model/box.cuh"
 #include "model/group.cuh"
 #include "nep_energy.cuh"
+#include "../minimize/minimizer_fire.cuh"
 #include "utilities/gpu_vector.cuh"
 #include <fstream>
 #include <iostream>

--- a/src/mc/mc_ensemble_canonical.cu
+++ b/src/mc/mc_ensemble_canonical.cu
@@ -19,7 +19,6 @@ The canonical ensemble for MCMD.
 
 #include "mc_ensemble_canonical.cuh"
 #include "utilities/gpu_macro.cuh"
-#include <cstring>
 
 MC_Ensemble_Canonical::MC_Ensemble_Canonical(
   const char** param, int num_param, int num_steps_mc_input)
@@ -385,4 +384,593 @@ void MC_Ensemble_Canonical::compute(
   }
 
   mc_output << md_step << "  " << num_accepted / double(num_steps_mc) << std::endl;
+}
+
+
+static __global__ void get_shpere_atoms(
+  const int N,
+  const int local_N,
+  const int* local_index,
+  const Box box,
+  const int i,
+  const int j,
+  const float rc_radial_square,
+  const double* __restrict__ g_x,
+  const double* __restrict__ g_y,
+  const double* __restrict__ g_z,
+  double* local_sphere_flags)
+{
+  int n = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n < local_N) {
+    int index = local_index[n];
+    double x0 = g_x[index];
+    double y0 = g_y[index];
+    double z0 = g_z[index];
+    double x0i = g_x[i] - x0;
+    double y0i = g_y[i] - y0;
+    double z0i = g_z[i] - z0;
+    double x0j = g_x[j] - x0;
+    double y0j = g_y[j] - y0;
+    double z0j = g_z[j] - z0;
+
+    apply_mic(box, x0i, y0i, z0i);
+    float distance_square_i = float(x0i * x0i + y0i * y0i + z0i * z0i);
+    apply_mic(box, x0j, y0j, z0j);
+    float distance_square_j = float(x0j * x0j + y0j * y0j + z0j * z0j);
+
+    if (distance_square_i < rc_radial_square) {
+      local_sphere_flags[n] = 1;
+      local_sphere_flags[n + local_N] = 1;
+      local_sphere_flags[n + 2 * local_N] = 1;
+    } else {
+      if (distance_square_j < rc_radial_square) {
+        local_sphere_flags[n] = 1;
+        local_sphere_flags[n + local_N] = 1;
+        local_sphere_flags[n + 2 * local_N] = 1;
+      }
+    }
+  }
+}
+
+static __global__ void get_outer_atoms(
+  const int N,
+  const int local_N,
+  const int* local_index,
+  const Box box,
+  const int i,
+  const int j,
+  const float rcmin_radial_square,
+  const float rcmax_radial_square,
+  const double* __restrict__ g_x,
+  const double* __restrict__ g_y,
+  const double* __restrict__ g_z,
+  double* outer_atoms_flags)
+{
+  int n = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n < local_N) {
+    int index = local_index[n];
+    double x0 = g_x[index];
+    double y0 = g_y[index];
+    double z0 = g_z[index];
+    double x0i = g_x[i] - x0;
+    double y0i = g_y[i] - y0;
+    double z0i = g_z[i] - z0;
+    double x0j = g_x[j] - x0;
+    double y0j = g_y[j] - y0;
+    double z0j = g_z[j] - z0;
+
+    apply_mic(box, x0i, y0i, z0i);
+    float distance_square_i = float(x0i * x0i + y0i * y0i + z0i * z0i);
+    apply_mic(box, x0j, y0j, z0j);
+    float distance_square_j = float(x0j * x0j + y0j * y0j + z0j * z0j);
+
+    if (distance_square_i < rcmax_radial_square && distance_square_i > rcmin_radial_square) {
+      outer_atoms_flags[n] += 1;
+    } else {
+      if (distance_square_j < rcmax_radial_square && distance_square_j > rcmin_radial_square) {
+        outer_atoms_flags[n] += 1;
+      }
+    }
+  }
+}
+
+
+//copy from a to b
+template <typename T>
+static __global__ void copy
+(
+  T* a,
+  T* b,
+  int* local_index,
+  int global_N,
+  int local_N,
+  int dimension)
+{
+  int n = blockDim.x * blockIdx.x + threadIdx.x;
+  if (n < local_N)
+  {
+    int index = local_index[n];
+    for (int i = 0; i < dimension; i++)
+    {
+      b[n + i * local_N] = a[index + i * global_N];
+    }
+  }
+}
+
+
+//copy from b to a
+template <typename T>
+static __global__ void copy_back
+(
+  T* a,
+  T* b,
+  int* local_index,
+  int global_N,
+  int local_N,
+  int dimension)
+{
+  int n = blockDim.x * blockIdx.x + threadIdx.x;
+  if (n < local_N)
+  {
+    int index = local_index[n];
+    for (int i = 0; i < dimension; i++)
+    {
+      a[index + i * global_N] = b[n + i * local_N];
+    }
+  }
+}
+
+
+static __global__ void gpu_sum(const int size, double* a, double* result)
+{
+  int number_of_patches = (size - 1) / 1024 + 1;
+  int tid = threadIdx.x;
+  int n, patch;
+  __shared__ double data[1024];
+  data[tid] = 0.0;
+  for (patch = 0; patch < number_of_patches; ++patch) {
+    n = tid + patch * 1024;
+    if (n < size)
+      data[tid] += a[n];
+  }
+  __syncthreads();
+  for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+    if (tid < offset) {
+      data[tid] += data[tid + offset];
+    }
+    __syncthreads();
+  }
+  if (tid == 0)
+    *result = data[0];
+}
+
+static __global__ void get_displacement(
+  const Box box,
+  double* global_position,
+  double* local_position,
+  int global_N,
+  int local_N,
+  int* local_index,
+  double* outer_atoms_flags,
+  double* displacement)
+{
+  int n = blockDim.x * blockIdx.x + threadIdx.x;
+  if (n < local_N)
+  {
+    int index = local_index[n];
+    double displace = 0;
+    double r12[3];
+    for (int i = 0; i < 3; i++)
+    {
+      r12[i] = (global_position[index + i * global_N] - local_position[n + i * local_N]);
+    }
+    apply_mic(box, r12[0], r12[1], r12[2]);
+    displace = r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2];
+    displacement[n] = sqrt(displace) * outer_atoms_flags[n];
+  }
+}
+
+double get_outer_average_displacement(
+  const Box box,
+  double* global_position,
+  double* local_position,
+  int global_N,
+  int local_N,
+  int* local_index,
+  double* outer_atoms_flags)
+{
+  GPU_Vector<double> displacement(local_N);
+  get_displacement<<<(local_N - 1) / 64 + 1, 64>>>(
+    box,
+    global_position,
+    local_position,
+    global_N,
+    local_N,
+    local_index,
+    outer_atoms_flags,
+    displacement.data());
+  gpuDeviceSynchronize();
+  
+  //calculate the average displacement
+  GPU_Vector<double> result(1);
+  gpu_sum<<<1, 1024>>>(local_N, displacement.data(), result.data());
+  GPU_Vector<double> outer_number(1);
+  gpu_sum<<<1, 1024>>>(local_N, outer_atoms_flags, outer_number.data());
+  gpuDeviceSynchronize();
+  double number;
+  outer_number.copy_to_host(&number, 1);
+  double ans;
+  result.copy_to_host(&ans, 1);
+  ans /= number;
+  return ans;
+}
+
+
+void build_all_atoms(
+  Atom& atom,
+  Atom& local_atoms,
+  int local_N,
+  int* local_index)
+{
+  copy_back<<<(local_N - 1) / 64 + 1, 64>>>(
+    atom.position_per_atom.data(),
+    local_atoms.position_per_atom.data(),
+    local_index,
+    atom.number_of_atoms,
+    local_N,
+    3);
+  gpuDeviceSynchronize();
+}
+
+void build_local_atoms(
+  Atom& atom,
+  Atom& local_atoms,
+  int local_N,
+  int* local_index)
+{
+  copy<<<(local_N - 1) / 64 + 1, 64>>>(
+    atom.mass.data(),
+    local_atoms.mass.data(),
+    local_index,
+    atom.number_of_atoms,
+    local_N,
+    1);
+  copy<<<(local_N - 1) / 64 + 1, 64>>>(
+    atom.type.data(),
+    local_atoms.type.data(),
+    local_index,
+    atom.number_of_atoms,
+    local_N,
+    1);
+  copy<<<(local_N - 1) / 64 + 1, 64>>>(
+    atom.position_per_atom.data(),
+    local_atoms.position_per_atom.data(),
+    local_index,
+    atom.number_of_atoms,
+    local_N,
+    3);
+  gpuDeviceSynchronize();
+}
+
+//implement the local simple MC
+void MC_Ensemble_Canonical::compute_local(
+    double scale_factor,
+    double temperature,
+    Force& force,
+    int max_relaxation_step,
+    double force_tolerance,
+    Atom& atom,
+    Box& box,
+    std::vector<Group>& groups,
+    int grouping_method,
+    int group_id)
+{
+  if (check_if_small_box(nep_energy.paramb.rc_radial, box)) {
+    printf("Cannot use small box for simple MC.\n");
+    exit(1);
+  }
+
+  if (type_before.size() < atom.number_of_atoms) {
+    type_before.resize(atom.number_of_atoms);
+    type_after.resize(atom.number_of_atoms);
+  }
+
+  int group_size =
+    grouping_method >= 0 ? groups[grouping_method].cpu_size[group_id] : atom.number_of_atoms;
+  std::uniform_int_distribution<int> r1(0, group_size - 1);
+
+  int num_accepted = 0;
+  for (int step = 0; step < num_steps_mc; ++step) {
+
+    int i = grouping_method >= 0
+              ? groups[grouping_method]
+                  .cpu_contents[groups[grouping_method].cpu_size_sum[group_id] + r1(rng)]
+              : r1(rng);
+    int type_i = atom.cpu_type[i];
+    int j = 0, type_j = type_i;
+    while (type_i == type_j) {
+      j = grouping_method >= 0
+            ? groups[grouping_method]
+                .cpu_contents[groups[grouping_method].cpu_size_sum[group_id] + r1(rng)]
+            : r1(rng);
+      type_j = atom.cpu_type[j];
+    }
+
+    CHECK(gpuMemset(NN_ij.data(), 0, sizeof(int)));
+    NL_ij.resize(atom.number_of_atoms);
+    get_neighbors_of_i_and_j<<<(atom.number_of_atoms - 1) / 64 + 1, 64>>>(
+      atom.number_of_atoms,
+      box,
+      i,
+      j,
+      nep_energy.paramb.rc_radial * nep_energy.paramb.rc_radial  * scale_factor * scale_factor,
+      atom.position_per_atom.data(),
+      atom.position_per_atom.data() + atom.number_of_atoms,
+      atom.position_per_atom.data() + atom.number_of_atoms * 2,
+      NN_ij.data(),
+      NL_ij.data());
+    GPU_CHECK_KERNEL
+
+    int NN_ij_cpu;
+    NN_ij.copy_to_host(&NN_ij_cpu);
+
+    get_types<<<(atom.number_of_atoms - 1) / 64 + 1, 64>>>(
+      atom.number_of_atoms,
+      i,
+      j,
+      type_i,
+      type_j,
+      atom.type.data(),
+      type_before.data(),
+      type_after.data());
+    GPU_CHECK_KERNEL
+
+    GPU_Vector<int> local_type_before_temp(atom.number_of_atoms);
+    GPU_Vector<int> local_type_after_temp(atom.number_of_atoms);
+    GPU_Vector<int> t2_radial_before_temp(atom.number_of_atoms * 1000);
+    GPU_Vector<int> t2_radial_after_temp(atom.number_of_atoms * 1000);
+    GPU_Vector<int> t2_angular_before_temp(atom.number_of_atoms * 1000);
+    GPU_Vector<int> t2_angular_after_temp(atom.number_of_atoms * 1000);
+    GPU_Vector<float> x12_radial_temp(atom.number_of_atoms * 1000);
+    GPU_Vector<float> y12_radial_temp(atom.number_of_atoms * 1000);
+    GPU_Vector<float> z12_radial_temp(atom.number_of_atoms * 1000);
+    GPU_Vector<float> x12_angular_temp(atom.number_of_atoms * 1000);
+    GPU_Vector<float> y12_angular_temp(atom.number_of_atoms * 1000);
+    GPU_Vector<float> z12_angular_temp(atom.number_of_atoms * 1000);
+    GPU_Vector<double> pe_before_temp(atom.number_of_atoms);
+
+    find_local_types<<<(NN_ij_cpu - 1) / 64 + 1, 64>>>(
+      NN_ij_cpu,
+      NL_ij.data(),
+      type_before.data(),
+      type_after.data(),
+      local_type_before_temp.data(),
+      local_type_after_temp.data());
+    GPU_CHECK_KERNEL
+
+    NN_radial.resize(atom.number_of_atoms);
+    NN_angular.resize(atom.number_of_atoms);
+    CHECK(gpuMemset(NN_radial.data(), 0, sizeof(int) * NN_radial.size()));
+    CHECK(gpuMemset(NN_angular.data(), 0, sizeof(int) * NN_angular.size()));
+    create_inputs_for_energy_calculator<<<(atom.number_of_atoms - 1) / 64 + 1, 64>>>(
+      atom.number_of_atoms,
+      NN_ij_cpu,
+      NL_ij.data(),
+      box,
+      nep_energy.paramb.rc_radial * nep_energy.paramb.rc_radial,
+      nep_energy.paramb.rc_angular * nep_energy.paramb.rc_angular,
+      atom.position_per_atom.data(),
+      atom.position_per_atom.data() + atom.number_of_atoms,
+      atom.position_per_atom.data() + atom.number_of_atoms * 2,
+      type_before.data(),
+      type_after.data(),
+      NN_radial.data(),
+      NN_angular.data(),
+      t2_radial_before_temp.data(),
+      t2_radial_after_temp.data(),
+      t2_angular_before_temp.data(),
+      t2_angular_after_temp.data(),
+      x12_radial_temp.data(),
+      y12_radial_temp.data(),
+      z12_radial_temp.data(),
+      x12_angular_temp.data(),
+      y12_angular_temp.data(),
+      z12_angular_temp.data());
+    GPU_CHECK_KERNEL
+
+    //get the before energy
+    nep_energy.find_energy(
+      NN_ij_cpu,
+      NN_radial.data(),
+      NN_angular.data(),
+      local_type_before_temp.data(),
+      t2_radial_before_temp.data(),
+      t2_angular_before_temp.data(),
+      x12_radial_temp.data(),
+      y12_radial_temp.data(),
+      z12_radial_temp.data(),
+      x12_angular_temp.data(),
+      y12_angular_temp.data(),
+      z12_angular_temp.data(),
+      pe_before_temp.data());
+
+    //calculate the after energy
+    exchange<<<1, 1>>>(
+      i,
+      j,
+      type_i,
+      type_j,
+      atom.type.data(),
+      atom.mass.data(),
+      atom.velocity_per_atom.data(),
+      atom.velocity_per_atom.data() + atom.number_of_atoms,
+      atom.velocity_per_atom.data() + atom.number_of_atoms * 2);
+
+
+    Atom local_atoms;
+    //find local atoms
+    GPU_Vector<int> local_N; //the length of local_index
+    GPU_Vector<int> local_index; // an array contains the index of the local atoms
+    GPU_Vector<double> local_sphere_flags; // an array labels the shell atom
+    local_N.resize(1);
+    local_index.resize(atom.number_of_atoms);
+    CHECK(gpuMemset(local_N.data(), 0, sizeof(int)));
+    get_neighbors_of_i_and_j<<<(atom.number_of_atoms - 1) / 64 + 1, 64>>>(
+      atom.number_of_atoms,
+      box,
+      i,
+      j,
+      nep_energy.paramb.rc_radial * nep_energy.paramb.rc_radial * (scale_factor + 1.2) * (scale_factor + 1.2),
+      atom.position_per_atom.data(),
+      atom.position_per_atom.data() + atom.number_of_atoms,
+      atom.position_per_atom.data() + atom.number_of_atoms * 2,
+      local_N.data(),
+      local_index.data());
+    GPU_CHECK_KERNEL
+
+    int local_N_cpu;
+    local_N.copy_to_host(&local_N_cpu);
+    local_sphere_flags.resize(local_N_cpu * 3);
+    local_sphere_flags.fill(0);
+
+    //get sphere atoms
+    get_shpere_atoms<<<(local_N_cpu - 1) / 64 + 1, 64>>>(
+      atom.number_of_atoms,
+      local_N_cpu,
+      local_index.data(),
+      box,
+      i,
+      j,
+      nep_energy.paramb.rc_radial * nep_energy.paramb.rc_radial * scale_factor * scale_factor,
+      atom.position_per_atom.data(),
+      atom.position_per_atom.data() + atom.number_of_atoms,
+      atom.position_per_atom.data() + atom.number_of_atoms * 2,
+      local_sphere_flags.data());
+
+
+    //build the local_atoms
+    local_atoms.number_of_atoms = local_N_cpu;
+    local_atoms.position_per_atom.resize(3 * local_N_cpu);
+    local_atoms.force_per_atom.resize(3 * local_N_cpu);
+    local_atoms.type.resize(local_N_cpu);
+    local_atoms.velocity_per_atom.resize(3 * local_N_cpu);
+    local_atoms.mass.resize(local_N_cpu);
+    local_atoms.potential_per_atom.resize(local_N_cpu);
+    local_atoms.virial_per_atom.resize(9 * local_N_cpu);
+
+    //initialize
+    local_atoms.force_per_atom.fill(0);
+    local_atoms.potential_per_atom.fill(0);
+    local_atoms.velocity_per_atom.fill(0);
+    local_atoms.virial_per_atom.fill(0);
+  
+    build_local_atoms(
+      atom,
+      local_atoms,
+      local_N_cpu,
+      local_index.data());
+
+
+    //need to modify here
+    force.potentials[0]->N2 = local_N_cpu;
+    Minimizer_FIRE Minimizer(
+      local_N_cpu,
+       max_relaxation_step,
+      force_tolerance);
+
+    Minimizer.compute_local(
+      force,
+      box,
+      local_atoms.position_per_atom,
+      local_atoms.type,
+      groups,
+      local_sphere_flags,
+      local_atoms.potential_per_atom,
+      local_atoms.force_per_atom,
+      local_atoms.virial_per_atom);
+
+    std::vector<double> pe_before_cpu(NN_ij_cpu);
+    std::vector<double> pe_after_cpu(local_N_cpu);
+    pe_before_temp.copy_to_host(pe_before_cpu.data(), NN_ij_cpu);
+    local_atoms.potential_per_atom.copy_to_host(pe_after_cpu.data(), local_N_cpu);
+    double pe_before_total = 0.0f;
+    double pe_after_total = 0.0f;
+    for (int n = 0; n < NN_ij_cpu; ++n) {
+      pe_before_total += pe_before_cpu[n];
+    }
+    for (int n = 0; n < local_N_cpu; ++n) {
+      pe_after_total += pe_after_cpu[n];
+    }
+    // printf("        per-atom energy before swapping = %g eV.\n", pe_before_total / NN_ij_cpu);
+    // printf("        per-atom energy after swapping = %g eV.\n", pe_after_total / NN_ij_cpu);
+    float energy_difference = pe_after_total - pe_before_total;
+    std::uniform_real_distribution<float> r2(0, 1);
+    float random_number = r2(rng);
+    float probability = exp(-energy_difference / (K_B * temperature));
+
+    if (random_number < probability) {
+      ++num_accepted;
+
+      atom.cpu_type[i] = type_j;
+      atom.cpu_type[j] = type_i;
+
+      auto atom_symbol_i = atom.cpu_atom_symbol[i];
+      atom.cpu_atom_symbol[i] = atom.cpu_atom_symbol[j];
+      atom.cpu_atom_symbol[j] = atom_symbol_i;
+
+      double mass_i = atom.cpu_mass[i];
+      atom.cpu_mass[i] = atom.cpu_mass[j];
+      atom.cpu_mass[j] = mass_i;
+
+      //get the output data
+      GPU_Vector<double> outer_atoms_flags(local_N_cpu);
+      outer_atoms_flags.fill(0);
+      get_outer_atoms<<<(local_N_cpu - 1) / 64 + 1, 64>>>(
+        atom.number_of_atoms,
+        local_N_cpu,
+        local_index.data(),
+        box,
+        i,
+        j,
+        nep_energy.paramb.rc_radial * nep_energy.paramb.rc_radial * (scale_factor - 1) * (scale_factor - 1),
+        nep_energy.paramb.rc_radial * nep_energy.paramb.rc_radial * scale_factor * scale_factor,
+        atom.position_per_atom.data(),
+        atom.position_per_atom.data() + atom.number_of_atoms,
+        atom.position_per_atom.data() + atom.number_of_atoms * 2,
+        outer_atoms_flags.data());
+      gpuDeviceSynchronize();
+
+      double output = get_outer_average_displacement(
+        box,
+        atom.position_per_atom.data(),
+        local_atoms.position_per_atom.data(),
+        atom.number_of_atoms,
+        local_atoms.number_of_atoms,
+        local_index.data(),
+        outer_atoms_flags.data());
+      mc_output << output << "  " << num_accepted / (double(step) + 1) << std::endl;
+
+      //copy the relaxed local structure to the global structure
+      build_all_atoms(
+        atom,
+        local_atoms,
+        local_N_cpu,
+        local_index.data());
+    }
+    else
+    {
+      exchange<<<1, 1>>>(
+        i,
+        j,
+        type_j,
+        type_i,
+        atom.type.data(),
+        atom.mass.data(),
+        atom.velocity_per_atom.data(),
+        atom.velocity_per_atom.data() + atom.number_of_atoms,
+        atom.velocity_per_atom.data() + atom.number_of_atoms * 2);
+    }
+    //need modification
+    force.potentials[0]->N2 = atom.number_of_atoms;
+  }
 }

--- a/src/mc/mc_ensemble_canonical.cu
+++ b/src/mc/mc_ensemble_canonical.cu
@@ -695,7 +695,7 @@ void MC_Ensemble_Canonical::compute_local(
             : r1(rng);
       type_j = atom.cpu_type[j];
     }
-
+    mc_output << "Maximum displacement" << "  " << "Average displacement" << "  " <<  "Accept ratio" << std::endl;
     CHECK(gpuMemset(NN_ij.data(), 0, sizeof(int)));
     NL_ij.resize(atom.number_of_atoms);
     get_neighbors_of_i_and_j<<<(atom.number_of_atoms - 1) / 64 + 1, 64>>>(

--- a/src/mc/mc_ensemble_canonical.cuh
+++ b/src/mc/mc_ensemble_canonical.cuh
@@ -30,6 +30,18 @@ public:
     std::vector<Group>& group,
     int grouping_method,
     int group_id);
+  
+  virtual void compute_local(
+    double scale_factor,
+    double temperature,
+    Force& force,
+    int max_relaxation_step,
+    double force_tolerance,
+    Atom& atom,
+    Box& box,
+    std::vector<Group>& group,
+    int grouping_method,
+    int group_id);
 
 private:
   GPU_Vector<int> NN_ij;

--- a/src/mc/nep_energy.cuh
+++ b/src/mc/nep_energy.cuh
@@ -91,6 +91,23 @@ public:
     const float* g_z12_angular,
     float* g_pe);
 
+    //new method
+
+  void find_energy(
+    const int N,
+    const int* g_NN_radial,
+    const int* g_NN_angular,
+    const int* g_type,
+    const int* g_t2_radial,
+    const int* g_t2_angular,
+    const float* g_x12_radial,
+    const float* g_y12_radial,
+    const float* g_z12_radial,
+    const float* g_x12_angular,
+    const float* g_y12_angular,
+    const float* g_z12_angular,
+    double* g_pe);
+
 private:
   GPU_Vector<float> nep_parameters; // parameters to be optimized
   void update_potential(float* parameters, ANN& ann);

--- a/src/minimize/minimizer_fire.cu
+++ b/src/minimize/minimizer_fire.cu
@@ -21,7 +21,6 @@ Reference: PhysRevLett 97, 170201 (2006)
 
 #include "minimizer_fire.cuh"
 #include "utilities/gpu_macro.cuh"
-#include <cstring>
 
 namespace
 {
@@ -179,4 +178,90 @@ void Minimizer_FIRE::compute(
   }
 
   printf("Energy minimization finished.\n");
+}
+
+
+
+void Minimizer_FIRE::compute_local(
+    Force& force,
+    Box& box,
+    GPU_Vector<double>& position_per_atom,
+    GPU_Vector<int>& type,
+    std::vector<Group>& group,
+    GPU_Vector<double>& local_flags,
+    GPU_Vector<double>& potential_per_atom,
+    GPU_Vector<double>& force_per_atom,
+    GPU_Vector<double>& virial_per_atom)
+{
+  double next_dt;
+  const int size = number_of_atoms_ * 3;
+  int base = (number_of_steps_ >= 10) ? (number_of_steps_ / 10) : 1;
+  // create a velocity vector in GPU
+  GPU_Vector<double> v(size, 0);
+  GPU_Vector<double> temp1(size);
+  GPU_Vector<double> temp2(size);
+
+  //printf("\nEnergy minimization started.\n");
+
+  for (int step = 0; step < number_of_steps_; ++step) {
+    force.compute(
+      box, position_per_atom, type, group, potential_per_atom, force_per_atom, virial_per_atom);
+    pairwise_product(force_per_atom, local_flags, force_per_atom);
+    pairwise_product(potential_per_atom, local_flags, potential_per_atom);
+    calculate_force_square_max(force_per_atom);
+    const double force_max = sqrt(cpu_force_square_max_[0]);
+    calculate_total_potential(potential_per_atom);
+
+    /*if (step % base == 0 || force_max < force_tolerance_) {
+      printf(
+        "    step %d: total_potential = %.10f eV, f_max = %.10f eV/A.\n",
+        step,
+        cpu_total_potential_[0],
+        force_max);
+    */
+    if (force_max < force_tolerance_)
+      break;
+    
+    P = dot(v, force_per_atom);
+
+    if (P > 0) {
+      if (N_neg > N_min) {
+        next_dt = dt * f_inc;
+        if (next_dt < dt_max)
+          dt = next_dt;
+        alpha *= f_alpha;
+      }
+      N_neg++;
+    } else {
+      next_dt = dt * f_dec;
+      if (next_dt > dt_min)
+        dt = next_dt;
+      alpha = alpha_start;
+      // move position back
+      scalar_multiply(-0.5 * dt, v, temp1);
+      pairwise_product(temp1, local_flags, temp1);
+      vector_sum(position_per_atom, temp1, position_per_atom);
+      v.fill(0);
+      N_neg = 0;
+    }
+
+    // md step
+    // implicit Euler integration
+    double F_modulus = sqrt(dot(force_per_atom, force_per_atom));
+    double v_modulus = sqrt(dot(v, v));
+    // dv = F/m*dt
+    scalar_multiply(dt / m, force_per_atom, temp2);
+    vector_sum(v, temp2, v);
+    pairwise_product(v, local_flags, v);
+    scalar_multiply(1 - alpha, v, temp1);
+    scalar_multiply(alpha * v_modulus / F_modulus, force_per_atom, temp2);
+    vector_sum(temp1, temp2, v);
+    pairwise_product(v, local_flags, v);
+    // dx = v*dt
+    scalar_multiply(dt, v, temp1);
+    pairwise_product(temp1, local_flags, temp1);
+    vector_sum(position_per_atom, temp1, position_per_atom);
+  }
+
+  //printf("Energy minimization finished.\n");
 }

--- a/src/minimize/minimizer_fire.cuh
+++ b/src/minimize/minimizer_fire.cuh
@@ -50,4 +50,15 @@ public:
     GPU_Vector<double>& potential_per_atom,
     GPU_Vector<double>& force_per_atom,
     GPU_Vector<double>& virial_per_atom);
+    
+  void compute_local(
+    Force& force,
+    Box& box,
+    GPU_Vector<double>& position_per_atom,
+    GPU_Vector<int>& type,
+    std::vector<Group>& group,
+    GPU_Vector<double>& local_flags,
+    GPU_Vector<double>& potential_per_atom,
+    GPU_Vector<double>& force_per_atom,
+    GPU_Vector<double>& virial_per_atom);
 };


### PR DESCRIPTION
add a new command
mc local_minimize <mc_trials> <T> <scale_factor> <force_tolerance> <maximal_number_of_relaxation_steps> [group <grouping_method> <group_id>]
This can perform simple mc and local relaxation.

Previously, we need to write a python jobscript to do the work, randomly select two atoms and swap - relax the structure - get the energy difference to calculate the probability of swap. 
Now the work flow has been implemented in GPUMD, although there still need some modification. The local relaxation method has been implemented, which means each time swap 2 atoms, we don't need to relax the whole system to get the energy, and the volumn of relax area can be controlled by the scale factor. The sphere area with radius scale_factor * radial_cutoff will be calculated.

TO DO: modify the output file
modify the code structure