### PR TITLE
Fix a potential float overflow problem for ILPs

### DIFF
--- a/src/force/ilp_nep_gr_hbn.cu
+++ b/src/force/ilp_nep_gr_hbn.cu
@@ -751,23 +751,25 @@ inline static __device__ void calc_vdW(
   float &f2_vdW)
 {
   float r2inv, r6inv, r8inv;
-  float TSvdw, TSvdwinv, Vilp;
+  double TSvdw, TSvdwinv_double;
+  float Vilp, TSvdwinv_float;
   float fpair, fsum;
 
   r2inv = 1.0f / rsq;
   r6inv = r2inv * r2inv * r2inv;
   r8inv = r2inv * r6inv;
 
-  // TODO: use float
   // TSvdw = 1.0 + exp(-d_Seff * r + d);
-  TSvdw = 1.0f + expf(-d_Seff * r + d);
-  TSvdwinv = 1.0f / TSvdw;
-  Vilp = -C_6 * r6inv * TSvdwinv;
+  // use double to avoid inf from exp function
+  TSvdw = 1.0 + exp((double) (-d_Seff * r + d));
+  TSvdwinv_double = 1.0 / TSvdw;
+  TSvdwinv_float = (float) TSvdwinv_double;
+  Vilp = -C_6 * r6inv * TSvdwinv_float;
 
   // derivatives
   // fpair = -6.0 * C_6 * r8inv * TSvdwinv + \
   //   C_6 * d_Seff * (TSvdw - 1.0) * TSvdwinv * TSvdwinv * r8inv * r;
-  fpair = (-6.0f + d_Seff * (TSvdw - 1.0f) * TSvdwinv * r ) * C_6 * TSvdwinv * r8inv;
+  fpair = (-6.0f + d_Seff * (1.0f - TSvdwinv_float) * r ) * C_6 * TSvdwinv_float * r8inv;
   fsum = fpair * Tap - Vilp * dTap * rinv;
 
   p2_vdW = Tap * Vilp;

--- a/src/force/ilp_nep_tmd.cu
+++ b/src/force/ilp_nep_tmd.cu
@@ -799,7 +799,8 @@ static __device__ void calc_vdW(
   float &f2_vdW)
 {
   float r2inv, r6inv, r8inv;
-  float TSvdw, TSvdwinv, Vilp;
+  double TSvdw, TSvdwinv_double;
+  float Vilp, TSvdwinv_float;
   float fpair, fsum;
 
   r2inv = 1.0f / rsq;
@@ -807,14 +808,16 @@ static __device__ void calc_vdW(
   r8inv = r2inv * r6inv;
 
   // TSvdw = 1.0 + exp(-d_Seff * r + d);
-  TSvdw = 1.0f + expf(-d_Seff * r + d);
-  TSvdwinv = 1.0f / TSvdw;
-  Vilp = -C_6 * r6inv * TSvdwinv;
+  // use double to avoid inf from exp function
+  TSvdw = 1.0 + exp((double) (-d_Seff * r + d));
+  TSvdwinv_double = 1.0 / TSvdw;
+  TSvdwinv_float = (float) TSvdwinv_double;
+  Vilp = -C_6 * r6inv * TSvdwinv_float;
 
   // derivatives
   // fpair = -6.0 * C_6 * r8inv * TSvdwinv + \
   //   C_6 * d_Seff * (TSvdw - 1.0) * TSvdwinv * TSvdwinv * r8inv * r;
-  fpair = (-6.0f + d_Seff * (TSvdw - 1.0f) * TSvdwinv * r ) * C_6 * TSvdwinv * r8inv;
+  fpair = (-6.0f + d_Seff * (1.0f - TSvdwinv_float) * r ) * C_6 * TSvdwinv_float * r8inv;
   fsum = fpair * Tap - Vilp * dTap * rinv;
 
   p2_vdW = Tap * Vilp;


### PR DESCRIPTION
## Summary
The `expf` function is called in `calc_vdW` function. However, parameter `d` of some materials is a little big, nearly 300. So the datatype **float** is not safe because its max value is about $2^{128}$. The **float** `TSvdw` may overflow and be calculated as **inf** then make `TSvdwinv` be calculated as **nan**. Hence, `TSvdw` and `TSvdwinv` need to be defined as **double**.

## Modification
Define `TSvdw` and `TSvdwinv` as **double** in three ILP files and use a **float** value to save `TSvdwinv` for the next computation.

## Others
This PR fix a potential bug in #761 #835 #860 .