### PR TITLE
Revised the 'installation' section related to NETCDF and the corresponding main program changes

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -5,17 +5,14 @@ Glossary
 
 .. glossary::
 
+   ACE
+        atomic cluster expansion [Drautz2019]_
+
    ADF
         angle distribution function
 
    ARDF
         angular-dependent radial distribution function
-
-   ACE
-        atomic cluster expansion [Drautz2019]_
-
-   ADF
-        angular distribution function
 
    BDP
         :ref:`Bussi-Donadio-Parrinello thermostat <bdp_thermostat>` [Bussi2007b]_

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -9,7 +9,7 @@ Glossary
         atomic cluster expansion [Drautz2019]_
 
    ADF
-        angle distribution function
+        angular distribution function
 
    ARDF
         angular-dependent radial distribution function

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -49,9 +49,14 @@ The setup instructions are below:
 
   .. code:: bash
 
-     ./configure --prefix=/home/alex/netcdf --disable-netcdf-4 --disable-dap
+     ./configure --prefix=<path> --disable-netcdf-4 --disable-dap
 
-  Here, the :attr:`--prefix` determines the output directory of the build.
+  Here, the :attr:`--prefix` determines the output directory of the build. Then make and install PLUMED:
+
+  .. code:: bash
+
+     make -j && make install
+
 * Enable the NetCDF functionality.
   To do this, one must enable the :attr:`USE_NETCDF` flag.
   In the makefile, this will look as follows:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -58,7 +58,7 @@ The setup instructions are below:
 
   .. code:: make
 
-     CFLAGS = -std=c++11 -O3 -arch=sm_75 -DUSE_NETCDF
+     CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -DUSE_NETCDF
 
   In addition to that line the makefile must also be updated to the following:
 
@@ -92,7 +92,7 @@ The setup instructions are below:
 
   .. code:: bash
 
-     ./configure --prefix=/home/user/plumed --disable-mpi --enable-openmp --enable-modules=all
+     ./configure --prefix=<path> --disable-mpi --enable-openmp --enable-modules=all
 
   Here, the :attr:`--prefix` determines the output directory of the build. Then make and install PLUMED:
 
@@ -115,13 +115,13 @@ The setup instructions are below:
 
   .. code:: make
 
-     CFLAGS = -std=c++11 -O3 -arch=sm_75 -DUSE_PLUMED
+     CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -DUSE_PLUMED
 
   In addition to that line the makefile must also be updated to the following:
 
   .. code:: make
 
-     INC = -I<path>/include
+     INC = -I<path>/include -I./
      LDFLAGS = -L<path>/lib -lplumed -lplumedKernel
 
   where :attr:`<path>` should be replaced with the installation path for PLUMED (defined in :attr:`--prefix` of the ``./configure`` command).

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -103,7 +103,7 @@ The setup instructions are below:
 
   .. code:: bash
 
-     make && make install
+     make -j8 && make install
 
   Then update your environment variables (e.g., add the following lines to your bashrc file):
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -69,9 +69,9 @@ The setup instructions are below:
 
   .. code:: make
 
-     INC = -I<path>/netcdf/include -I./
-     LDFLAGS = -L<path>/netcdf/lib
-     LIBS = -l:libnetcdf.a
+     INC = -I<path>/include -I./
+     LDFLAGS = -L<path>/lib
+     LIBS = -lcublas -lcusolver -l:libnetcdf.a
 
   where :attr:`<path>` should be replaced with the installation path for NetCDF (defined in :attr:`--prefix` of the ``./configure`` command).
 * Follow the remaining :program:`GPUMD` installation instructions

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -51,7 +51,7 @@ The setup instructions are below:
 
      ./configure --prefix=<path> --disable-netcdf-4 --disable-dap
 
-  Here, the :attr:`--prefix` determines the output directory of the build. Then make and install PLUMED:
+  Here, the :attr:`--prefix` determines the output directory of the build. Then make and install NetCDF:
 
   .. code:: bash
 
@@ -103,7 +103,7 @@ The setup instructions are below:
 
   .. code:: bash
 
-     make -j8 && make install
+     make -j6 && make install
 
   Then update your environment variables (e.g., add the following lines to your bashrc file):
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -64,7 +64,7 @@ The setup instructions are below:
 
   .. code:: make
 
-     INC = -I<path>/netcdf/include
+     INC = -I<path>/netcdf/include -I./
      LDFLAGS = -L<path>/netcdf/lib
      LIBS = -l:libnetcdf.a
 

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -334,6 +334,10 @@ void DUMP_NETCDF::write(
     cell_lengths[0] = box.cpu_h[0];
     cell_lengths[1] = box.cpu_h[4];
     cell_lengths[2] = box.cpu_h[8];
+
+    cell_angles[0] = 90;
+    cell_angles[1] = 90;
+    cell_angles[2] = 90;
   }
 
   // Set lengths to 0 if PBC is off

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -314,7 +314,8 @@ void DUMP_NETCDF::write(
   // Get cell lengths and angles
   double cell_lengths[3];
   double cell_angles[3];
-  if (box.triclinic) {
+  if (box.cpu_h[1] != 0 || box.cpu_h[2] != 0 || box.cpu_h[3] != 0 ||
+      box.cpu_h[5] != 0 || box.cpu_h[6] != 0 || box.cpu_h[7] != 0) {
     const double* t = box.cpu_h;
     double cosgamma, cosbeta, cosalpha;
     cell_lengths[0] = sqrt(t[0] * t[0] + t[3] * t[3] + t[6] * t[6]); // a-side
@@ -331,12 +332,8 @@ void DUMP_NETCDF::write(
 
   } else {
     cell_lengths[0] = box.cpu_h[0];
-    cell_lengths[1] = box.cpu_h[1];
-    cell_lengths[2] = box.cpu_h[2];
-
-    cell_angles[0] = 90;
-    cell_angles[1] = 90;
-    cell_angles[2] = 90;
+    cell_lengths[1] = box.cpu_h[4];
+    cell_lengths[2] = box.cpu_h[8];
   }
 
   // Set lengths to 0 if PBC is off


### PR DESCRIPTION
**Summary**

Revise the `NetCDF/PLUMED Setup Instructions` and main program code related to `dump netcdf`.
There are also warnings encountered when compiling the `doc` directory.

I have done the compilation of the include main program as well as compiling the doc using sphinx, both pass with no errors and warnings.

**Modification**

1. During the compilation process, one need to pay attention to the statement problem in the makefile of `dump netcdf` keyword,

`INC = -I<path>/include -I./`

A similar issue was fixed in the `PLUMED Setup Instructions`.

2. Error encountered during the compilation process about:

`measure/dump_netcdf.cu(317): error: class "Box" has no member "triclinic"`

After modifying two parts in measure/dump_netcdf.cu, it was successfully compiled.

**Others**

Warning encountered during document compilation:

`${GPUMD}/doc/glossary.rst:16: WARNING: duplicate term description of ADF, other instance in glossary`

Deleted duplicate ADF keywords and sorted them.