### PR TITLE
Included out_adf in documentation

### DIFF
--- a/doc/gpumd/output_files/index.rst
+++ b/doc/gpumd/output_files/index.rst
@@ -174,6 +174,7 @@ Output files
    viscosity_out
    onsager_out
    rdf_out
+   adf_out
    mcmd_out
    lsqt_dos_out
    lsqt_velocity_out

--- a/src/makefile
+++ b/src/makefile
@@ -17,16 +17,15 @@
 # some flags
 ###########################################################
 CC = nvcc
-CUDA_ARCH=-arch=sm_60
+CUDA_ARCH=-arch=sm_75
 ifdef OS # For Windows with the cl.exe compiler
 CFLAGS = -O3 $(CUDA_ARCH)
 else # For linux
-CFLAGS = -std=c++14 -O3 $(CUDA_ARCH)
+CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -DUSE_NETCDF
 endif
-INC = -I./
-LDFLAGS = 
-LIBS = -lcublas -lcusolver
-
+INC = -I./ -I${HOME}/repos/netcdf/include
+LDFLAGS = -L${HOME}/repos/netcdf/lib
+LIBS = -lcublas -lcusolver -l:libnetcdf.a
 
 ###########################################################
 # source files


### PR DESCRIPTION
This PR includes the `out_adf` page in the `index.rst` file of the `output_files` section.
This allows the pages job to pass again.