### PR TITLE
NEP-Charge

### DIFF
--- a/src/main_nep/dataset.cu
+++ b/src/main_nep/dataset.cu
@@ -32,6 +32,7 @@ void Dataset::copy_structures(std::vector<Structure>& structures_input, int n1, 
     structures[n].num_atom = structures_input[n_input].num_atom;
     structures[n].weight = structures_input[n_input].weight;
     structures[n].has_virial = structures_input[n_input].has_virial;
+    structures[n].charge = structures_input[n_input].charge;
     structures[n].energy = structures_input[n_input].energy;
     structures[n].has_temperature = structures_input[n_input].has_temperature;
     structures[n].temperature = structures_input[n_input].temperature;
@@ -125,14 +126,17 @@ void Dataset::initialize_gpu_data(Parameters& para)
   std::vector<float> r_cpu(N * 3);
   std::vector<int> type_cpu(N);
 
+  charge.resize(N);
   energy.resize(N);
   virial.resize(N * 6);
   force.resize(N * 3);
+  charge_cpu.resize(N);
   energy_cpu.resize(N);
   virial_cpu.resize(N * 6);
   force_cpu.resize(N * 3);
 
   weight_cpu.resize(Nc);
+  charge_ref_cpu.resize(Nc);
   energy_ref_cpu.resize(Nc);
   energy_weight_cpu.resize(Nc);
   virial_ref_cpu.resize(Nc * 6);
@@ -141,6 +145,7 @@ void Dataset::initialize_gpu_data(Parameters& para)
 
   for (int n = 0; n < Nc; ++n) {
     weight_cpu[n] = structures[n].weight;
+    charge_ref_cpu[n] = structures[n].charge;
     energy_ref_cpu[n] = structures[n].energy;
     energy_weight_cpu[n] = structures[n].energy_weight;
     for (int k = 0; k < 6; ++k) {
@@ -168,12 +173,14 @@ void Dataset::initialize_gpu_data(Parameters& para)
   }
 
   type_weight_gpu.resize(NUM_ELEMENTS);
+  charge_ref_gpu.resize(Nc);
   energy_ref_gpu.resize(Nc);
   energy_weight_gpu.resize(Nc);
   virial_ref_gpu.resize(Nc * 6);
   force_ref_gpu.resize(N * 3);
   temperature_ref_gpu.resize(N);
   type_weight_gpu.copy_from_host(para.type_weight_cpu.data());
+  charge_ref_gpu.copy_from_host(charge_ref_cpu.data());
   energy_ref_gpu.copy_from_host(energy_ref_cpu.data());
   energy_weight_gpu.copy_from_host(energy_weight_cpu.data());
   virial_ref_gpu.copy_from_host(virial_ref_cpu.data());
@@ -655,3 +662,72 @@ std::vector<float> Dataset::get_rmse_virial(Parameters& para, const bool use_wei
   }
   return rmse_array;
 }
+
+static __global__ void gpu_sum_charge_error(
+  int* g_Na, 
+  int* g_Na_sum, 
+  float* g_charge, 
+  float* g_charge_ref,  
+  float* error_gpu)
+{
+  int tid = threadIdx.x;
+  int bid = blockIdx.x;
+  int Na = g_Na[bid];
+  int N1 = g_Na_sum[bid];
+  int N2 = N1 + Na;
+  extern __shared__ float s_charge[];
+  s_charge[tid] = 0.0f;
+
+  for (int n = N1 + tid; n < N2; n += blockDim.x) {
+    s_charge[tid] += g_charge[n];
+  }
+  __syncthreads();
+
+  for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+    if (tid < offset) {
+      s_charge[tid] += s_charge[tid + offset];
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    float diff = s_charge[0] / Na - g_charge_ref[bid];
+    error_gpu[bid] = diff * diff;
+  }
+}
+
+std::vector<float> Dataset::get_rmse_charge(Parameters& para, int device_id)
+{
+  CHECK(gpuSetDevice(device_id));
+
+  std::vector<float> rmse_array(para.num_types + 1, 0.0f);
+  std::vector<int> count_array(para.num_types + 1, 0);
+
+  int mem = sizeof(float) * Nc;
+  const int block_size = 256;
+
+  gpu_sum_charge_error<<<Nc, block_size, sizeof(float) * block_size>>>(
+    Na.data(),
+    Na_sum.data(),
+    charge.data(),
+    charge_ref_gpu.data(),
+    error_gpu.data());
+  CHECK(gpuMemcpy(error_cpu.data(), error_gpu.data(), mem, gpuMemcpyDeviceToHost));
+  for (int n = 0; n < Nc; ++n) {
+      float rmse_temp = error_cpu[n];
+      for (int t = 0; t < para.num_types + 1; ++t) {
+        if (has_type[t * Nc + n]) {
+          rmse_array[t] += rmse_temp;
+          count_array[t] += 1;
+        }
+      }
+  }
+
+  for (int t = 0; t <= para.num_types; ++t) {
+    if (count_array[t] > 0) {
+      rmse_array[t] = sqrt(rmse_array[t] / count_array[t]);
+    }
+  }
+  return rmse_array;
+}
+

--- a/src/main_nep/dataset.cuh
+++ b/src/main_nep/dataset.cuh
@@ -39,19 +39,23 @@ public:
   GPU_Vector<float> box_original; // (original) box (9 components)
   GPU_Vector<int> num_cell;       // number of cells in the expanded box (3 components)
 
+  GPU_Vector<float> charge;      // calculated charge in GPU
   GPU_Vector<float> energy;      // calculated energy in GPU
   GPU_Vector<float> virial;      // calculated virial in GPU
   GPU_Vector<float> force;       // calculated force in GPU
+  std::vector<float> charge_cpu;  // calculated charge in CPU
   std::vector<float> energy_cpu; // calculated energy in CPU
   std::vector<float> virial_cpu; // calculated virial in CPU
   std::vector<float> force_cpu;  // calculated force in CPU
 
   GPU_Vector<float> energy_weight_gpu;    // energy weight in GPU
+  GPU_Vector<float> charge_ref_gpu;       // reference charge in GPU
   GPU_Vector<float> energy_ref_gpu;       // reference energy in GPU
   GPU_Vector<float> virial_ref_gpu;       // reference virial in GPU
   GPU_Vector<float> force_ref_gpu;        // reference force in GPU
   GPU_Vector<float> temperature_ref_gpu;  // reference temperature in GPU
   std::vector<float> energy_weight_cpu;   // energy weight in CPU
+  std::vector<float> charge_ref_cpu;      // reference charge in CPU
   std::vector<float> energy_ref_cpu;      // reference energy in CPU
   std::vector<float> virial_ref_cpu;      // reference virial in CPU
   std::vector<float> force_ref_cpu;       // reference force in CPU
@@ -77,6 +81,7 @@ public:
     const bool do_shift,
     int device_id);
   std::vector<float> get_rmse_virial(Parameters& para, const bool use_weight, int device_id);
+  std::vector<float> get_rmse_charge(Parameters& para, int device_id);
 
 private:
   void copy_structures(std::vector<Structure>& structures_input, int n1, int n2);

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -587,7 +587,6 @@ void Fitness::predict(Parameters& para, float* elite)
       update_energy_force_virial(
         fid_energy, fid_force, fid_virial, fid_stress, train_set[batch_id][0]);
       if (para.has_charge) {
-        FILE* fid_charge = my_fopen("charge_train.out", "w");
         update_charge(fid_charge, train_set[batch_id][0]);
       }
     }

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -19,6 +19,7 @@ Get the fitness
 
 #include "fitness.cuh"
 #include "nep.cuh"
+#include "nep_charge.cuh"
 #include "tnep.cuh"
 #include "parameters.cuh"
 #include "structure.cuh"
