### PR TITLE
Add ADF to glossary to fix pages job

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -5,6 +5,9 @@ Glossary
 
 .. glossary::
 
+   ADF
+        angle distribution function
+
    ARDF
         angular-dependent radial distribution function
 


### PR DESCRIPTION
This PR adds the abbreviation ADF to the glossary. This fixes the failing pages job.