### PR TITLE
Fix typo for ADF documentation

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -8,6 +8,9 @@ Glossary
    ACE
         atomic cluster expansion [Drautz2019]_
 
+   ADF
+        angular distribution function
+
    BDP
         :ref:`Bussi-Donadio-Parrinello thermostat <bdp_thermostat>` [Bussi2007b]_
 

--- a/doc/gpumd/input_parameters/compute_adf.rst
+++ b/doc/gpumd/input_parameters/compute_adf.rst
@@ -5,25 +5,25 @@
 :attr:`compute_adf`
 ===================
 
-This keyword computes the angular distribution function (:term:`ADF`) for all atoms or specific triples of species. Each ADF is represented as a histogram, created by measuring the angles formed between a central atom and two neighboring atoms, and binning these angles into `num_bins` bins. Only neighbors with distances `rc_min < R < rc_max` are considered, where `rc_min` and `rc_max` are specified separately for the first and second neighbor atoms in each ADF calculation.
+This keyword computes the angular distribution function (:term:`ADF`) for all atoms or specific triples of species. Each :term:`ADF` is represented as a histogram, created by measuring the angles formed between a central atom and two neighboring atoms, and binning these angles into `num_bins` bins. Only neighbors with distances `rc_min < R < rc_max` are considered, where `rc_min` and `rc_max` are specified separately for the first and second neighbor atoms in each :term:`ADF` calculation.
 Currently, this feature is only available for classical :term:`MD`.
 The results are written to the :ref:`adf.out <adf_out>` file.
 
 Syntax
 ------
 
-For global ADF, the keyword is used as follows::
+For global :term:`ADF`, the keyword is used as follows::
 
   compute_adf <interval> <num_bins> <rc_min> <rc_max>
 
 This means the :term:`ADF` calculations will be performed every :attr:`interval` steps, with :attr:`num_bins` data points.
 
-For local ADF, the keyword is used as follows::
+For local :term:`ADF`, the keyword is used as follows::
 
   compute_adf <interval> <num_bins> <itype1> <jtype1> <ktype1> <rc_min_j1> <rc_max_j1> <rc_min_k1> <rc_max_k1> ...
 
 This means the :term:`ADF` calculations will be performed every :attr:`interval` steps, with :attr:`num_bins` data points. 
-The angle formed by the central atom I and neighboring atoms J and K is included in the ADF if the following conditions are met:
+The angle formed by the central atom I and neighboring atoms J and K is included in the :term:`ADF` if the following conditions are met:
 
 - The distance between atoms I and J is between `rc_min_jN` and `rc_max_jN`.
 - The distance between atoms I and K is between `rc_min_kN` and `rc_max_kN`.
@@ -32,11 +32,11 @@ The angle formed by the central atom I and neighboring atoms J and K is included
 - The type of atom K matches `ktypeN`.
 - Atoms I, J, and K are distinct.
 
-The ADF value for a bin is computed by dividing the histogram count by the total number of triples that satisfy the criteria, ensuring that the integral of the ADF with respect to the angle is 1. In other words, the ADF is a probability density function.
+The :term:`ADF` value for a bin is computed by dividing the histogram count by the total number of triples that satisfy the criteria, ensuring that the integral of the :term:`ADF` with respect to the angle is 1. In other words, the :term:`ADF` is a probability density function.
 
 Example
 -------
 
-   compute_rdf 100 30 0.0 1.2  # Total ADF every 100 MD steps with 30 data points for bond lengths between 0.0 and 1.2
-   compute_rdf 500 50 0 1 1 0.0 1.2 0.0 1.3  # Calculate 0-1-1 ADF every 500 MD steps with 50 data points for I-J bond lengths between 0.0 and 1.2, and I-K bond lengths between 0.0 and 1.3
-   compute_rdf 500 50 0 1 1 0.0 1.2 0.0 1.3 1 0 1 0.0 1.2 0.0 1.3  # Calculate 0-1-1 and 1-0-1 ADF every 500 MD steps with 50 data points
+  - compute_adf 100 30 0.0 1.2  # Total :term:`ADF` every 100 MD steps with 30 data points for bond lengths between 0.0 and 1.2
+  - compute_adf 500 50 0 1 1 0.0 1.2 0.0 1.3  # Calculate 0-1-1 :term:`ADF` every 500 MD steps with 50 data points for I-J bond lengths between 0.0 and 1.2, and I-K bond lengths between 0.0 and 1.3
+  - compute_adf 500 50 0 1 1 0.0 1.2 0.0 1.3 1 0 1 0.0 1.2 0.0 1.3  # Calculate 0-1-1 and 1-0-1 :term:`ADF` every 500 MD steps with 50 data points

--- a/doc/gpumd/output_files/adf_out.rst
+++ b/doc/gpumd/output_files/adf_out.rst
@@ -11,9 +11,11 @@ It is generated when the :ref:`compute_adf keyword <kw_compute_adf>` is used.
 File Format
 -------------
 For global ADF, the data in this file are organized as follows:
-* Column 1: Angles (in degrees)
-* Column 2: The (:term:`ADF`) for the entire system
+
+- Column 1: Angles (in degrees)
+- Column 2: The (:term:`ADF`) for the entire system
 
 For local ADF, the data are organized as follows:
-* Column 1: Angles (in degrees)
-* The next Ntriples columns: The (:term:`ADF`) for each specific atom triple
+
+- Column 1: Angles (in degrees)
+- The next Ntriples columns: The (:term:`ADF`) for each specific atom triple

--- a/doc/gpumd/output_files/index.rst
+++ b/doc/gpumd/output_files/index.rst
@@ -145,7 +145,8 @@ Output files
 .. toctree::
    :maxdepth: 0
    :caption: Contents
-
+   
+   adf_out
    cohesive_out
    compute_out
    D_out


### PR DESCRIPTION
This PR fixes a typo in the ADF documentation. I have tested it locally, and the output is now as follows:

![image](https://github.com/user-attachments/assets/4a6bc35e-cfb2-406c-ac67-2ef7fe1b2b2f)
![image](https://github.com/user-attachments/assets/2294b25c-ad03-43e3-9ee3-00663eb4f867)