@@ -121,8 +122,13 @@ Fitness::Fitness(Parameters& para)
     potential.reset(
       new TNEP(para, N, N_times_max_NN_radial, N_times_max_NN_angular, para.version, deviceCount));
   } else {
-    potential.reset(
-      new NEP(para, N, N_times_max_NN_radial, N_times_max_NN_angular, para.version, deviceCount));
+    if (para.has_charge) {
+      potential.reset(
+        new NEP_Charge(para, N, N_times_max_NN_radial, N_times_max_NN_angular, para.version, deviceCount));
+    } else {
+      potential.reset(
+        new NEP(para, N, N_times_max_NN_radial, N_times_max_NN_angular, para.version, deviceCount));
+    }
   }
 
   if (para.prediction == 0) {

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -195,6 +195,8 @@ void Fitness::compute(
           if (para.has_charge) {
             fitness[deviceCount * n + m + (7 * t + 6) * para.population_size] =
               para.lambda_q * rmse_charge_array[t];
+          } else {
+            fitness[deviceCount * n + m + (7 * t + 6) * para.population_size] = 0.0f;
           }
         }
       }

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -127,7 +127,7 @@ Fitness::Fitness(Parameters& para)
     potential.reset(
       new TNEP(para, N, N_times_max_NN_radial, N_times_max_NN_angular, para.version, deviceCount));
   } else {
-    if (para.has_charge) {
+    if (para.charge_mode) {
       potential.reset(
         new NEP_Charge(para, N, Nc, N_times_max_NN_radial, N_times_max_NN_angular, para.version, deviceCount));
     } else {
@@ -192,7 +192,7 @@ void Fitness::compute(
             para.lambda_f * rmse_force_array[t];
           fitness[deviceCount * n + m + (7 * t + 5) * para.population_size] =
             para.lambda_v * rmse_virial_array[t];
-          if (para.has_charge) {
+          if (para.charge_mode) {
             fitness[deviceCount * n + m + (7 * t + 6) * para.population_size] =
               para.lambda_q * rmse_charge_array[t];
           } else {
@@ -493,7 +493,7 @@ void Fitness::report_error(
         fclose(fid_force);
         fclose(fid_virial);
         fclose(fid_stress);
-        if (para.has_charge) {
+        if (para.charge_mode) {
           FILE* fid_charge = my_fopen("charge_test.out", "w");
           update_charge(fid_charge, test_set[0]);
           fclose(fid_charge);
@@ -579,14 +579,14 @@ void Fitness::predict(Parameters& para, float* elite)
     FILE* fid_virial = my_fopen("virial_train.out", "w");
     FILE* fid_stress = my_fopen("stress_train.out", "w");
     FILE* fid_charge;
-    if (para.has_charge) {
+    if (para.charge_mode) {
       fid_charge = my_fopen("charge_train.out", "w");
     }
     for (int batch_id = 0; batch_id < num_batches; ++batch_id) {
       potential->find_force(para, elite, train_set[batch_id], false, true, 1);
       update_energy_force_virial(
         fid_energy, fid_force, fid_virial, fid_stress, train_set[batch_id][0]);
-      if (para.has_charge) {
+      if (para.charge_mode) {
         update_charge(fid_charge, train_set[batch_id][0]);
       }
     }
@@ -594,7 +594,7 @@ void Fitness::predict(Parameters& para, float* elite)
     fclose(fid_force);
     fclose(fid_virial);
     fclose(fid_stress);
-    if (para.has_charge) {
+    if (para.charge_mode) {
       fclose(fid_charge);
     }
   } else if (para.train_mode == 1) {

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -88,12 +88,14 @@ Fitness::Fitness(Parameters& para)
   }
 
   int N = -1;
+  int Nc = -1;
   int N_times_max_NN_radial = -1;
   int N_times_max_NN_angular = -1;
   max_NN_radial = -1;
   max_NN_angular = -1;
   if (has_test_set) {
     N = test_set[0].N;
+    Nc = test_set[0].Nc;
     N_times_max_NN_radial = test_set[0].N * test_set[0].max_NN_radial;
     N_times_max_NN_angular = test_set[0].N * test_set[0].max_NN_angular;
     max_NN_radial = test_set[0].max_NN_radial;
@@ -102,6 +104,9 @@ Fitness::Fitness(Parameters& para)
   for (int n = 0; n < num_batches; ++n) {
     if (train_set[n][0].N > N) {
       N = train_set[n][0].N;
+    };
+    if (train_set[n][0].Nc > Nc) {
+      Nc = train_set[n][0].Nc;
     };
     if (train_set[n][0].N * train_set[n][0].max_NN_radial > N_times_max_NN_radial) {
       N_times_max_NN_radial = train_set[n][0].N * train_set[n][0].max_NN_radial;
@@ -124,7 +129,7 @@ Fitness::Fitness(Parameters& para)
   } else {
     if (para.has_charge) {
       potential.reset(
-        new NEP_Charge(para, N, N_times_max_NN_radial, N_times_max_NN_angular, para.version, deviceCount));
+        new NEP_Charge(para, N, Nc, N_times_max_NN_radial, N_times_max_NN_angular, para.version, deviceCount));
     } else {
       potential.reset(
         new NEP(para, N, N_times_max_NN_radial, N_times_max_NN_angular, para.version, deviceCount));

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -183,14 +183,19 @@ void Fitness::compute(
           para, energy_shift_per_structure_not_used, true, true, m);
         auto rmse_force_array = train_set[batch_id][m].get_rmse_force(para, true, m);
         auto rmse_virial_array = train_set[batch_id][m].get_rmse_virial(para, true, m);
+        auto rmse_charge_array = train_set[batch_id][m].get_rmse_charge(para, m);
 
         for (int t = 0; t <= para.num_types; ++t) {
-          fitness[deviceCount * n + m + (6 * t + 3) * para.population_size] =
+          fitness[deviceCount * n + m + (7 * t + 3) * para.population_size] =
             para.lambda_e * rmse_energy_array[t];
-          fitness[deviceCount * n + m + (6 * t + 4) * para.population_size] =
+          fitness[deviceCount * n + m + (7 * t + 4) * para.population_size] =
             para.lambda_f * rmse_force_array[t];
-          fitness[deviceCount * n + m + (6 * t + 5) * para.population_size] =
+          fitness[deviceCount * n + m + (7 * t + 5) * para.population_size] =
             para.lambda_v * rmse_virial_array[t];
+          if (para.has_charge) {
+            fitness[deviceCount * n + m + (7 * t + 6) * para.population_size] =
+              para.lambda_q * rmse_charge_array[t];
+          }
         }
       }
     }
@@ -214,23 +219,23 @@ void Fitness::compute(
             auto rmse_virial_array = train_set[batch_id][m].get_rmse_virial(para, true, m);
             for (int t = 0; t <= para.num_types; ++t) {
               // energy
-              float old_value = fitness[deviceCount * n + m + (6 * t + 3) * para.population_size];
+              float old_value = fitness[deviceCount * n + m + (7 * t + 3) * para.population_size];
               float new_value = para.lambda_e * rmse_energy_array[t];
               new_value = old_value * old_value * count_batch + new_value * new_value;
               new_value = sqrt(new_value / (count_batch + 1));
-              fitness[deviceCount * n + m + (6 * t + 3) * para.population_size] = new_value;
+              fitness[deviceCount * n + m + (7 * t + 3) * para.population_size] = new_value;
               // force
-              old_value = fitness[deviceCount * n + m + (6 * t + 4) * para.population_size];
+              old_value = fitness[deviceCount * n + m + (7 * t + 4) * para.population_size];
               new_value = para.lambda_f * rmse_force_array[t];
               new_value = old_value * old_value * count_batch + new_value * new_value;
               new_value = sqrt(new_value / (count_batch + 1));
-              fitness[deviceCount * n + m + (6 * t + 4) * para.population_size] = new_value;
+              fitness[deviceCount * n + m + (7 * t + 4) * para.population_size] = new_value;
               // virial
-              old_value = fitness[deviceCount * n + m + (6 * t + 5) * para.population_size];
+              old_value = fitness[deviceCount * n + m + (7 * t + 5) * para.population_size];
               new_value = para.lambda_v * rmse_virial_array[t];
               new_value = old_value * old_value * count_batch + new_value * new_value;
               new_value = sqrt(new_value / (count_batch + 1));
-              fitness[deviceCount * n + m + (6 * t + 5) * para.population_size] = new_value;
+              fitness[deviceCount * n + m + (7 * t + 5) * para.population_size] = new_value;
             }
           }
         }

--- a/src/main_nep/fitness.cuh
+++ b/src/main_nep/fitness.cuh
@@ -56,6 +56,7 @@ protected:
     Dataset& dataset);
   void update_energy_force_virial(
     FILE* fid_energy, FILE* fid_force, FILE* fid_virial, FILE* fid_stress, Dataset& dataset);
+  void update_charge(FILE* fid_charge, Dataset& dataset);
   void update_dipole(FILE* fid_dipole, Dataset& dataset);
   void update_polarizability(FILE* fid_polarizability, Dataset& dataset);
   void write_nep_txt(FILE* fid_nep, Parameters& para, float* elite);

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -841,9 +841,8 @@ static __global__ void find_force_charge_reciprocal_space(
         temp_force_sum[1] += ky * imag_term;
         temp_force_sum[2] += kz * imag_term;
       }
-      const float charge = g_charge[n];
-      g_pe[n] += K_C * (temp_energy_sum / (N2 - N1) - charge * charge * 0.5f * 0.564189583547756f);
-      const float charge_factor = K_C * 2.0f * charge;
+      g_pe[n] += K_C_SP * temp_energy_sum / (N2 - N1);
+      const float charge_factor = K_C_SP * 2.0f * g_charge[n];
       g_fx[n] += charge_factor * temp_force_sum[0];
       g_fy[n] += charge_factor * temp_force_sum[1];
       g_fz[n] += charge_factor * temp_force_sum[2];

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -952,9 +952,10 @@ static __global__ void find_k_and_G(
       b3[d] *= two_pi_over_det;
     }
 
-    int n1_max = alpha * two_pi / sqrt(b1[0] * b1[0] + b1[1] * b1[1] + b1[2] * b1[2]);
-    int n2_max = alpha * two_pi / sqrt(b2[0] * b2[0] + b2[1] * b2[1] + b2[2] * b2[2]);
-    int n3_max = alpha * two_pi / sqrt(b3[0] * b3[0] + b3[1] * b3[1] + b3[2] * b3[2]);
+    // The factor of 2 is a safe buffer
+    int n1_max = 2.0f * alpha * two_pi / sqrt(b1[0] * b1[0] + b1[1] * b1[1] + b1[2] * b1[2]);
+    int n2_max = 2.0f * alpha * two_pi / sqrt(b2[0] * b2[0] + b2[1] * b2[1] + b2[2] * b2[2]);
+    int n3_max = 2.0f * alpha * two_pi / sqrt(b3[0] * b3[0] + b3[1] * b3[1] + b3[2] * b3[2]);
     float ksq_max = two_pi * two_pi * alpha * alpha;
 
     int nk = 0;

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -294,6 +294,10 @@ NEP_Charge::NEP_Charge(
     }
   }
 
+  charge_para.alpha = float(PI) / paramb.rc_radial; // a good value
+  charge_para.two_alpha_over_sqrt_pi = 2.0f * charge_para.alpha / sqrt(float(PI));
+  charge_para.alpha_factor = 0.25f / (charge_para.alpha * charge_para.alpha);
+
   for (int device_id = 0; device_id < deviceCount; device_id++) {
     gpuSetDevice(device_id);
     annmb[device_id].dim = para.dim;

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -1051,6 +1051,19 @@ void NEP_Charge::find_force(
       nep_data[device_id].charge_derivative.data());
     GPU_CHECK_KERNEL
 
+    if (para.prediction == 1 && true) {
+      FILE* fid_charge = my_fopen("charge.out", "a");
+      std::vector<float> charge_cpu(nep_data[device_id].charge.size());
+      nep_data[device_id].charge.copy_to_host(charge_cpu.data());
+      for (int nc = 0; nc < dataset[device_id].Nc; ++nc) {
+        for (int na = 0; na < dataset[device_id].Na_cpu[nc]; ++na) {
+          int n = dataset[device_id].Na_sum_cpu[nc] + na;
+          fprintf(fid_charge, "%g\n", charge_cpu[n]);
+        }
+      }
+      fclose(fid_charge);
+    }
+
     find_force_radial<<<grid_size, block_size>>>(
       dataset[device_id].N,
       nep_data[device_id].NN_radial.data(),

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -323,14 +323,14 @@ void NEP_Charge::update_potential(Parameters& para, float* parameters, ANN& ann)
   float* pointer = parameters;
   for (int t = 0; t < paramb.num_types; ++t) {
     if (t > 0 && paramb.version == 3) { // Use the same set of NN parameters for NEP3
-      pointer -= (ann.dim + 2) * ann.num_neurons1;
+      pointer -= (ann.dim + 3) * ann.num_neurons1;
     }
     ann.w0[t] = pointer;
     pointer += ann.num_neurons1 * ann.dim;
     ann.b0[t] = pointer;
     pointer += ann.num_neurons1;
     ann.w1[t] = pointer;
-    pointer += ann.num_neurons1;
+    pointer += ann.num_neurons1 * 2; // potential and charge
   }
   ann.b1 = pointer;
   pointer += 1;

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -890,7 +890,8 @@ static __global__ void gpu_find_k_and_g_factor(
       g_ky[nc_nk] = ky;
       g_kz[nc_nk] = kz;
       const float ksq = kx * kx + ky * ky + kz * kz;
-      g_g_factor[nc * num_kpoints + nk] = abs(two_pi_over_det) / ksq * exp(-ksq * alpha_factor);
+      const float symmetry_factor = (k1 > 0) ? 2.0f : 1.0f;
+      g_g_factor[nc * num_kpoints + nk] = symmetry_factor * abs(two_pi_over_det) / ksq * exp(-ksq * alpha_factor);
     }
   }
 }
@@ -1083,8 +1084,7 @@ void NEP_Charge::find_force(
       nep_data[device_id].g_factor.data());
     GPU_CHECK_KERNEL
 
-    // ewald summation for long-range force
-    gpu_sum_q_factor<<<charge_para.num_kpoints, 1024>>>(
+    gpu_sum_q_factor<<<dataset[device_id].Nc * charge_para.num_kpoints, 1024>>>(
       dataset[device_id].N,
       nep_data[device_id].charge.data(),
       dataset[device_id].r.data(),

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -1,0 +1,967 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*----------------------------------------------------------------------------80
+The neuroevolution potential (NEP)
+Ref: Zheyong Fan et al., Neuroevolution machine learning potentials:
+Combining high accuracy and low cost in atomistic simulations and application to
+heat transport, Phys. Rev. B. 104, 104309 (2021).
+------------------------------------------------------------------------------*/
+
+#include "dataset.cuh"
+#include "mic.cuh"
+#include "nep_charge.cuh"
+#include "parameters.cuh"
+#include "utilities/common.cuh"
+#include "utilities/error.cuh"
+#include "utilities/gpu_macro.cuh"
+#include "utilities/gpu_vector.cuh"
+#include "utilities/nep_utilities.cuh"
+#include <cstring>
+
+static __global__ void gpu_find_neighbor_list(
+  const NEP_Charge::ParaMB paramb,
+  const int N,
+  const int* Na,
+  const int* Na_sum,
+  const bool use_typewise_cutoff,
+  const int* g_type,
+  const float g_rc_radial,
+  const float g_rc_angular,
+  const float* __restrict__ g_box,
+  const float* __restrict__ g_box_original,
+  const int* __restrict__ g_num_cell,
+  const float* x,
+  const float* y,
+  const float* z,
+  int* NN_radial,
+  int* NL_radial,
+  int* NN_angular,
+  int* NL_angular,
+  float* x12_radial,
+  float* y12_radial,
+  float* z12_radial,
+  float* x12_angular,
+  float* y12_angular,
+  float* z12_angular)
+{
+  int N1 = Na_sum[blockIdx.x];
+  int N2 = N1 + Na[blockIdx.x];
+  for (int n1 = N1 + threadIdx.x; n1 < N2; n1 += blockDim.x) {
+    const float* __restrict__ box = g_box + 18 * blockIdx.x;
+    const float* __restrict__ box_original = g_box_original + 9 * blockIdx.x;
+    const int* __restrict__ num_cell = g_num_cell + 3 * blockIdx.x;
+    float x1 = x[n1];
+    float y1 = y[n1];
+    float z1 = z[n1];
+    int t1 = g_type[n1];
+    int count_radial = 0;
+    int count_angular = 0;
+    for (int n2 = N1; n2 < N2; ++n2) {
+      for (int ia = 0; ia < num_cell[0]; ++ia) {
+        for (int ib = 0; ib < num_cell[1]; ++ib) {
+          for (int ic = 0; ic < num_cell[2]; ++ic) {
+            if (ia == 0 && ib == 0 && ic == 0 && n1 == n2) {
+              continue; // exclude self
+            }
+            float delta_x = box_original[0] * ia + box_original[1] * ib + box_original[2] * ic;
+            float delta_y = box_original[3] * ia + box_original[4] * ib + box_original[5] * ic;
+            float delta_z = box_original[6] * ia + box_original[7] * ib + box_original[8] * ic;
+            float x12 = x[n2] + delta_x - x1;
+            float y12 = y[n2] + delta_y - y1;
+            float z12 = z[n2] + delta_z - z1;
+            dev_apply_mic(box, x12, y12, z12);
+            float distance_square = x12 * x12 + y12 * y12 + z12 * z12;
+            int t2 = g_type[n2];
+            float rc_radial = g_rc_radial;
+            float rc_angular = g_rc_angular;
+            if (use_typewise_cutoff) {
+              int z1 = paramb.atomic_numbers[t1];
+              int z2 = paramb.atomic_numbers[t2];
+              rc_radial = min(
+                (COVALENT_RADIUS[z1] + COVALENT_RADIUS[z2]) * paramb.typewise_cutoff_radial_factor,
+                rc_radial);
+              rc_angular = min(
+                (COVALENT_RADIUS[z1] + COVALENT_RADIUS[z2]) * paramb.typewise_cutoff_angular_factor,
+                rc_angular);
+            }
+            if (distance_square < rc_radial * rc_radial) {
+              NL_radial[count_radial * N + n1] = n2;
+              x12_radial[count_radial * N + n1] = x12;
+              y12_radial[count_radial * N + n1] = y12;
+              z12_radial[count_radial * N + n1] = z12;
+              count_radial++;
+            }
+            if (distance_square < rc_angular * rc_angular) {
+              NL_angular[count_angular * N + n1] = n2;
+              x12_angular[count_angular * N + n1] = x12;
+              y12_angular[count_angular * N + n1] = y12;
+              z12_angular[count_angular * N + n1] = z12;
+              count_angular++;
+            }
+          }
+        }
+      }
+    }
+    NN_radial[n1] = count_radial;
+    NN_angular[n1] = count_angular;
+  }
+}
+
+static __global__ void find_descriptors_radial(
+  const int N,
+  const int* g_NN,
+  const int* g_NL,
+  const NEP_Charge::ParaMB paramb,
+  const NEP_Charge::ANN annmb,
+  const int* __restrict__ g_type,
+  const float* __restrict__ g_x12,
+  const float* __restrict__ g_y12,
+  const float* __restrict__ g_z12,
+  float* g_descriptors)
+{
+  int n1 = threadIdx.x + blockIdx.x * blockDim.x;
+  if (n1 < N) {
+    int t1 = g_type[n1];
+    int neighbor_number = g_NN[n1];
+    float q[MAX_NUM_N] = {0.0f};
+    for (int i1 = 0; i1 < neighbor_number; ++i1) {
+      int index = n1 + N * i1;
+      int n2 = g_NL[index];
+      float x12 = g_x12[index];
+      float y12 = g_y12[index];
+      float z12 = g_z12[index];
+      float d12 = sqrt(x12 * x12 + y12 * y12 + z12 * z12);
+      float fc12;
+      int t2 = g_type[n2];
+      float rc = paramb.rc_radial;
+      if (paramb.use_typewise_cutoff) {
+        rc = min(
+          (COVALENT_RADIUS[paramb.atomic_numbers[t1]] +
+           COVALENT_RADIUS[paramb.atomic_numbers[t2]]) *
+            paramb.typewise_cutoff_radial_factor,
+          rc);
+      }
+      float rcinv = 1.0f / rc;
+      find_fc(rc, rcinv, d12, fc12);
+
+      float fn12[MAX_NUM_N];
+      find_fn(paramb.basis_size_radial, rcinv, d12, fc12, fn12);
+      for (int n = 0; n <= paramb.n_max_radial; ++n) {
+        float gn12 = 0.0f;
+        for (int k = 0; k <= paramb.basis_size_radial; ++k) {
+          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
+          c_index += t1 * paramb.num_types + t2;
+          gn12 += fn12[k] * annmb.c[c_index];
+        }
+        q[n] += gn12;
+      }
+    }
+    for (int n = 0; n <= paramb.n_max_radial; ++n) {
+      g_descriptors[n1 + n * N] = q[n];
+    }
+  }
+}
+
+static __global__ void find_descriptors_angular(
+  const int N,
+  const int* g_NN,
+  const int* g_NL,
+  const NEP_Charge::ParaMB paramb,
+  const NEP_Charge::ANN annmb,
+  const int* __restrict__ g_type,
+  const float* __restrict__ g_x12,
+  const float* __restrict__ g_y12,
+  const float* __restrict__ g_z12,
+  float* g_descriptors,
+  float* g_sum_fxyz)
+{
+  int n1 = threadIdx.x + blockIdx.x * blockDim.x;
+  if (n1 < N) {
+    int t1 = g_type[n1];
+    int neighbor_number = g_NN[n1];
+    float q[MAX_DIM_ANGULAR] = {0.0f};
+
+    for (int n = 0; n <= paramb.n_max_angular; ++n) {
+      float s[NUM_OF_ABC] = {0.0f};
+      for (int i1 = 0; i1 < neighbor_number; ++i1) {
+        int index = n1 + N * i1;
+        int n2 = g_NL[n1 + N * i1];
+        float x12 = g_x12[index];
+        float y12 = g_y12[index];
+        float z12 = g_z12[index];
+        float d12 = sqrt(x12 * x12 + y12 * y12 + z12 * z12);
+        float fc12;
+        int t2 = g_type[n2];
+        float rc = paramb.rc_angular;
+        if (paramb.use_typewise_cutoff) {
+          rc = min(
+            (COVALENT_RADIUS[paramb.atomic_numbers[t1]] +
+             COVALENT_RADIUS[paramb.atomic_numbers[t2]]) *
+              paramb.typewise_cutoff_angular_factor,
+            rc);
+        }
+        float rcinv = 1.0f / rc;
+        find_fc(rc, rcinv, d12, fc12);
+        float fn12[MAX_NUM_N];
+        find_fn(paramb.basis_size_angular, rcinv, d12, fc12, fn12);
+        float gn12 = 0.0f;
+        for (int k = 0; k <= paramb.basis_size_angular; ++k) {
+          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
+          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          gn12 += fn12[k] * annmb.c[c_index];
+        }
+        accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
+      }
+      find_q(paramb.L_max, paramb.num_L, paramb.n_max_angular + 1, n, s, q);
+      for (int abc = 0; abc < NUM_OF_ABC; ++abc) {
+        g_sum_fxyz[(n * NUM_OF_ABC + abc) * N + n1] = s[abc];
+      }
+    }
+
+    for (int n = 0; n <= paramb.n_max_angular; ++n) {
+      for (int l = 0; l < paramb.num_L; ++l) {
+        int ln = l * (paramb.n_max_angular + 1) + n;
+        g_descriptors[n1 + ((paramb.n_max_radial + 1) + ln) * N] = q[ln];
+      }
+    }
+  }
+}
+
+NEP_Charge::NEP_Charge(
+  Parameters& para,
+  int N,
+  int N_times_max_NN_radial,
+  int N_times_max_NN_angular,
+  int version,
+  int deviceCount)
+{
+  paramb.version = version;
+  paramb.rc_radial = para.rc_radial;
+  paramb.rcinv_radial = 1.0f / paramb.rc_radial;
+  paramb.rc_angular = para.rc_angular;
+  paramb.rcinv_angular = 1.0f / paramb.rc_angular;
+  paramb.use_typewise_cutoff = para.use_typewise_cutoff;
+  paramb.use_typewise_cutoff_zbl = para.use_typewise_cutoff_zbl;
+  paramb.typewise_cutoff_radial_factor = para.typewise_cutoff_radial_factor;
+  paramb.typewise_cutoff_angular_factor = para.typewise_cutoff_angular_factor;
+  paramb.typewise_cutoff_zbl_factor = para.typewise_cutoff_zbl_factor;
+  paramb.num_types = para.num_types;
+  paramb.n_max_radial = para.n_max_radial;
+  paramb.n_max_angular = para.n_max_angular;
+  paramb.L_max = para.L_max;
+  paramb.num_L = paramb.L_max;
+  if (para.L_max_4body == 2) {
+    paramb.num_L += 1;
+  }
+  if (para.L_max_5body == 1) {
+    paramb.num_L += 1;
+  }
+  paramb.dim_angular = (para.n_max_angular + 1) * paramb.num_L;
+
+  paramb.basis_size_radial = para.basis_size_radial;
+  paramb.basis_size_angular = para.basis_size_angular;
+  paramb.num_types_sq = para.num_types * para.num_types;
+  paramb.num_c_radial =
+    paramb.num_types_sq * (para.n_max_radial + 1) * (para.basis_size_radial + 1);
+
+  zbl.enabled = para.enable_zbl;
+  zbl.flexibled = para.flexible_zbl;
+  zbl.rc_inner = para.zbl_rc_inner;
+  zbl.rc_outer = para.zbl_rc_outer;
+  for (int n = 0; n < para.atomic_numbers.size(); ++n) {
+    zbl.atomic_numbers[n] = para.atomic_numbers[n];        // starting from 1
+    paramb.atomic_numbers[n] = para.atomic_numbers[n] - 1; // starting from 0
+  }
+  if (zbl.flexibled) {
+    zbl.num_types = para.num_types;
+    int num_type_zbl = (para.num_types * (para.num_types + 1)) / 2;
+    for (int n = 0; n < num_type_zbl * 10; ++n) {
+      zbl.para[n] = para.zbl_para[n];
+    }
+  }
+
+  for (int device_id = 0; device_id < deviceCount; device_id++) {
+    gpuSetDevice(device_id);
+    annmb[device_id].dim = para.dim;
+    annmb[device_id].num_neurons1 = para.num_neurons1;
+    annmb[device_id].num_para = para.number_of_variables;
+
+    nep_data[device_id].NN_radial.resize(N);
+    nep_data[device_id].NN_angular.resize(N);
+    nep_data[device_id].NL_radial.resize(N_times_max_NN_radial);
+    nep_data[device_id].NL_angular.resize(N_times_max_NN_angular);
+    nep_data[device_id].x12_radial.resize(N_times_max_NN_radial);
+    nep_data[device_id].y12_radial.resize(N_times_max_NN_radial);
+    nep_data[device_id].z12_radial.resize(N_times_max_NN_radial);
+    nep_data[device_id].x12_angular.resize(N_times_max_NN_angular);
+    nep_data[device_id].y12_angular.resize(N_times_max_NN_angular);
+    nep_data[device_id].z12_angular.resize(N_times_max_NN_angular);
+    nep_data[device_id].descriptors.resize(N * annmb[device_id].dim);
+    nep_data[device_id].Fp.resize(N * annmb[device_id].dim);
+    nep_data[device_id].sum_fxyz.resize(N * (paramb.n_max_angular + 1) * NUM_OF_ABC);
+    nep_data[device_id].parameters.resize(annmb[device_id].num_para);
+  }
+}
+
+void NEP_Charge::update_potential(Parameters& para, float* parameters, ANN& ann)
+{
+  float* pointer = parameters;
+  for (int t = 0; t < paramb.num_types; ++t) {
+    if (t > 0 && paramb.version == 3) { // Use the same set of NN parameters for NEP3
+      pointer -= (ann.dim + 2) * ann.num_neurons1;
+    }
+    ann.w0[t] = pointer;
+    pointer += ann.num_neurons1 * ann.dim;
+    ann.b0[t] = pointer;
+    pointer += ann.num_neurons1;
+    ann.w1[t] = pointer;
+    pointer += ann.num_neurons1;
+    if (para.version == 5) {
+      pointer += 1; // one extra bias for NEP5 stored in ann.w1[t]
+    }
+  }
+  ann.b1 = pointer;
+  pointer += 1;
+  ann.c = pointer;
+}
+
+static void __global__ find_max_min(const int N, const float* g_q, float* g_q_scaler)
+{
+  const int tid = threadIdx.x;
+  const int bid = blockIdx.x;
+  __shared__ float s_max[1024];
+  __shared__ float s_min[1024];
+  s_max[tid] = -1000000.0f; // a small number
+  s_min[tid] = +1000000.0f; // a large number
+  const int stride = 1024;
+  const int number_of_rounds = (N - 1) / stride + 1;
+  for (int round = 0; round < number_of_rounds; ++round) {
+    const int n = round * stride + tid;
+    if (n < N) {
+      const int m = n + N * bid;
+      float q = g_q[m];
+      if (q > s_max[tid]) {
+        s_max[tid] = q;
+      }
+      if (q < s_min[tid]) {
+        s_min[tid] = q;
+      }
+    }
+  }
+  __syncthreads();
+  for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+    if (tid < offset) {
+      if (s_max[tid] < s_max[tid + offset]) {
+        s_max[tid] = s_max[tid + offset];
+      }
+      if (s_min[tid] > s_min[tid + offset]) {
+        s_min[tid] = s_min[tid + offset];
+      }
+    }
+    __syncthreads();
+  }
+  if (tid == 0) {
+    g_q_scaler[bid] = min(g_q_scaler[bid], 1.0f / (s_max[0] - s_min[0]));
+  }
+}
+
+static __global__ void apply_ann(
+  const int N,
+  const NEP_Charge::ParaMB paramb,
+  const NEP_Charge::ANN annmb,
+  const int* __restrict__ g_type,
+  const float* __restrict__ g_descriptors,
+  const float* __restrict__ g_q_scaler,
+  float* g_pe,
+  float* g_Fp)
+{
+  int n1 = threadIdx.x + blockIdx.x * blockDim.x;
+  int type = g_type[n1];
+  if (n1 < N) {
+    // get descriptors
+    float q[MAX_DIM] = {0.0f};
+    for (int d = 0; d < annmb.dim; ++d) {
+      q[d] = g_descriptors[n1 + d * N] * g_q_scaler[d];
+    }
+    // get energy and energy gradient
+    float F = 0.0f, Fp[MAX_DIM] = {0.0f};
+
+    if (paramb.version == 5) {
+      apply_ann_one_layer_nep5(
+        annmb.dim,
+        annmb.num_neurons1,
+        annmb.w0[type],
+        annmb.b0[type],
+        annmb.w1[type],
+        annmb.b1,
+        q,
+        F,
+        Fp);
+    } else {
+      apply_ann_one_layer(
+        annmb.dim,
+        annmb.num_neurons1,
+        annmb.w0[type],
+        annmb.b0[type],
+        annmb.w1[type],
+        annmb.b1,
+        q,
+        F,
+        Fp);
+    }
+    g_pe[n1] = F;
+
+    for (int d = 0; d < annmb.dim; ++d) {
+      g_Fp[n1 + d * N] = Fp[d] * g_q_scaler[d];
+    }
+  }
+}
+
+static __global__ void apply_ann_temperature(
+  const int N,
+  const NEP_Charge::ParaMB paramb,
+  const NEP_Charge::ANN annmb,
+  const int* __restrict__ g_type,
+  const float* __restrict__ g_descriptors,
+  float* __restrict__ g_q_scaler,
+  const float* __restrict__ g_temperature,
+  float* g_pe,
+  float* g_Fp)
+{
+  int n1 = threadIdx.x + blockIdx.x * blockDim.x;
+  int type = g_type[n1];
+  float temperature = g_temperature[n1];
+  if (n1 < N) {
+    // get descriptors
+    float q[MAX_DIM] = {0.0f};
+    for (int d = 0; d < annmb.dim - 1; ++d) {
+      q[d] = g_descriptors[n1 + d * N] * g_q_scaler[d];
+    }
+    g_q_scaler[annmb.dim - 1] = 0.001; // temperature dimension scaler
+    q[annmb.dim - 1] = temperature * g_q_scaler[annmb.dim - 1];
+    // get energy and energy gradient
+    float F = 0.0f, Fp[MAX_DIM] = {0.0f};
+    apply_ann_one_layer(
+      annmb.dim,
+      annmb.num_neurons1,
+      annmb.w0[type],
+      annmb.b0[type],
+      annmb.w1[type],
+      annmb.b1,
+      q,
+      F,
+      Fp);
+    g_pe[n1] = F;
+
+    for (int d = 0; d < annmb.dim; ++d) {
+      g_Fp[n1 + d * N] = Fp[d] * g_q_scaler[d];
+    }
+  }
+}
+
+static __global__ void zero_force(
+  const int N, float* g_fx, float* g_fy, float* g_fz, float* g_vxx, float* g_vyy, float* g_vzz)
+{
+  int n1 = threadIdx.x + blockIdx.x * blockDim.x;
+  if (n1 < N) {
+    g_fx[n1] = 0.0f;
+    g_fy[n1] = 0.0f;
+    g_fz[n1] = 0.0f;
+    g_vxx[n1] = 0.0f;
+    g_vyy[n1] = 0.0f;
+    g_vzz[n1] = 0.0f;
+  }
+}
+
+static __global__ void find_force_radial(
+  const int N,
+  const int* g_NN,
+  const int* g_NL,
+  const NEP_Charge::ParaMB paramb,
+  const NEP_Charge::ANN annmb,
+  const int* __restrict__ g_type,
+  const float* __restrict__ g_x12,
+  const float* __restrict__ g_y12,
+  const float* __restrict__ g_z12,
+  const float* __restrict__ g_Fp,
+  float* g_fx,
+  float* g_fy,
+  float* g_fz,
+  float* g_virial)
+{
+  int n1 = threadIdx.x + blockIdx.x * blockDim.x;
+  if (n1 < N) {
+    int neighbor_number = g_NN[n1];
+    float s_virial_xx = 0.0f;
+    float s_virial_yy = 0.0f;
+    float s_virial_zz = 0.0f;
+    float s_virial_xy = 0.0f;
+    float s_virial_yz = 0.0f;
+    float s_virial_zx = 0.0f;
+    int t1 = g_type[n1];
+    for (int i1 = 0; i1 < neighbor_number; ++i1) {
+      int index = i1 * N + n1;
+      int n2 = g_NL[index];
+      int t2 = g_type[n2];
+      float r12[3] = {g_x12[index], g_y12[index], g_z12[index]};
+      float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
+      float d12inv = 1.0f / d12;
+      float fc12, fcp12;
+      float rc = paramb.rc_radial;
+      if (paramb.use_typewise_cutoff) {
+        rc = min(
+          (COVALENT_RADIUS[paramb.atomic_numbers[t1]] +
+           COVALENT_RADIUS[paramb.atomic_numbers[t2]]) *
+            paramb.typewise_cutoff_radial_factor,
+          rc);
+      }
+      float rcinv = 1.0f / rc;
+      find_fc_and_fcp(rc, rcinv, d12, fc12, fcp12);
+      float fn12[MAX_NUM_N];
+      float fnp12[MAX_NUM_N];
+      float f12[3] = {0.0f};
+
+      find_fn_and_fnp(paramb.basis_size_radial, rcinv, d12, fc12, fcp12, fn12, fnp12);
+      for (int n = 0; n <= paramb.n_max_radial; ++n) {
+        float gnp12 = 0.0f;
+        for (int k = 0; k <= paramb.basis_size_radial; ++k) {
+          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
+          c_index += t1 * paramb.num_types + t2;
+          gnp12 += fnp12[k] * annmb.c[c_index];
+        }
+        float tmp12 = g_Fp[n1 + n * N] * gnp12 * d12inv;
+        for (int d = 0; d < 3; ++d) {
+          f12[d] += tmp12 * r12[d];
+        }
+      }
+
+      atomicAdd(&g_fx[n1], f12[0]);
+      atomicAdd(&g_fy[n1], f12[1]);
+      atomicAdd(&g_fz[n1], f12[2]);
+      atomicAdd(&g_fx[n2], -f12[0]);
+      atomicAdd(&g_fy[n2], -f12[1]);
+      atomicAdd(&g_fz[n2], -f12[2]);
+
+      s_virial_xx -= r12[0] * f12[0];
+      s_virial_yy -= r12[1] * f12[1];
+      s_virial_zz -= r12[2] * f12[2];
+      s_virial_xy -= r12[0] * f12[1];
+      s_virial_yz -= r12[1] * f12[2];
+      s_virial_zx -= r12[2] * f12[0];
+    }
+    g_virial[n1] += s_virial_xx;
+    g_virial[n1 + N] += s_virial_yy;
+    g_virial[n1 + N * 2] += s_virial_zz;
+    g_virial[n1 + N * 3] = s_virial_xy;
+    g_virial[n1 + N * 4] = s_virial_yz;
+    g_virial[n1 + N * 5] = s_virial_zx;
+  }
+}
+
+static __global__ void find_force_angular(
+  const int N,
+  const int* g_NN,
+  const int* g_NL,
+  const NEP_Charge::ParaMB paramb,
+  const NEP_Charge::ANN annmb,
+  const int* __restrict__ g_type,
+  const float* __restrict__ g_x12,
+  const float* __restrict__ g_y12,
+  const float* __restrict__ g_z12,
+  const float* __restrict__ g_Fp,
+  const float* __restrict__ g_sum_fxyz,
+  float* g_fx,
+  float* g_fy,
+  float* g_fz,
+  float* g_virial)
+{
+  int n1 = threadIdx.x + blockIdx.x * blockDim.x;
+  if (n1 < N) {
+
+    float s_virial_xx = 0.0f;
+    float s_virial_yy = 0.0f;
+    float s_virial_zz = 0.0f;
+    float s_virial_xy = 0.0f;
+    float s_virial_yz = 0.0f;
+    float s_virial_zx = 0.0f;
+
+    float Fp[MAX_DIM_ANGULAR] = {0.0f};
+    float sum_fxyz[NUM_OF_ABC * MAX_NUM_N];
+    for (int d = 0; d < paramb.dim_angular; ++d) {
+      Fp[d] = g_Fp[(paramb.n_max_radial + 1 + d) * N + n1];
+    }
+    for (int d = 0; d < (paramb.n_max_angular + 1) * NUM_OF_ABC; ++d) {
+      sum_fxyz[d] = g_sum_fxyz[d * N + n1];
+    }
+    int neighbor_number = g_NN[n1];
+    int t1 = g_type[n1];
+    for (int i1 = 0; i1 < neighbor_number; ++i1) {
+      int index = i1 * N + n1;
+      int n2 = g_NL[index];
+      float r12[3] = {g_x12[index], g_y12[index], g_z12[index]};
+      float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
+      float fc12, fcp12;
+      int t2 = g_type[n2];
+      float rc = paramb.rc_angular;
+      if (paramb.use_typewise_cutoff) {
+        rc = min(
+          (COVALENT_RADIUS[paramb.atomic_numbers[t1]] +
+           COVALENT_RADIUS[paramb.atomic_numbers[t2]]) *
+            paramb.typewise_cutoff_angular_factor,
+          rc);
+      }
+      float rcinv = 1.0f / rc;
+      find_fc_and_fcp(rc, rcinv, d12, fc12, fcp12);
+      float f12[3] = {0.0f};
+
+      float fn12[MAX_NUM_N];
+      float fnp12[MAX_NUM_N];
+      find_fn_and_fnp(paramb.basis_size_angular, rcinv, d12, fc12, fcp12, fn12, fnp12);
+      for (int n = 0; n <= paramb.n_max_angular; ++n) {
+        float gn12 = 0.0f;
+        float gnp12 = 0.0f;
+        for (int k = 0; k <= paramb.basis_size_angular; ++k) {
+          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
+          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          gn12 += fn12[k] * annmb.c[c_index];
+          gnp12 += fnp12[k] * annmb.c[c_index];
+        }
+        accumulate_f12(paramb.L_max, paramb.num_L, n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
+      }
+
+      atomicAdd(&g_fx[n1], f12[0]);
+      atomicAdd(&g_fy[n1], f12[1]);
+      atomicAdd(&g_fz[n1], f12[2]);
+      atomicAdd(&g_fx[n2], -f12[0]);
+      atomicAdd(&g_fy[n2], -f12[1]);
+      atomicAdd(&g_fz[n2], -f12[2]);
+
+      s_virial_xx -= r12[0] * f12[0];
+      s_virial_yy -= r12[1] * f12[1];
+      s_virial_zz -= r12[2] * f12[2];
+      s_virial_xy -= r12[0] * f12[1];
+      s_virial_yz -= r12[1] * f12[2];
+      s_virial_zx -= r12[2] * f12[0];
+    }
+    g_virial[n1] += s_virial_xx;
+    g_virial[n1 + N] += s_virial_yy;
+    g_virial[n1 + N * 2] += s_virial_zz;
+    g_virial[n1 + N * 3] += s_virial_xy;
+    g_virial[n1 + N * 4] += s_virial_yz;
+    g_virial[n1 + N * 5] += s_virial_zx;
+  }
+}
+
+static __global__ void find_force_ZBL(
+  const int N,
+  const NEP_Charge::ParaMB paramb,
+  const NEP_Charge::ZBL zbl,
+  const int* g_NN,
+  const int* g_NL,
+  const int* __restrict__ g_type,
+  const float* __restrict__ g_x12,
+  const float* __restrict__ g_y12,
+  const float* __restrict__ g_z12,
+  float* g_fx,
+  float* g_fy,
+  float* g_fz,
+  float* g_virial,
+  float* g_pe)
+{
+  int n1 = threadIdx.x + blockIdx.x * blockDim.x;
+  if (n1 < N) {
+    float s_pe = 0.0f;
+    float s_virial_xx = 0.0f;
+    float s_virial_yy = 0.0f;
+    float s_virial_zz = 0.0f;
+    float s_virial_xy = 0.0f;
+    float s_virial_yz = 0.0f;
+    float s_virial_zx = 0.0f;
+    int type1 = g_type[n1];
+    int zi = zbl.atomic_numbers[type1]; // starting from 1
+    float pow_zi = pow(float(zi), 0.23f);
+    int neighbor_number = g_NN[n1];
+    for (int i1 = 0; i1 < neighbor_number; ++i1) {
+      int index = i1 * N + n1;
+      int n2 = g_NL[index];
+      float r12[3] = {g_x12[index], g_y12[index], g_z12[index]};
+      float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
+      float d12inv = 1.0f / d12;
+      float f, fp;
+      int type2 = g_type[n2];
+      int zj = zbl.atomic_numbers[type2]; // starting from 1
+      float a_inv = (pow_zi + pow(float(zj), 0.23f)) * 2.134563f;
+      float zizj = K_C_SP * zi * zj;
+      if (zbl.flexibled) {
+        int t1, t2;
+        if (type1 < type2) {
+          t1 = type1;
+          t2 = type2;
+        } else {
+          t1 = type2;
+          t2 = type1;
+        }
+        int zbl_index = t1 * zbl.num_types - (t1 * (t1 - 1)) / 2 + (t2 - t1);
+        float ZBL_para[10];
+        for (int i = 0; i < 10; ++i) {
+          ZBL_para[i] = zbl.para[10 * zbl_index + i];
+        }
+        find_f_and_fp_zbl(ZBL_para, zizj, a_inv, d12, d12inv, f, fp);
+      } else {
+        float rc_inner = zbl.rc_inner;
+        float rc_outer = zbl.rc_outer;
+        if (paramb.use_typewise_cutoff_zbl) {
+          // zi and zj start from 1, so need to minus 1 here
+          rc_outer = min(
+            (COVALENT_RADIUS[zi - 1] + COVALENT_RADIUS[zj - 1]) * paramb.typewise_cutoff_zbl_factor,
+            rc_outer);
+          rc_inner = rc_outer * 0.5f;
+        }
+        find_f_and_fp_zbl(zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
+      }
+      float f2 = fp * d12inv * 0.5f;
+      float f12[3] = {r12[0] * f2, r12[1] * f2, r12[2] * f2};
+
+      atomicAdd(&g_fx[n1], f12[0]);
+      atomicAdd(&g_fy[n1], f12[1]);
+      atomicAdd(&g_fz[n1], f12[2]);
+      atomicAdd(&g_fx[n2], -f12[0]);
+      atomicAdd(&g_fy[n2], -f12[1]);
+      atomicAdd(&g_fz[n2], -f12[2]);
+      s_virial_xx -= r12[0] * f12[0];
+      s_virial_yy -= r12[1] * f12[1];
+      s_virial_zz -= r12[2] * f12[2];
+      s_virial_xy -= r12[0] * f12[1];
+      s_virial_yz -= r12[1] * f12[2];
+      s_virial_zx -= r12[2] * f12[0];
+      s_pe += f * 0.5f;
+    }
+    g_virial[n1 + N * 0] += s_virial_xx;
+    g_virial[n1 + N * 1] += s_virial_yy;
+    g_virial[n1 + N * 2] += s_virial_zz;
+    g_virial[n1 + N * 3] += s_virial_xy;
+    g_virial[n1 + N * 4] += s_virial_yz;
+    g_virial[n1 + N * 5] += s_virial_zx;
+    g_pe[n1] += s_pe;
+  }
+}
+
+void NEP_Charge::find_force(
+  Parameters& para,
+  const float* parameters,
+  std::vector<Dataset>& dataset,
+  bool calculate_q_scaler,
+  bool calculate_neighbor,
+  int device_in_this_iter)
+{
+
+  for (int device_id = 0; device_id < device_in_this_iter; ++device_id) {
+    CHECK(gpuSetDevice(device_id));
+    nep_data[device_id].parameters.copy_from_host(
+      parameters + device_id * para.number_of_variables);
+    update_potential(para, nep_data[device_id].parameters.data(), annmb[device_id]);
+  }
+
+  for (int device_id = 0; device_id < device_in_this_iter; ++device_id) {
+    CHECK(gpuSetDevice(device_id));
+    const int block_size = 32;
+    const int grid_size = (dataset[device_id].N - 1) / block_size + 1;
+
+    if (calculate_neighbor) {
+      gpu_find_neighbor_list<<<dataset[device_id].Nc, 256>>>(
+        paramb,
+        dataset[device_id].N,
+        dataset[device_id].Na.data(),
+        dataset[device_id].Na_sum.data(),
+        para.use_typewise_cutoff,
+        dataset[device_id].type.data(),
+        para.rc_radial,
+        para.rc_angular,
+        dataset[device_id].box.data(),
+        dataset[device_id].box_original.data(),
+        dataset[device_id].num_cell.data(),
+        dataset[device_id].r.data(),
+        dataset[device_id].r.data() + dataset[device_id].N,
+        dataset[device_id].r.data() + dataset[device_id].N * 2,
+        nep_data[device_id].NN_radial.data(),
+        nep_data[device_id].NL_radial.data(),
+        nep_data[device_id].NN_angular.data(),
+        nep_data[device_id].NL_angular.data(),
+        nep_data[device_id].x12_radial.data(),
+        nep_data[device_id].y12_radial.data(),
+        nep_data[device_id].z12_radial.data(),
+        nep_data[device_id].x12_angular.data(),
+        nep_data[device_id].y12_angular.data(),
+        nep_data[device_id].z12_angular.data());
+      GPU_CHECK_KERNEL
+    }
+
+    find_descriptors_radial<<<grid_size, block_size>>>(
+      dataset[device_id].N,
+      nep_data[device_id].NN_radial.data(),
+      nep_data[device_id].NL_radial.data(),
+      paramb,
+      annmb[device_id],
+      dataset[device_id].type.data(),
+      nep_data[device_id].x12_radial.data(),
+      nep_data[device_id].y12_radial.data(),
+      nep_data[device_id].z12_radial.data(),
+      nep_data[device_id].descriptors.data());
+    GPU_CHECK_KERNEL
+
+    find_descriptors_angular<<<grid_size, block_size>>>(
+      dataset[device_id].N,
+      nep_data[device_id].NN_angular.data(),
+      nep_data[device_id].NL_angular.data(),
+      paramb,
+      annmb[device_id],
+      dataset[device_id].type.data(),
+      nep_data[device_id].x12_angular.data(),
+      nep_data[device_id].y12_angular.data(),
+      nep_data[device_id].z12_angular.data(),
+      nep_data[device_id].descriptors.data(),
+      nep_data[device_id].sum_fxyz.data());
+    GPU_CHECK_KERNEL
+
+    if (para.prediction == 1 && para.output_descriptor >= 1) {
+      FILE* fid_descriptor = my_fopen("descriptor.out", "a");
+      std::vector<float> descriptor_cpu(nep_data[device_id].descriptors.size());
+      nep_data[device_id].descriptors.copy_to_host(descriptor_cpu.data());
+      for (int nc = 0; nc < dataset[device_id].Nc; ++nc) {
+        float q_structure[MAX_DIM] = {0.0f};
+        for (int na = 0; na < dataset[device_id].Na_cpu[nc]; ++na) {
+          int n = dataset[device_id].Na_sum_cpu[nc] + na;
+          for (int d = 0; d < annmb[device_id].dim; ++d) {
+            float q = descriptor_cpu[n + d * dataset[device_id].N] * para.q_scaler_cpu[d];
+            q_structure[d] += q;
+            if (para.output_descriptor == 2) {
+              fprintf(fid_descriptor, "%g ", q);
+            }
+          }
+          if (para.output_descriptor == 2) {
+            fprintf(fid_descriptor, "\n");
+          }
+        }
+        if (para.output_descriptor == 1) {
+          for (int d = 0; d < annmb[device_id].dim; ++d) {
+            fprintf(fid_descriptor, "%g ", q_structure[d] / dataset[device_id].Na_cpu[nc]);
+          }
+        }
+        if (para.output_descriptor == 1) {
+          fprintf(fid_descriptor, "\n");
+        }
+      }
+      fclose(fid_descriptor);
+    }
+
+    if (calculate_q_scaler) {
+      find_max_min<<<annmb[device_id].dim, 1024>>>(
+        dataset[device_id].N,
+        nep_data[device_id].descriptors.data(),
+        para.q_scaler_gpu[device_id].data());
+      GPU_CHECK_KERNEL
+    }
+
+    zero_force<<<grid_size, block_size>>>(
+      dataset[device_id].N,
+      dataset[device_id].force.data(),
+      dataset[device_id].force.data() + dataset[device_id].N,
+      dataset[device_id].force.data() + dataset[device_id].N * 2,
+      dataset[device_id].virial.data(),
+      dataset[device_id].virial.data() + dataset[device_id].N,
+      dataset[device_id].virial.data() + dataset[device_id].N * 2);
+    GPU_CHECK_KERNEL
+
+    if (para.train_mode == 3) {
+      apply_ann_temperature<<<grid_size, block_size>>>(
+        dataset[device_id].N,
+        paramb,
+        annmb[device_id],
+        dataset[device_id].type.data(),
+        nep_data[device_id].descriptors.data(),
+        para.q_scaler_gpu[device_id].data(),
+        dataset[device_id].temperature_ref_gpu.data(),
+        dataset[device_id].energy.data(),
+        nep_data[device_id].Fp.data());
+      GPU_CHECK_KERNEL
+    } else {
+      apply_ann<<<grid_size, block_size>>>(
+        dataset[device_id].N,
+        paramb,
+        annmb[device_id],
+        dataset[device_id].type.data(),
+        nep_data[device_id].descriptors.data(),
+        para.q_scaler_gpu[device_id].data(),
+        dataset[device_id].energy.data(),
+        nep_data[device_id].Fp.data());
+      GPU_CHECK_KERNEL
+    }
+
+    find_force_radial<<<grid_size, block_size>>>(
+      dataset[device_id].N,
+      nep_data[device_id].NN_radial.data(),
+      nep_data[device_id].NL_radial.data(),
+      paramb,
+      annmb[device_id],
+      dataset[device_id].type.data(),
+      nep_data[device_id].x12_radial.data(),
+      nep_data[device_id].y12_radial.data(),
+      nep_data[device_id].z12_radial.data(),
+      nep_data[device_id].Fp.data(),
+      dataset[device_id].force.data(),
+      dataset[device_id].force.data() + dataset[device_id].N,
+      dataset[device_id].force.data() + dataset[device_id].N * 2,
+      dataset[device_id].virial.data());
+    GPU_CHECK_KERNEL
+
+    find_force_angular<<<grid_size, block_size>>>(
+      dataset[device_id].N,
+      nep_data[device_id].NN_angular.data(),
+      nep_data[device_id].NL_angular.data(),
+      paramb,
+      annmb[device_id],
+      dataset[device_id].type.data(),
+      nep_data[device_id].x12_angular.data(),
+      nep_data[device_id].y12_angular.data(),
+      nep_data[device_id].z12_angular.data(),
+      nep_data[device_id].Fp.data(),
+      nep_data[device_id].sum_fxyz.data(),
+      dataset[device_id].force.data(),
+      dataset[device_id].force.data() + dataset[device_id].N,
+      dataset[device_id].force.data() + dataset[device_id].N * 2,
+      dataset[device_id].virial.data());
+    GPU_CHECK_KERNEL
+
+    if (zbl.enabled) {
+      find_force_ZBL<<<grid_size, block_size>>>(
+        dataset[device_id].N,
+        paramb,
+        zbl,
+        nep_data[device_id].NN_angular.data(),
+        nep_data[device_id].NL_angular.data(),
+        dataset[device_id].type.data(),
+        nep_data[device_id].x12_angular.data(),
+        nep_data[device_id].y12_angular.data(),
+        nep_data[device_id].z12_angular.data(),
+        dataset[device_id].force.data(),
+        dataset[device_id].force.data() + dataset[device_id].N,
+        dataset[device_id].force.data() + dataset[device_id].N * 2,
+        dataset[device_id].virial.data(),
+        dataset[device_id].energy.data());
+      GPU_CHECK_KERNEL
+    }
+  }
+}

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -256,12 +256,6 @@ void NEP_Charge::find_k1k2k3()
       }
     }
   }
-  charge_para.k1_gpu.resize(charge_para.k1.size());
-  charge_para.k2_gpu.resize(charge_para.k2.size());
-  charge_para.k3_gpu.resize(charge_para.k3.size());
-  charge_para.k1_gpu.copy_from_host(charge_para.k1.data());
-  charge_para.k2_gpu.copy_from_host(charge_para.k2.data());
-  charge_para.k3_gpu.copy_from_host(charge_para.k3.data());
 }
 
 NEP_Charge::NEP_Charge(
@@ -348,6 +342,12 @@ NEP_Charge::NEP_Charge(
     nep_data[device_id].S_real.resize(Nc * charge_para.num_kpoints);
     nep_data[device_id].S_imag.resize(Nc * charge_para.num_kpoints);
     nep_data[device_id].D_real.resize(N);
+    nep_data[device_id].k1_gpu.resize(charge_para.k1.size());
+    nep_data[device_id].k2_gpu.resize(charge_para.k2.size());
+    nep_data[device_id].k3_gpu.resize(charge_para.k3.size());
+    nep_data[device_id].k1_gpu.copy_from_host(charge_para.k1.data());
+    nep_data[device_id].k2_gpu.copy_from_host(charge_para.k2.data());
+    nep_data[device_id].k3_gpu.copy_from_host(charge_para.k3.data());
   }
 }
 
@@ -1162,9 +1162,9 @@ void NEP_Charge::find_force(
       charge_para.num_kpoints,
       charge_para.alpha_factor,
       dataset[device_id].box_original.data(),
-      charge_para.k1_gpu.data(),
-      charge_para.k2_gpu.data(),
-      charge_para.k3_gpu.data(),
+      nep_data[device_id].k1_gpu.data(),
+      nep_data[device_id].k2_gpu.data(),
+      nep_data[device_id].k3_gpu.data(),
       nep_data[device_id].kx.data(),
       nep_data[device_id].ky.data(),
       nep_data[device_id].kz.data(),

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -310,6 +310,8 @@ NEP_Charge::NEP_Charge(
     nep_data[device_id].y12_angular.resize(N_times_max_NN_angular);
     nep_data[device_id].z12_angular.resize(N_times_max_NN_angular);
     nep_data[device_id].descriptors.resize(N * annmb[device_id].dim);
+    nep_data[device_id].charge.resize(N);
+    nep_data[device_id].charge_derivative.resize(N * annmb[device_id].dim);
     nep_data[device_id].Fp.resize(N * annmb[device_id].dim);
     nep_data[device_id].sum_fxyz.resize(N * (paramb.n_max_angular + 1) * NUM_OF_ABC);
     nep_data[device_id].parameters.resize(annmb[device_id].num_para);

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -916,6 +916,15 @@ static __device__ void cross_product(const float a[3], const float b[3], float c
   c[2] =  a[0] * b [1] - a[1] * b [0];
 }
 
+static __device__ float get_area(const float* a, const float* b)
+{
+  const float s1 = a[1] * b[2] - a[2] * b[1];
+  const float s2 = a[2] * b[0] - a[0] * b[2];
+  const float s3 = a[0] * b[1] - a[1] * b[0];
+  return sqrt(s1 * s1 + s2 * s2 + s3 * s3);
+}
+
+
 static __global__ void find_k_and_G(
   const int Nc,
   const int num_kpoints_max,
@@ -952,10 +961,10 @@ static __global__ void find_k_and_G(
       b3[d] *= two_pi_over_det;
     }
 
-    // The factor of 2 is a safe buffer
-    int n1_max = 2.0f * alpha * two_pi / sqrt(b1[0] * b1[0] + b1[1] * b1[1] + b1[2] * b1[2]);
-    int n2_max = 2.0f * alpha * two_pi / sqrt(b2[0] * b2[0] + b2[1] * b2[1] + b2[2] * b2[2]);
-    int n3_max = 2.0f * alpha * two_pi / sqrt(b3[0] * b3[0] + b3[1] * b3[1] + b3[2] * b3[2]);
+    const float volume_k = two_pi * two_pi * two_pi / abs(det);
+    int n1_max = alpha * two_pi * get_area(b2, b3) / volume_k;
+    int n2_max = alpha * two_pi * get_area(b3, b1) / volume_k;
+    int n3_max = alpha * two_pi * get_area(b1, b2) / volume_k;
     float ksq_max = two_pi * two_pi * alpha * alpha;
 
     int nk = 0;

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -1178,19 +1178,6 @@ void NEP_Charge::find_force(
       dataset[device_id].charge.data());
     GPU_CHECK_KERNEL
 
-    if (para.prediction == 1 && true) {
-      FILE* fid_charge = my_fopen("charge.out", "a");
-      std::vector<float> charge_cpu(dataset[device_id].charge.size());
-      dataset[device_id].charge.copy_to_host(charge_cpu.data());
-      for (int nc = 0; nc < dataset[device_id].Nc; ++nc) {
-        for (int na = 0; na < dataset[device_id].Na_cpu[nc]; ++na) {
-          int n = dataset[device_id].Na_sum_cpu[nc] + na;
-          fprintf(fid_charge, "%g\n", charge_cpu[n]);
-        }
-      }
-      fclose(fid_charge);
-    }
-
     find_k_and_G<<<(dataset[device_id].Nc - 1) / 64 + 1, 64>>>(
       dataset[device_id].Nc,
       charge_para.num_kpoints_max,

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -850,6 +850,7 @@ static __global__ void find_force_charge_reciprocal_space(
   }
 }
 
+/*
 static __global__ void find_force_charge_real_space(
   const int N,
   const float alpha,
@@ -912,6 +913,7 @@ static __global__ void find_force_charge_real_space(
     g_pe[n1] += s_pe;
   }
 }
+*/
 
 static __device__ void cross_product(const float a[3], const float b[3], float c[3])
 {
@@ -1210,6 +1212,7 @@ void NEP_Charge::find_force(
       dataset[device_id].energy.data());
     GPU_CHECK_KERNEL
 
+/*
     find_force_charge_real_space<<<grid_size, block_size>>>(
       dataset[device_id].N,
       charge_para.alpha,
@@ -1225,6 +1228,7 @@ void NEP_Charge::find_force(
       dataset[device_id].virial.data(),
       dataset[device_id].energy.data());
     GPU_CHECK_KERNEL
+*/
 
     if (zbl.enabled) {
       find_force_ZBL<<<grid_size, block_size>>>(

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -977,6 +977,18 @@ void NEP_Charge::find_force(
     GPU_CHECK_KERNEL
 
     // ewald summation for long-range force
+    gpu_sum_q_factor<<<charge_para.num_kpoints, 1024>>>(
+      dataset[device_id].N,
+      nep_data[device_id].charge.data(),
+      dataset[device_id].r.data(),
+      dataset[device_id].r.data() + dataset[device_id].N,
+      dataset[device_id].r.data() + dataset[device_id].N * 2,
+      nep_data[device_id].kx.data(),
+      nep_data[device_id].ky.data(),
+      nep_data[device_id].kz.data(),
+      nep_data[device_id].q_factor_real.data(),
+      nep_data[device_id].q_factor_imag.data());
+    GPU_CHECK_KERNEL
 
     if (zbl.enabled) {
       find_force_ZBL<<<grid_size, block_size>>>(

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -430,48 +430,6 @@ static __global__ void apply_ann(
   }
 }
 
-static __global__ void apply_ann_temperature(
-  const int N,
-  const NEP_Charge::ParaMB paramb,
-  const NEP_Charge::ANN annmb,
-  const int* __restrict__ g_type,
-  const float* __restrict__ g_descriptors,
-  float* __restrict__ g_q_scaler,
-  const float* __restrict__ g_temperature,
-  float* g_pe,
-  float* g_Fp)
-{
-  int n1 = threadIdx.x + blockIdx.x * blockDim.x;
-  int type = g_type[n1];
-  float temperature = g_temperature[n1];
-  if (n1 < N) {
-    // get descriptors
-    float q[MAX_DIM] = {0.0f};
-    for (int d = 0; d < annmb.dim - 1; ++d) {
-      q[d] = g_descriptors[n1 + d * N] * g_q_scaler[d];
-    }
-    g_q_scaler[annmb.dim - 1] = 0.001; // temperature dimension scaler
-    q[annmb.dim - 1] = temperature * g_q_scaler[annmb.dim - 1];
-    // get energy and energy gradient
-    float F = 0.0f, Fp[MAX_DIM] = {0.0f};
-    apply_ann_one_layer(
-      annmb.dim,
-      annmb.num_neurons1,
-      annmb.w0[type],
-      annmb.b0[type],
-      annmb.w1[type],
-      annmb.b1,
-      q,
-      F,
-      Fp);
-    g_pe[n1] = F;
-
-    for (int d = 0; d < annmb.dim; ++d) {
-      g_Fp[n1 + d * N] = Fp[d] * g_q_scaler[d];
-    }
-  }
-}
-
 static __global__ void zero_force(
   const int N, float* g_fx, float* g_fy, float* g_fz, float* g_vxx, float* g_vyy, float* g_vzz)
 {
@@ -885,30 +843,16 @@ void NEP_Charge::find_force(
       dataset[device_id].virial.data() + dataset[device_id].N * 2);
     GPU_CHECK_KERNEL
 
-    if (para.train_mode == 3) {
-      apply_ann_temperature<<<grid_size, block_size>>>(
-        dataset[device_id].N,
-        paramb,
-        annmb[device_id],
-        dataset[device_id].type.data(),
-        nep_data[device_id].descriptors.data(),
-        para.q_scaler_gpu[device_id].data(),
-        dataset[device_id].temperature_ref_gpu.data(),
-        dataset[device_id].energy.data(),
-        nep_data[device_id].Fp.data());
-      GPU_CHECK_KERNEL
-    } else {
-      apply_ann<<<grid_size, block_size>>>(
-        dataset[device_id].N,
-        paramb,
-        annmb[device_id],
-        dataset[device_id].type.data(),
-        nep_data[device_id].descriptors.data(),
-        para.q_scaler_gpu[device_id].data(),
-        dataset[device_id].energy.data(),
-        nep_data[device_id].Fp.data());
-      GPU_CHECK_KERNEL
-    }
+    apply_ann<<<grid_size, block_size>>>(
+      dataset[device_id].N,
+      paramb,
+      annmb[device_id],
+      dataset[device_id].type.data(),
+      nep_data[device_id].descriptors.data(),
+      para.q_scaler_gpu[device_id].data(),
+      dataset[device_id].energy.data(),
+      nep_data[device_id].Fp.data());
+    GPU_CHECK_KERNEL
 
     find_force_radial<<<grid_size, block_size>>>(
       dataset[device_id].N,

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -252,7 +252,6 @@ void NEP_Charge::find_k1k2k3()
           charge_para.k1.emplace_back(kx);
           charge_para.k2.emplace_back(ky);
           charge_para.k3.emplace_back(kz);
-          printf("%d (%d %d %d) \n", charge_para.num_kpoints, kx, ky, kz);
         }
       }
     }

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -1133,41 +1133,6 @@ void NEP_Charge::find_force(
       fclose(fid_charge);
     }
 
-    find_force_radial<<<grid_size, block_size>>>(
-      dataset[device_id].N,
-      nep_data[device_id].NN_radial.data(),
-      nep_data[device_id].NL_radial.data(),
-      paramb,
-      annmb[device_id],
-      dataset[device_id].type.data(),
-      nep_data[device_id].x12_radial.data(),
-      nep_data[device_id].y12_radial.data(),
-      nep_data[device_id].z12_radial.data(),
-      nep_data[device_id].Fp.data(),
-      dataset[device_id].force.data(),
-      dataset[device_id].force.data() + dataset[device_id].N,
-      dataset[device_id].force.data() + dataset[device_id].N * 2,
-      dataset[device_id].virial.data());
-    GPU_CHECK_KERNEL
-
-    find_force_angular<<<grid_size, block_size>>>(
-      dataset[device_id].N,
-      nep_data[device_id].NN_angular.data(),
-      nep_data[device_id].NL_angular.data(),
-      paramb,
-      annmb[device_id],
-      dataset[device_id].type.data(),
-      nep_data[device_id].x12_angular.data(),
-      nep_data[device_id].y12_angular.data(),
-      nep_data[device_id].z12_angular.data(),
-      nep_data[device_id].Fp.data(),
-      nep_data[device_id].sum_fxyz.data(),
-      dataset[device_id].force.data(),
-      dataset[device_id].force.data() + dataset[device_id].N,
-      dataset[device_id].force.data() + dataset[device_id].N * 2,
-      dataset[device_id].virial.data());
-    GPU_CHECK_KERNEL
-
     find_k_and_G<<<(dataset[device_id].Nc - 1) / 64 + 1, 64>>>(
       dataset[device_id].Nc,
       charge_para.num_kpoints,
@@ -1216,6 +1181,41 @@ void NEP_Charge::find_force(
       dataset[device_id].force.data() + dataset[device_id].N,
       dataset[device_id].force.data() + dataset[device_id].N * 2,
       dataset[device_id].energy.data());
+    GPU_CHECK_KERNEL
+
+    find_force_radial<<<grid_size, block_size>>>(
+      dataset[device_id].N,
+      nep_data[device_id].NN_radial.data(),
+      nep_data[device_id].NL_radial.data(),
+      paramb,
+      annmb[device_id],
+      dataset[device_id].type.data(),
+      nep_data[device_id].x12_radial.data(),
+      nep_data[device_id].y12_radial.data(),
+      nep_data[device_id].z12_radial.data(),
+      nep_data[device_id].Fp.data(),
+      dataset[device_id].force.data(),
+      dataset[device_id].force.data() + dataset[device_id].N,
+      dataset[device_id].force.data() + dataset[device_id].N * 2,
+      dataset[device_id].virial.data());
+    GPU_CHECK_KERNEL
+
+    find_force_angular<<<grid_size, block_size>>>(
+      dataset[device_id].N,
+      nep_data[device_id].NN_angular.data(),
+      nep_data[device_id].NL_angular.data(),
+      paramb,
+      annmb[device_id],
+      dataset[device_id].type.data(),
+      nep_data[device_id].x12_angular.data(),
+      nep_data[device_id].y12_angular.data(),
+      nep_data[device_id].z12_angular.data(),
+      nep_data[device_id].Fp.data(),
+      nep_data[device_id].sum_fxyz.data(),
+      dataset[device_id].force.data(),
+      dataset[device_id].force.data() + dataset[device_id].N,
+      dataset[device_id].force.data() + dataset[device_id].N * 2,
+      dataset[device_id].virial.data());
     GPU_CHECK_KERNEL
 
 /*

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -337,7 +337,6 @@ NEP_Charge::NEP_Charge(
     nep_data[device_id].y12_angular.resize(N_times_max_NN_angular);
     nep_data[device_id].z12_angular.resize(N_times_max_NN_angular);
     nep_data[device_id].descriptors.resize(N * annmb[device_id].dim);
-    nep_data[device_id].charge.resize(N);
     nep_data[device_id].charge_derivative.resize(N * annmb[device_id].dim);
     nep_data[device_id].Fp.resize(N * annmb[device_id].dim);
     nep_data[device_id].sum_fxyz.resize(N * (paramb.n_max_angular + 1) * NUM_OF_ABC);
@@ -1136,14 +1135,14 @@ void NEP_Charge::find_force(
       para.q_scaler_gpu[device_id].data(),
       dataset[device_id].energy.data(),
       nep_data[device_id].Fp.data(),
-      nep_data[device_id].charge.data(),
+      dataset[device_id].charge.data(),
       nep_data[device_id].charge_derivative.data());
     GPU_CHECK_KERNEL
 
     if (para.prediction == 1 && true) {
       FILE* fid_charge = my_fopen("charge.out", "a");
-      std::vector<float> charge_cpu(nep_data[device_id].charge.size());
-      nep_data[device_id].charge.copy_to_host(charge_cpu.data());
+      std::vector<float> charge_cpu(dataset[device_id].charge.size());
+      dataset[device_id].charge.copy_to_host(charge_cpu.data());
       for (int nc = 0; nc < dataset[device_id].Nc; ++nc) {
         for (int na = 0; na < dataset[device_id].Na_cpu[nc]; ++na) {
           int n = dataset[device_id].Na_sum_cpu[nc] + na;
@@ -1171,7 +1170,7 @@ void NEP_Charge::find_force(
       charge_para.num_kpoints,
       dataset[device_id].Na.data(),
       dataset[device_id].Na_sum.data(),
-      nep_data[device_id].charge.data(),
+      dataset[device_id].charge.data(),
       dataset[device_id].r.data(),
       dataset[device_id].r.data() + dataset[device_id].N,
       dataset[device_id].r.data() + dataset[device_id].N * 2,
@@ -1188,7 +1187,7 @@ void NEP_Charge::find_force(
       charge_para.alpha_factor,
       dataset[device_id].Na.data(),
       dataset[device_id].Na_sum.data(),
-      nep_data[device_id].charge.data(),
+      dataset[device_id].charge.data(),
       dataset[device_id].r.data(),
       dataset[device_id].r.data() + dataset[device_id].N,
       dataset[device_id].r.data() + dataset[device_id].N * 2,

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -81,6 +81,7 @@ public:
     GPU_Vector<float> G;
     GPU_Vector<float> S_real;
     GPU_Vector<float> S_imag;
+    GPU_Vector<float> D_real;
   };
 
   struct Charge_Para {

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -84,7 +84,7 @@ public:
   };
 
   struct Charge_Para {
-    int kmax = 5;
+    int kmax = 6;
     int num_kpoints = 0;
     std::vector<int> k1;
     std::vector<int> k2;
@@ -92,7 +92,7 @@ public:
     GPU_Vector<int> k1_gpu;
     GPU_Vector<int> k2_gpu;
     GPU_Vector<int> k3_gpu;
-    float alpha_factor = 1.0f; // 1 / (4 * alpha * alpha) with alpha = 0.5
+    float alpha_factor = 0.25f; // 1 / (4 * alpha * alpha) with alpha = 0.5
   };
 
   struct ZBL {

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -20,7 +20,7 @@
 class Parameters;
 class Dataset;
 
-struct NEP_Data {
+struct NEP_Charge_Data {
   GPU_Vector<int> NN_radial;  // radial neighbor number
   GPU_Vector<int> NL_radial;  // radial neighbor list
   GPU_Vector<int> NN_angular; // angular neighbor number
@@ -103,7 +103,7 @@ public:
 private:
   ParaMB paramb;
   ANN annmb[16];
-  NEP_Data nep_data[16];
+  NEP_Charge_Data nep_data[16];
   ZBL zbl;
   void update_potential(Parameters& para, float* parameters, ANN& ann);
 };

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -20,23 +20,6 @@
 class Parameters;
 class Dataset;
 
-struct NEP_Charge_Data {
-  GPU_Vector<int> NN_radial;  // radial neighbor number
-  GPU_Vector<int> NL_radial;  // radial neighbor list
-  GPU_Vector<int> NN_angular; // angular neighbor number
-  GPU_Vector<int> NL_angular; // angular neighbor list
-  GPU_Vector<float> x12_radial;
-  GPU_Vector<float> y12_radial;
-  GPU_Vector<float> z12_radial;
-  GPU_Vector<float> x12_angular;
-  GPU_Vector<float> y12_angular;
-  GPU_Vector<float> z12_angular;
-  GPU_Vector<float> descriptors; // descriptors
-  GPU_Vector<float> Fp;          // gradient of descriptors
-  GPU_Vector<float> sum_fxyz;
-  GPU_Vector<float> parameters; // parameters to be optimized
-};
-
 class NEP_Charge : public Potential
 {
 public:
@@ -73,6 +56,23 @@ public:
     const float* w1[NUM_ELEMENTS]; // weight from the hidden layer to the output layer
     const float* b1;               // bias for the output layer
     const float* c;                // for elements in descriptor
+  };
+
+  struct NEP_Charge_Data {
+    GPU_Vector<int> NN_radial;  // radial neighbor number
+    GPU_Vector<int> NL_radial;  // radial neighbor list
+    GPU_Vector<int> NN_angular; // angular neighbor number
+    GPU_Vector<int> NL_angular; // angular neighbor list
+    GPU_Vector<float> x12_radial;
+    GPU_Vector<float> y12_radial;
+    GPU_Vector<float> z12_radial;
+    GPU_Vector<float> x12_angular;
+    GPU_Vector<float> y12_angular;
+    GPU_Vector<float> z12_angular;
+    GPU_Vector<float> descriptors; // descriptors
+    GPU_Vector<float> Fp;          // gradient of descriptors
+    GPU_Vector<float> sum_fxyz;
+    GPU_Vector<float> parameters; // parameters to be optimized
   };
 
   struct ZBL {

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -89,7 +89,7 @@ public:
     std::vector<int> k1;
     std::vector<int> k2;
     std::vector<int> k3;
-    float alpha = 0.5f;
+    float alpha_factor = 1.0f; // 1 / (4 * alpha * alpha) with alpha = 0.5
   };
 
   struct ZBL {

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -84,9 +84,12 @@ public:
   };
 
   struct Charge_Para {
-    int kmax = 6;
+    int kmax = 5;
     int num_kpoints = 0;
-    float alpha = 1.0f;
+    std::vector<int> k1;
+    std::vector<int> k2;
+    std::vector<int> k3;
+    float alpha = 0.5f;
   };
 
   struct ZBL {
@@ -102,6 +105,7 @@ public:
   NEP_Charge(
     Parameters& para,
     int N,
+    int Nc,
     int N_times_max_NN_radial,
     int N_times_max_NN_angular,
     int version,
@@ -113,6 +117,7 @@ public:
     bool calculate_q_scaler,
     bool calculate_neighbor,
     int deviceCount);
+  void find_k1k2k3();
 
 private:
   ParaMB paramb;

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -69,8 +69,10 @@ public:
     GPU_Vector<float> x12_angular;
     GPU_Vector<float> y12_angular;
     GPU_Vector<float> z12_angular;
-    GPU_Vector<float> descriptors; // descriptors
-    GPU_Vector<float> Fp;          // gradient of descriptors
+    GPU_Vector<float> descriptors;       // descriptors
+    GPU_Vector<float> charge;            // per-atom charge
+    GPU_Vector<float> charge_derivative; // derivative of charge with respect to descriptor
+    GPU_Vector<float> Fp;                // derivative of energy with respect to descriptor
     GPU_Vector<float> sum_fxyz;
     GPU_Vector<float> parameters; // parameters to be optimized
   };

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -24,6 +24,7 @@ class NEP_Charge : public Potential
 {
 public:
   struct ParaMB {
+    int charge_mode = 0;
     bool use_typewise_cutoff = false;
     bool use_typewise_cutoff_zbl = false;
     float typewise_cutoff_radial_factor = 2.5f;

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -78,9 +78,9 @@ public:
     GPU_Vector<float> kx;
     GPU_Vector<float> ky;
     GPU_Vector<float> kz;
-    GPU_Vector<float> g_factor;
-    GPU_Vector<float> q_factor_real;
-    GPU_Vector<float> q_factor_imag;
+    GPU_Vector<float> G;
+    GPU_Vector<float> S_real;
+    GPU_Vector<float> S_imag;
   };
 
   struct Charge_Para {

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -89,6 +89,9 @@ public:
     std::vector<int> k1;
     std::vector<int> k2;
     std::vector<int> k3;
+    GPU_Vector<int> k1_gpu;
+    GPU_Vector<int> k2_gpu;
+    GPU_Vector<int> k3_gpu;
     float alpha_factor = 1.0f; // 1 / (4 * alpha * alpha) with alpha = 0.5
   };
 

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -92,8 +92,8 @@ public:
     GPU_Vector<int> k1_gpu;
     GPU_Vector<int> k2_gpu;
     GPU_Vector<int> k3_gpu;
-    float alpha = 1.0f; // 1 / (2 Angstrom)
-    float alpha_factor = 0.25f; // 1 / (4 * alpha * alpha)
+    float alpha = 0.5f; // 1 / (2 Angstrom)
+    float alpha_factor = 1.0f; // 1 / (4 * alpha * alpha)
   };
 
   struct ZBL {

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -81,17 +81,12 @@ public:
     GPU_Vector<float> S_real;
     GPU_Vector<float> S_imag;
     GPU_Vector<float> D_real;
-    GPU_Vector<int> k1_gpu;
-    GPU_Vector<int> k2_gpu;
-    GPU_Vector<int> k3_gpu;
+    GPU_Vector<int> num_kpoints;
   };
 
   struct Charge_Para {
     int kmax = 8;
-    int num_kpoints = 0;
-    std::vector<int> k1;
-    std::vector<int> k2;
-    std::vector<int> k3;
+    int num_kpoints_max = 10000;
     float alpha = 0.5f; // 1 / (2 Angstrom)
     float alpha_factor = 1.0f; // 1 / (4 * alpha * alpha)
     float two_alpha_over_sqrt_pi = 0.564189583547756f;

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -1,0 +1,109 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "potential.cuh"
+#include "utilities/common.cuh"
+#include "utilities/gpu_vector.cuh"
+class Parameters;
+class Dataset;
+
+struct NEP_Data {
+  GPU_Vector<int> NN_radial;  // radial neighbor number
+  GPU_Vector<int> NL_radial;  // radial neighbor list
+  GPU_Vector<int> NN_angular; // angular neighbor number
+  GPU_Vector<int> NL_angular; // angular neighbor list
+  GPU_Vector<float> x12_radial;
+  GPU_Vector<float> y12_radial;
+  GPU_Vector<float> z12_radial;
+  GPU_Vector<float> x12_angular;
+  GPU_Vector<float> y12_angular;
+  GPU_Vector<float> z12_angular;
+  GPU_Vector<float> descriptors; // descriptors
+  GPU_Vector<float> Fp;          // gradient of descriptors
+  GPU_Vector<float> sum_fxyz;
+  GPU_Vector<float> parameters; // parameters to be optimized
+};
+
+class NEP_Charge : public Potential
+{
+public:
+  struct ParaMB {
+    bool use_typewise_cutoff = false;
+    bool use_typewise_cutoff_zbl = false;
+    float typewise_cutoff_radial_factor = 2.5f;
+    float typewise_cutoff_angular_factor = 2.0f;
+    float typewise_cutoff_zbl_factor = 0.65f;
+    float rc_radial = 0.0f;     // radial cutoff
+    float rc_angular = 0.0f;    // angular cutoff
+    float rcinv_radial = 0.0f;  // inverse of the radial cutoff
+    float rcinv_angular = 0.0f; // inverse of the angular cutoff
+    int basis_size_radial = 0;
+    int basis_size_angular = 0;
+    int n_max_radial = 0;  // n_radial = 0, 1, 2, ..., n_max_radial
+    int n_max_angular = 0; // n_angular = 0, 1, 2, ..., n_max_angular
+    int L_max = 0;         // l = 1, 2, ..., L_max
+    int dim_angular;
+    int num_L;
+    int num_types = 0;
+    int num_types_sq = 0;
+    int num_c_radial = 0;
+    int version = 4; // 3 for NEP3 and 4 for NEP4
+    int atomic_numbers[NUM_ELEMENTS];
+  };
+
+  struct ANN {
+    int dim = 0;                    // dimension of the descriptor
+    int num_neurons1 = 0;           // number of neurons in the hidden layer
+    int num_para = 0;               // number of parameters
+    const float* w0[NUM_ELEMENTS]; // weight from the input layer to the hidden layer
+    const float* b0[NUM_ELEMENTS]; // bias for the hidden layer
+    const float* w1[NUM_ELEMENTS]; // weight from the hidden layer to the output layer
+    const float* b1;               // bias for the output layer
+    const float* c;                // for elements in descriptor
+  };
+
+  struct ZBL {
+    bool enabled = false;
+    bool flexibled = false;
+    float rc_inner = 1.0f;
+    float rc_outer = 2.0f;
+    int num_types;
+    float para[550];
+    int atomic_numbers[NUM_ELEMENTS];
+  };
+
+  NEP_Charge(
+    Parameters& para,
+    int N,
+    int N_times_max_NN_radial,
+    int N_times_max_NN_angular,
+    int version,
+    int deviceCount);
+  void find_force(
+    Parameters& para,
+    const float* parameters,
+    std::vector<Dataset>& dataset,
+    bool calculate_q_scaler,
+    bool calculate_neighbor,
+    int deviceCount);
+
+private:
+  ParaMB paramb;
+  ANN annmb[16];
+  NEP_Data nep_data[16];
+  ZBL zbl;
+  void update_potential(Parameters& para, float* parameters, ANN& ann);
+};

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -92,7 +92,8 @@ public:
     GPU_Vector<int> k1_gpu;
     GPU_Vector<int> k2_gpu;
     GPU_Vector<int> k3_gpu;
-    float alpha_factor = 0.25f; // 1 / (4 * alpha * alpha) with alpha = 0.5
+    float alpha = 0.5f; // 1 / (2 Angstrom)
+    float alpha_factor = 1.0f; // 1 / (4 * alpha * alpha)
   };
 
   struct ZBL {

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -94,6 +94,7 @@ public:
     GPU_Vector<int> k3_gpu;
     float alpha = 0.5f; // 1 / (2 Angstrom)
     float alpha_factor = 1.0f; // 1 / (4 * alpha * alpha)
+    float two_alpha_over_sqrt_pi = 0.564189583547756f;
   };
 
   struct ZBL {

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -85,7 +85,7 @@ public:
   };
 
   struct Charge_Para {
-    int kmax = 6;
+    int kmax = 8;
     int num_kpoints = 0;
     std::vector<int> k1;
     std::vector<int> k2;

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -70,7 +70,6 @@ public:
     GPU_Vector<float> y12_angular;
     GPU_Vector<float> z12_angular;
     GPU_Vector<float> descriptors;       // descriptors
-    GPU_Vector<float> charge;            // per-atom charge
     GPU_Vector<float> charge_derivative; // derivative of charge with respect to descriptor
     GPU_Vector<float> Fp;                // derivative of energy with respect to descriptor
     GPU_Vector<float> sum_fxyz;
@@ -93,8 +92,8 @@ public:
     GPU_Vector<int> k1_gpu;
     GPU_Vector<int> k2_gpu;
     GPU_Vector<int> k3_gpu;
-    float alpha = 0.5f; // 1 / (2 Angstrom)
-    float alpha_factor = 1.0f; // 1 / (4 * alpha * alpha)
+    float alpha = 1.0f; // 1 / (2 Angstrom)
+    float alpha_factor = 0.25f; // 1 / (4 * alpha * alpha)
   };
 
   struct ZBL {

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -85,8 +85,7 @@ public:
   };
 
   struct Charge_Para {
-    int kmax = 8;
-    int num_kpoints_max = 10000;
+    int num_kpoints_max = 50000;
     float alpha = 0.5f; // 1 / (2 Angstrom)
     float alpha_factor = 1.0f; // 1 / (4 * alpha * alpha)
     float two_alpha_over_sqrt_pi = 0.564189583547756f;

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -75,6 +75,18 @@ public:
     GPU_Vector<float> Fp;                // derivative of energy with respect to descriptor
     GPU_Vector<float> sum_fxyz;
     GPU_Vector<float> parameters; // parameters to be optimized
+    GPU_Vector<float> kx;
+    GPU_Vector<float> ky;
+    GPU_Vector<float> kz;
+    GPU_Vector<float> g_factor;
+    GPU_Vector<float> q_factor_real;
+    GPU_Vector<float> q_factor_imag;
+  };
+
+  struct Charge_Para {
+    int kmax = 6;
+    int num_kpoints = 0;
+    float alpha = 1.0f;
   };
 
   struct ZBL {
@@ -107,5 +119,6 @@ private:
   ANN annmb[16];
   NEP_Charge_Data nep_data[16];
   ZBL zbl;
+  Charge_Para charge_para;
   void update_potential(Parameters& para, float* parameters, ANN& ann);
 };

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -81,6 +81,9 @@ public:
     GPU_Vector<float> S_real;
     GPU_Vector<float> S_imag;
     GPU_Vector<float> D_real;
+    GPU_Vector<int> k1_gpu;
+    GPU_Vector<int> k2_gpu;
+    GPU_Vector<int> k3_gpu;
   };
 
   struct Charge_Para {
@@ -89,9 +92,6 @@ public:
     std::vector<int> k1;
     std::vector<int> k2;
     std::vector<int> k3;
-    GPU_Vector<int> k1_gpu;
-    GPU_Vector<int> k2_gpu;
-    GPU_Vector<int> k3_gpu;
     float alpha = 0.5f; // 1 / (2 Angstrom)
     float alpha_factor = 1.0f; // 1 / (4 * alpha * alpha)
     float two_alpha_over_sqrt_pi = 0.564189583547756f;

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -92,6 +92,7 @@ void Parameters::set_default_parameters()
   lambda_e = lambda_f = 1.0f;  // energy and force are more important
   lambda_v = 0.1f;             // virial is less important
   lambda_shear = 1.0f;         // do not weight shear virial more by default
+  lambda_q = 0.01f;            // need to test
   force_delta = 0.0f;          // no modification of force loss
   batch_size = 1000;           // large enough in most cases
   use_full_batch = 0;          // default is not to enable effective full-batch

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -107,7 +107,7 @@ void Parameters::set_default_parameters()
   typewise_cutoff_angular_factor = -1.0f;
   typewise_cutoff_zbl_factor = -1.0f;
   output_descriptor = false;
-  has_charge = false;
+  charge_mode = 0;
 
   type_weight_cpu.resize(NUM_ELEMENTS);
   zbl_para.resize(550); // Maximum number of zbl parameters
@@ -161,7 +161,7 @@ void Parameters::read_zbl_in()
 
 void Parameters::calculate_parameters()
 {
-  if (has_charge) {
+  if (charge_mode) {
     if (train_mode != 0) {
       PRINT_INPUT_ERROR("Charge is only supported for potential model.");
     }
@@ -196,12 +196,12 @@ void Parameters::calculate_parameters()
 
   if (version == 3) {
     number_of_variables_ann = (dim + 2) * num_neurons1 + 1;
-    if (has_charge) {
+    if (charge_mode) {
       number_of_variables_ann += num_neurons1;
     }
   } else if (version == 4) {
     number_of_variables_ann = (dim + 2) * num_neurons1 * num_types + 1;
-    if (has_charge) {
+    if (charge_mode) {
       number_of_variables_ann += num_neurons1 * num_types;
     }
   }
@@ -313,13 +313,11 @@ void Parameters::report_inputs()
   }
 
   if (is_has_charge_set) {
-    if (has_charge) {
-      printf("    (input)   use NEP-Charge and consider dynamic charges.\n");
-    } else {
-      printf("    (input)   use pure NEP without considering charges.\n");
+    if (charge_mode == 1) {
+      printf("    (input)   use NEP-Charge and include real-space.\n");
+    } else if (charge_mode == 2) {
+      printf("    (input)   use NEP-Charge and exclude real-space.\n");
     }
-  } else {
-    printf("    (default) use pure NEP without considering charges.\n");
   }
 
   if (is_cutoff_set) {
@@ -1101,11 +1099,11 @@ void Parameters::parse_has_charge(const char** param, int num_param)
   if (num_param != 2) {
     PRINT_INPUT_ERROR("has_charge should have one parameter.\n");
   }
-  if (!is_valid_int(param[1], &has_charge)) {
-    PRINT_INPUT_ERROR("has_charge should be an integer.\n");
+  if (!is_valid_int(param[1], &charge_mode)) {
+    PRINT_INPUT_ERROR("charge mode should be an integer.\n");
   }
-  if (has_charge != 0 && has_charge != 1) {
-    PRINT_INPUT_ERROR("has_charge should be 0 or 1.");
+  if (charge_mode != 0 && charge_mode != 1 && charge_mode != 2) {
+    PRINT_INPUT_ERROR("charge mode should be 0 or 1 or 2.");
   }
 }
 

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -158,6 +158,13 @@ void Parameters::read_zbl_in()
 
 void Parameters::calculate_parameters()
 {
+  // only allow for NEP4 potential with charge (to be simple)
+  if (has_charge) {
+    if (train_mode != 0) {
+      PRINT_INPUT_ERROR("Charge is only supported for potential model.");
+    }
+  }
+
   if (version == 5 && train_mode != 0) {
     PRINT_INPUT_ERROR("Can only use NEP5 for potential model.");
   }
@@ -191,8 +198,14 @@ void Parameters::calculate_parameters()
 
   if (version == 3) {
     number_of_variables_ann = (dim + 2) * num_neurons1 + 1;
+    if (has_charge) {
+      number_of_variables_ann += num_neurons1;
+    }
   } else if (version == 4) {
     number_of_variables_ann = (dim + 2) * num_neurons1 * num_types + 1;
+    if (has_charge) {
+      number_of_variables_ann += num_neurons1 * num_types;
+    }
   } else if (version == 5) {
     number_of_variables_ann = ((dim + 2) * num_neurons1 + 1) * num_types + 1;
   }

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -74,6 +74,7 @@ void Parameters::set_default_parameters()
   is_force_delta_set = false;
   is_use_typewise_cutoff_set = false;
   is_use_typewise_cutoff_zbl_set = false;
+  is_has_charge_set = false;
 
   train_mode = 0;              // potential
   prediction = 0;              // not prediction mode
@@ -106,6 +107,7 @@ void Parameters::set_default_parameters()
   typewise_cutoff_angular_factor = -1.0f;
   typewise_cutoff_zbl_factor = -1.0f;
   output_descriptor = false;
+  has_charge = false;
 
   type_weight_cpu.resize(NUM_ELEMENTS);
   zbl_para.resize(550); // Maximum number of zbl parameters
@@ -310,6 +312,16 @@ void Parameters::report_inputs()
     printf("    (default) will not add the ZBL potential.\n");
   }
 
+  if (is_has_charge_set) {
+    if (has_charge) {
+      printf("    (input)   use NEP-Charge and consider dynamic charges.\n");
+    } else {
+      printf("    (input)   use pure NEP without considering charges.\n");
+    }
+  } else {
+    printf("    (default) use pure NEP without considering charges.\n");
+  }
+
   if (is_cutoff_set) {
     printf("    (input)   radial cutoff = %g A.\n", rc_radial);
     printf("    (input)   angular cutoff = %g A.\n", rc_angular);
@@ -503,6 +515,8 @@ void Parameters::parse_one_keyword(std::vector<std::string>& tokens)
     parse_use_typewise_cutoff_zbl(param, num_param);
   } else if (strcmp(param[0], "output_descriptor") == 0) {
     parse_output_descriptor(param, num_param);
+  } else if (strcmp(param[0], "has_charge") == 0) {
+    parse_has_charge(param, num_param);
   } else {
     PRINT_KEYWORD_ERROR(param[0]);
   }
@@ -1079,3 +1093,19 @@ void Parameters::parse_output_descriptor(const char** param, int num_param)
     PRINT_INPUT_ERROR("output_descriptor should >= 0 and <= 2.");
   }
 }
+
+void Parameters::parse_has_charge(const char** param, int num_param)
+{
+  is_has_charge_set = true;
+
+  if (num_param != 2) {
+    PRINT_INPUT_ERROR("has_charge should have one parameter.\n");
+  }
+  if (!is_valid_int(param[1], &has_charge)) {
+    PRINT_INPUT_ERROR("has_charge should be an integer.\n");
+  }
+  if (has_charge != 0 && has_charge != 1) {
+    PRINT_INPUT_ERROR("has_charge should be 0 or 1.");
+  }
+}
+

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -62,7 +62,7 @@ public:
   float typewise_cutoff_angular_factor;
   float typewise_cutoff_zbl_factor;
   int output_descriptor;
-  int has_charge; // add dynamic charge to NEP potential model
+  int charge_mode; // add dynamic charge to NEP potential model
 
   // check if a parameter has been set:
   bool is_train_mode_set;

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -62,7 +62,7 @@ public:
   float typewise_cutoff_angular_factor;
   float typewise_cutoff_zbl_factor;
   int output_descriptor;
-  bool has_charge = true; // for quick test; to be changed
+  int has_charge; // add dynamic charge to NEP potential model
 
   // check if a parameter has been set:
   bool is_train_mode_set;
@@ -88,6 +88,7 @@ public:
   bool is_zbl_set;
   bool is_use_typewise_cutoff_set;
   bool is_use_typewise_cutoff_zbl_set;
+  bool is_has_charge_set;
 
   // other parameters
   int dim;                            // dimension of the descriptor vector
@@ -142,4 +143,5 @@ private:
   void parse_use_typewise_cutoff(const char** param, int num_param);
   void parse_use_typewise_cutoff_zbl(const char** param, int num_param);
   void parse_output_descriptor(const char** param, int num_param);
+  void parse_has_charge(const char** param, int num_param);
 };

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -46,6 +46,7 @@ public:
   float lambda_f;         // weight parameter for force RMSE loss
   float lambda_v;         // weight parameter for virial RMSE loss
   float lambda_shear;     // extra weight parameter for shear virial
+  float lambda_q;         // weight for global charge
   float force_delta;      // a parameters used to modify the force loss
   bool enable_zbl;        // true for inlcuding the universal ZBL potential
   bool flexible_zbl;      // true for inlcuding the flexible ZBL potential

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -61,6 +61,7 @@ public:
   float typewise_cutoff_angular_factor;
   float typewise_cutoff_zbl_factor;
   int output_descriptor;
+  bool has_charge = true; // for quick test; to be changed
 
   // check if a parameter has been set:
   bool is_train_mode_set;

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -51,7 +51,7 @@ SNES::SNES(Parameters& para, Fitness* fitness_function)
     num /= para.num_types;
   }
   eta_sigma = (3.0f + std::log(num * 1.0f)) / (5.0f * sqrt(num * 1.0f)) / 2.0f;
-  fitness.resize(population_size * 6 * (para.num_types + 1));
+  fitness.resize(population_size * 7 * (para.num_types + 1));
   index.resize(population_size * (para.num_types + 1));
   population.resize(N);
   mu.resize(number_of_variables);
@@ -229,9 +229,9 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
       sort_population(para);
 
       int best_index = index[para.num_types * population_size];
-      float fitness_total = fitness[0 + (6 * para.num_types + 0) * population_size];
-      float fitness_L1 = fitness[best_index + (6 * para.num_types + 1) * population_size];
-      float fitness_L2 = fitness[best_index + (6 * para.num_types + 2) * population_size];
+      float fitness_total = fitness[0 + (7 * para.num_types + 0) * population_size];
+      float fitness_L1 = fitness[best_index + (7 * para.num_types + 1) * population_size];
+      float fitness_L2 = fitness[best_index + (7 * para.num_types + 2) * population_size];
       fitness_function->report_error(
         para,
         n,
@@ -375,11 +375,12 @@ void SNES::regularize_NEP4(Parameters& para)
     for (int p = 0; p < population_size; ++p) {
       float cost_L1 = para.lambda_1 * cost_L1reg[p] / num_variables;
       float cost_L2 = para.lambda_2 * sqrt(cost_L2reg[p] / num_variables);
-      fitness[p + (6 * t + 0) * population_size] =
-        cost_L1 + cost_L2 + fitness[p + (6 * t + 3) * population_size] +
-        fitness[p + (6 * t + 4) * population_size] + fitness[p + (6 * t + 5) * population_size];
-      fitness[p + (6 * t + 1) * population_size] = cost_L1;
-      fitness[p + (6 * t + 2) * population_size] = cost_L2;
+      fitness[p + (7 * t + 0) * population_size] =
+        cost_L1 + cost_L2 + fitness[p + (7 * t + 3) * population_size] +
+        fitness[p + (7 * t + 4) * population_size] + fitness[p + (7 * t + 5) * population_size] +
+        fitness[p + (7 * t + 6) * population_size];
+      fitness[p + (7 * t + 1) * population_size] = cost_L1;
+      fitness[p + (7 * t + 2) * population_size] = cost_L2;
     }
   }
 }
@@ -431,11 +432,12 @@ void SNES::regularize(Parameters& para)
     float cost_L2 = para.lambda_2 * sqrt(cost_L2reg[p] / number_of_variables);
 
     for (int t = 0; t <= para.num_types; ++t) {
-      fitness[p + (6 * t + 0) * population_size] =
-        cost_L1 + cost_L2 + fitness[p + (6 * t + 3) * population_size] +
-        fitness[p + (6 * t + 4) * population_size] + fitness[p + (6 * t + 5) * population_size];
-      fitness[p + (6 * t + 1) * population_size] = cost_L1;
-      fitness[p + (6 * t + 2) * population_size] = cost_L2;
+      fitness[p + (7 * t + 0) * population_size] =
+        cost_L1 + cost_L2 + fitness[p + (7 * t + 3) * population_size] +
+        fitness[p + (7 * t + 4) * population_size] + fitness[p + (7 * t + 5) * population_size] +
+        fitness[p + (7 * t + 6) * population_size];
+      fitness[p + (7 * t + 1) * population_size] = cost_L1;
+      fitness[p + (7 * t + 2) * population_size] = cost_L2;
     }
   }
 }
@@ -463,7 +465,7 @@ void SNES::sort_population(Parameters& para)
     }
 
     insertion_sort(
-      fitness.data() + t * population_size * 6,
+      fitness.data() + t * population_size * 7,
       index.data() + t * population_size,
       population_size);
   }

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -127,7 +127,7 @@ void SNES::calculate_utility()
 void SNES::find_type_of_variable(Parameters& para)
 {
   int num_para_ann_per_type = (para.dim + 2) * para.num_neurons1;
-  if (para.has_charge) {
+  if (para.charge_mode) {
     num_para_ann_per_type += para.num_neurons1;
   }
 

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -126,6 +126,11 @@ void SNES::calculate_utility()
 
 void SNES::find_type_of_variable(Parameters& para)
 {
+  int num_para_ann_per_type = (para.dim + 2) * para.num_neurons1;
+  if (para.has_charge) {
+    num_para_ann_per_type += para.num_neurons1;
+  }
+
   int offset = 0;
 
   // NN part
@@ -133,15 +138,15 @@ void SNES::find_type_of_variable(Parameters& para)
     int num_ann = (para.train_mode == 2) ? 2 : 1;
     for (int ann = 0; ann < num_ann; ++ann) {
       for (int t = 0; t < para.num_types; ++t) {
-        for (int n = 0; n < (para.dim + 2) * para.num_neurons1; ++n) {
+        for (int n = 0; n < num_para_ann_per_type; ++n) {
           type_of_variable[n + offset] = t;
         }
-        offset += (para.dim + 2) * para.num_neurons1;
+        offset += num_para_ann_per_type;
       }
       ++offset; // the bias
     }
   } else {
-    offset += (para.dim + 2) * para.num_neurons1 + 1;
+    offset += num_para_ann_per_type + 1;
   }
 
   // descriptor part

--- a/src/main_nep/structure.cuh
+++ b/src/main_nep/structure.cuh
@@ -24,6 +24,7 @@ struct Structure {
   int has_virial;
   int has_temperature;
   float weight;
+  float charge = 0.0f;
   float energy = 0.0f;
   float energy_weight = 1.0f;
   float virial[6];

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -195,7 +195,6 @@ static __device__ void apply_ann_one_layer_nep5(
 }
 
 static __device__ void apply_ann_one_layer_charge(
-  const bool is_nep5,
   const int N_des,
   const int N_neu,
   const float* w0,
@@ -204,7 +203,9 @@ static __device__ void apply_ann_one_layer_charge(
   const float* b1,
   float* q,
   float& energy,
-  float* energy_derivative)
+  float* energy_derivative,
+  float& charge,
+  float* charge_derivative)
 {
   for (int n = 0; n < N_neu; ++n) {
     float w0_times_q = 0.0f;
@@ -219,11 +220,7 @@ static __device__ void apply_ann_one_layer_charge(
       energy_derivative[d] += w1[n] * y1;
     }
   }
-  if (is_nep5) {
-    energy -= w1[N_neu] + b1[0]; // typewise bias + common bias
-  } else {
-    energy -= b1[0];
-  }
+  energy -= b1[0];
 }
 
 static __device__ __forceinline__ void find_fc(float rc, float rcinv, float d12, float& fc)

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -194,6 +194,38 @@ static __device__ void apply_ann_one_layer_nep5(
   energy -= w1[N_neu] + b1[0]; // typewise bias + common bias
 }
 
+static __device__ void apply_ann_one_layer_charge(
+  const bool is_nep5,
+  const int N_des,
+  const int N_neu,
+  const float* w0,
+  const float* b0,
+  const float* w1,
+  const float* b1,
+  float* q,
+  float& energy,
+  float* energy_derivative)
+{
+  for (int n = 0; n < N_neu; ++n) {
+    float w0_times_q = 0.0f;
+    for (int d = 0; d < N_des; ++d) {
+      w0_times_q += w0[n * N_des + d] * q[d];
+    }
+    float x1 = tanh(w0_times_q - b0[n]);
+    float tanh_der = 1.0f - x1 * x1;
+    energy += w1[n] * x1;
+    for (int d = 0; d < N_des; ++d) {
+      float y1 = tanh_der * w0[n * N_des + d];
+      energy_derivative[d] += w1[n] * y1;
+    }
+  }
+  if (is_nep5) {
+    energy -= w1[N_neu] + b1[0]; // typewise bias + common bias
+  } else {
+    energy -= b1[0];
+  }
+}
+
 static __device__ __forceinline__ void find_fc(float rc, float rcinv, float d12, float& fc)
 {
   if (d12 < rc) {

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -215,9 +215,11 @@ static __device__ void apply_ann_one_layer_charge(
     float x1 = tanh(w0_times_q - b0[n]);
     float tanh_der = 1.0f - x1 * x1;
     energy += w1[n] * x1;
+    charge += w1[n + N_neu] * x1;
     for (int d = 0; d < N_des; ++d) {
       float y1 = tanh_der * w0[n * N_des + d];
       energy_derivative[d] += w1[n] * y1;
+      charge_derivative[d] += w1[n + N_neu] * y1;
     }
   }
   energy -= b1[0];


### PR DESCRIPTION
**Summary**

Add the charge degree of freedom into the NEP approach. The resulting method will be called `NEP-Charge`.

* Usage in `nep.in`:
```
has_charge 1 # default is 0 (check your screen output) and 2 is to exclude real-space part
```

* Formalism:
  - Similar to this: [Charge-Optimized Electrostatic Interaction Atom-Centered Neural Network Algorithm](https://doi.org/10.1021/acs.jctc.3c01254) [1]
  - Learn the global charge of the structure only, not partial charges on the atoms. Ref. [1] does not learn the global charge.   Besides this, charge neutrality is enforced.
  - Charge and potential share most of the neural network but have different weights from the hidden layer to the output layer. Using completely separate neural networks is not benificial.
  - Electrostatic interactions are evaluated using the standard Ewald summation. The speed is ok for training but I need to explore more efficient algorithms for MD simulation.
  - Virial and heat current are carefully derived. Still very elegant formulation, in the spirit of [Force and heat current formulas for many-body potentials in molecular dynamics simulations with applications to thermal conductivity calculations](https://doi.org/10.1103/PhysRevB.92.094301). These are our new contributions.
  - It was suggested that the real-space and self-energy parts could be removed [Latent Ewald summation for machine learning of long-range interactions](https://doi.org/10.48550/arXiv.2408.15165), and I also provide this option.

* A typical charge distribution predicted for the PbTe example:

![image](https://github.com/user-attachments/assets/11544748-2ae5-434a-9207-6ad48091ac16)


* Force checked against my Matlab (no chance to be wrong) code:

![image](https://github.com/user-attachments/assets/6dfd0eb1-6316-4755-82e9-8356e78765e9)


* To solve the issue #299 
* TODO: documentation + MD part + NEP_CPU, but these are for new PRs.
