### PR TITLE
disable nep5 training

### DIFF
--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -278,13 +278,7 @@ void Fitness::write_nep_txt(FILE* fid_nep, Parameters& para, float* elite)
       } else {
         fprintf(fid_nep, "nep4 %d ", para.num_types);
       }
-    } else if (para.version == 5) {
-      if (para.enable_zbl) {
-        fprintf(fid_nep, "nep5_zbl %d ", para.num_types);
-      } else {
-        fprintf(fid_nep, "nep5 %d ", para.num_types);
-      }
-    }
+    } 
   } else if (para.train_mode == 1) { // dipole model
     if (para.version == 3) {
       fprintf(fid_nep, "nep3_dipole %d ", para.num_types);

--- a/src/main_nep/nep.cu
+++ b/src/main_nep/nep.cu
@@ -329,9 +329,6 @@ void NEP::update_potential(Parameters& para, float* parameters, ANN& ann)
     pointer += ann.num_neurons1;
     ann.w1[t] = pointer;
     pointer += ann.num_neurons1;
-    if (para.version == 5) {
-      pointer += 1; // one extra bias for NEP5 stored in ann.w1[t]
-    }
   }
   ann.b1 = pointer;
   pointer += 1;
@@ -399,29 +396,16 @@ static __global__ void apply_ann(
     // get energy and energy gradient
     float F = 0.0f, Fp[MAX_DIM] = {0.0f};
 
-    if (paramb.version == 5) {
-      apply_ann_one_layer_nep5(
-        annmb.dim,
-        annmb.num_neurons1,
-        annmb.w0[type],
-        annmb.b0[type],
-        annmb.w1[type],
-        annmb.b1,
-        q,
-        F,
-        Fp);
-    } else {
-      apply_ann_one_layer(
-        annmb.dim,
-        annmb.num_neurons1,
-        annmb.w0[type],
-        annmb.b0[type],
-        annmb.w1[type],
-        annmb.b1,
-        q,
-        F,
-        Fp);
-    }
+    apply_ann_one_layer(
+      annmb.dim,
+      annmb.num_neurons1,
+      annmb.w0[type],
+      annmb.b0[type],
+      annmb.w1[type],
+      annmb.b1,
+      q,
+      F,
+      Fp);
     g_pe[n1] = F;
 
     for (int d = 0; d < annmb.dim; ++d) {

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -158,10 +158,6 @@ void Parameters::read_zbl_in()
 
 void Parameters::calculate_parameters()
 {
-  if (version == 5 && train_mode != 0) {
-    PRINT_INPUT_ERROR("Can only use NEP5 for potential model.");
-  }
-
   if (train_mode != 0 && train_mode != 3) {
     // take virial as dipole or polarizability
     lambda_e = lambda_f = 0.0f;
@@ -193,8 +189,6 @@ void Parameters::calculate_parameters()
     number_of_variables_ann = (dim + 2) * num_neurons1 + 1;
   } else if (version == 4) {
     number_of_variables_ann = (dim + 2) * num_neurons1 * num_types + 1;
-  } else if (version == 5) {
-    number_of_variables_ann = ((dim + 2) * num_neurons1 + 1) * num_types + 1;
   }
 
   number_of_variables_descriptor =
@@ -541,8 +535,8 @@ void Parameters::parse_version(const char** param, int num_param)
   if (!is_valid_int(param[1], &version)) {
     PRINT_INPUT_ERROR("version should be an integer.\n");
   }
-  if (version < 3 || version > 5) {
-    PRINT_INPUT_ERROR("version should = 3 or 4 or 5.");
+  if (version < 3 || version > 4) {
+    PRINT_INPUT_ERROR("version should = 3 or 4.");
   }
 }
 

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -131,13 +131,12 @@ void SNES::find_type_of_variable(Parameters& para)
   // NN part
   if (para.version != 3) {
     int num_ann = (para.train_mode == 2) ? 2 : 1;
-    int num_extra_bias = (para.version == 5) ? 1 : 0;
     for (int ann = 0; ann < num_ann; ++ann) {
       for (int t = 0; t < para.num_types; ++t) {
-        for (int n = 0; n < (para.dim + 2) * para.num_neurons1 + num_extra_bias; ++n) {
+        for (int n = 0; n < (para.dim + 2) * para.num_neurons1; ++n) {
           type_of_variable[n + offset] = t;
         }
-        offset += (para.dim + 2) * para.num_neurons1 + num_extra_bias;
+        offset += (para.dim + 2) * para.num_neurons1;
       }
       ++offset; // the bias
     }


### PR DESCRIPTION
**Summary**

NEP5 is not necessary. So I want to disable its future training with `nep`. Existing NEP5 models can still run with `gpumd`. The major reason for creating NEP5 is to enable the models trained using `PWMLFF` to run with `gpumd`.
