### PR TITLE
FIX BUG: calculate NEP in different layers

### DIFF
--- a/src/force/ilp_nep_gr_hbn.cu
+++ b/src/force/ilp_nep_gr_hbn.cu
@@ -1380,6 +1380,7 @@ static __global__ void find_neighbor_list_nep(
   const int nz,
   const Box box,
   const int* g_type,
+  const int* group_label_ilp,
   const int* __restrict__ g_cell_count,
   const int* __restrict__ g_cell_count_sum,
   const int* __restrict__ g_cell_contents,
@@ -1449,6 +1450,11 @@ static __global__ void find_neighbor_list_nep(
           const int n2 = g_cell_contents[num_atoms_previous_cells + m];
 
           if (n2 < N1 || n2 >= N2 || n1 == n2) {
+            continue;
+          }
+
+          // check if the same layer
+          if (group_label_ilp[n1] != group_label_ilp[n2]) {
             continue;
           }
 
@@ -2090,6 +2096,7 @@ void ILP_NEP_GR_HBN::compute_ilp(
     num_bins[2],
     box,
     type.data(),
+    group_label_ilp,
     nep_data.cell_count.data(),
     nep_data.cell_count_sum.data(),
     nep_data.cell_contents.data(),

--- a/src/force/ilp_nep_tmd.cu
+++ b/src/force/ilp_nep_tmd.cu
@@ -1412,6 +1412,7 @@ static __global__ void find_neighbor_list_nep(
   const int nz,
   const Box box,
   const int* g_type,
+  const int* group_label_ilp,
   const int* __restrict__ g_cell_count,
   const int* __restrict__ g_cell_count_sum,
   const int* __restrict__ g_cell_contents,
@@ -1481,6 +1482,11 @@ static __global__ void find_neighbor_list_nep(
           const int n2 = g_cell_contents[num_atoms_previous_cells + m];
 
           if (n2 < N1 || n2 >= N2 || n1 == n2) {
+            continue;
+          }
+
+          // check if the same layer
+          if (group_label_ilp[n1] != group_label_ilp[n2]) {
             continue;
           }
 
@@ -2124,6 +2130,7 @@ void ILP_NEP_TMD::compute_ilp(
     num_bins[2],
     box,
     type.data(),
+    group_label_ilp,
     nep_data.cell_count.data(),
     nep_data.cell_count_sum.data(),
     nep_data.cell_contents.data(),


### PR DESCRIPTION
**Summary**
Fix a bug for NEP+ILP potentials. The cutoff of NEP potential file testing before is less than interlayer distance. So the bug is hidden. I am deeply sorry for my oversight.

**Modification**
Add check statements in **ilp_nep_gr_hbn.cu** and **ilp_nep_tmd.cu** files.

**Test**
- [x] `DEBUG` flag test.
- [x] Run 1e5 in time step 1fs with NVE to test energy conservation.
- [x] The two tests above with `USE_TABLE` flag.

**Others**
If any questions, please feel free to let me know!