### PR TITLE
update doc related to NEP version

### DIFF
--- a/doc/bibliography.rst
+++ b/doc/bibliography.rst
@@ -227,6 +227,12 @@ Bibliography
    | GECCO '11 (Association for Computing Machinery), New York, USA (2011), pp. 845–852
    | DOI: `10.1145/2001576.2001692 <https://doi.org/10.1145/2001576.2001692>`_
 
+.. [Song2024]
+   | Keke Song, Rui Zhao, Jiahui Liu, Yanzhou Wang, Eric Lindgren, Yong Wang, Shunda Chen, Ke Xu, Ting Liang, Penghua Ying, Nan Xu, Zhiqiang Zhao, Jiuyang Shi, Junjie Wang, Shuang Lyu, Zezhu Zeng, Shirong Liang, Haikuan Dong, Ligang Sun, Yue Chen, Zhuhua Zhang, Wanlin Guo, Ping Qian, Jian Sun, Paul Erhart, Tapio Ala-Nissila, Yanjing Su, and Zheyong Fan
+   | *General-purpose machine-learned potential for 16 elemental metals and their alloys*
+   | Nature Communications *15*, 10208 (2024)
+   | DOI: `10.1038/s41467-024-54554-x <https://doi.org/10.1038/s41467-024-54554-x>`_
+
 .. [Tersoff1988]
    | Jerry Tersoff
    | *New empirical approach for the structure and energy of covalent systems*

--- a/doc/nep/input_files/nep_in.rst
+++ b/doc/nep/input_files/nep_in.rst
@@ -6,8 +6,8 @@
 ==========
 
 This file specifies hyperparameters used for training neuroevolution potential (:term:`NEP`) models, the functional form of which is outline :ref:`here <nep_formalism>`.
-The :term:`NEP` approach was proposed in [Fan2021]_ (NEP1) and later improved in [Fan2022a]_ (NEP2) and [Fan2022b]_ (NEP3).
-Currently, we support NEP3, NEP4 (to be published), and NEP5 (to be published), which can be chosen by the :ref:`version keyword <kw_version>`.
+The :term:`NEP` approach was proposed in [Fan2021]_ (NEP1) and later improved in [Fan2022a]_ (NEP2), [Fan2022b]_ (NEP3), and [Song2024]_ (NEP4).
+Currently, we support NEP3 and NEP4, which can be chosen by the :ref:`version keyword <kw_version>`.
 
 File format
 -----------

--- a/doc/nep/input_parameters/version.rst
+++ b/doc/nep/input_parameters/version.rst
@@ -10,7 +10,7 @@ The syntax is::
 
   version <version_number>
 
-Here, :attr:`<version_number>` must be an integer, which can be 3 or 4 or 5, corresponding to NEP3, NEP4, and NEP5, respectively.
+Here, :attr:`<version_number>` must be an integer, which can be 3 or 4, corresponding to NEP3 and NEP4, respectively.
 The default is 4.
 
 More information about the :term:`NEP` formalism can be found :ref:`here <nep_formalism>`.

--- a/doc/potentials/nep.rst
+++ b/doc/potentials/nep.rst
@@ -5,10 +5,10 @@
 Neuroevolution potential
 ************************
 
-The neuroevolution potential (:term:`NEP`) approach was proposed in [Fan2021]_ (NEP1) and later improved in [Fan2022a]_ (NEP2) and [Fan2022b]_ (NEP3).
-Currently, :program:`GPUMD` supports NEP3, NEP4 (to be published), and NEP5 (to be published).
-All versions have comparable accuracy for single-component systems.
-For multi-component systems, NEP4 and NEP5 usually have higher accuracy, if all the other hyperparameters are the same.
+The neuroevolution potential (:term:`NEP`) approach was proposed in [Fan2021]_ (NEP1) and later improved in [Fan2022a]_ (NEP2), [Fan2022b]_ (NEP3), and [Song2024]_ (NEP4).
+Currently, :program:`GPUMD` only supports NEP3 and NEP4, as NEP1 and NEP2 are deprecated.
+Both versions are identical for single-component systems.
+For multi-component systems, NEP4 usually has higher accuracy, if all the other hyperparameters are the same.
 
 :program:`GPUMD` not only allows one to carry out simulations using :term:`NEP` models via the :ref:`gpumd executable <gpumd_executable>` but even the construction of such models via the :ref:`nep executable <nep_executable>`.
 
@@ -123,8 +123,6 @@ Model dimensions
      - :math:`N_\mathrm{nn} = (N_\mathrm{des} +2) N_\mathrm{neu}+1` (NEP3)
    * -
      - :math:`N_\mathrm{nn} = (N_\mathrm{des} +2) N_\mathrm{neu} N_\mathrm{typ}+1` (NEP4)
-   * -
-     - :math:`N_\mathrm{nn} = ((N_\mathrm{des} +2) N_\mathrm{neu} + 1) N_\mathrm{typ}+1` (NEP5)
 
 The total number of trainable parameters is the sum of the number of trainable descriptor parameters and the number of :term:`NN` parameters :math:`N_\mathrm{nn}`.
 


### PR DESCRIPTION
At some point in master after GPUMD-v3.9.5, I introduced NEP5, but found it not beneficial now. So I want to remove it from the documentation (this PR) and training part (already done). It is still kept in the MD part as some external code would like to run MD with it.

I just don't encourage users to train NEP5.
