### PR TITLE
add option for deform without lateral pressure control

### DIFF
--- a/doc/gpumd/input_parameters/deform.rst
+++ b/doc/gpumd/input_parameters/deform.rst
@@ -39,5 +39,7 @@ Caveats
 -------
 * Currently, one must use the NPT ensemble when using this keyword.
   That is, the code assumes that the pressure components in the directions which are not deformed will be controlled.
+  If one does not want to control the pressure (box) in a direction that is not deformed, 
+  one can set the elastic constant for that direction to be larger than 2000 GPa.
 * In the equilibration stage, it is also recommended to use the NPT ensemble to obtain the zero strain state before applying the deformation.
 * One must control the three pressure components independently when using this keyword.

--- a/doc/gpumd/input_parameters/ensemble_standard.rst
+++ b/doc/gpumd/input_parameters/ensemble_standard.rst
@@ -90,6 +90,7 @@ with three different options for specifying :attr:`pressure_control_parameters`:
   
   It is sufficient for the elastic constant tensor :attr:`C_ab` to be a (very rough) estimate as long as it is of the right magnitude.
   It is used to convert the coupling constant (or relaxation time, see :ref:`here <choice_of_parameters>`) of the barostat into suitable internal units.
+  If a elastic constant component exceeds 2000 GPa, the coupling constant for that component will be zero and that box component will not be changed. 
 
 :attr:`npt_scr`
 ^^^^^^^^^^^^^^^

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -553,6 +553,9 @@ void Integrate::parse_ensemble(
     }
     for (int i = 0; i < 6; i++) {
       pressure_coupling[i] = 1.0 / (tau_p * 3.0 * elastic_modulus[i]);
+      if (elastic_modulus[i] > 2.0e3) {
+        pressure_coupling[i] = 0.0;
+      }
     }
   }
 
@@ -726,6 +729,9 @@ void Integrate::parse_ensemble(
         }
         for (int i = 0; i < 6; i++) {
           pressure_coupling[i] = 1.0 / (tau_p * 3.0 * elastic_modulus[i]);
+          if (elastic_modulus[i] > 2.0e3) {
+            pressure_coupling[i] = 0.0;
+          }
         }
       }
     }


### PR DESCRIPTION
If you don't want to control the pressure (box) in a lateral direciton, you can set the elastic constant for that direction to be larger than 2000 GPa:

```
ensemble    npt_ber 300 300 100 0 0 0 1000 10000 1000 1000    
dump_thermo 100

# deform in the x direction; 
# box in y direction will not be changed (elastic constant is set to 10000 GPa > 2000 GPa) 
# but box in z direction could be changed due to Poisson effect (elastic constant is set to 1000 GPa < 2000 GPa) 
deform 1.0e-3 1 0 0      
run         10000
```

This effectively solved issue #677 
