### PR TITLE
Fix bug: include stdint lib for some macros

### DIFF
--- a/src/force/ilp_nep.cuh
+++ b/src/force/ilp_nep.cuh
@@ -18,6 +18,7 @@
 #include "utilities/common.cuh"
 #include "utilities/gpu_vector.cuh"
 #include <stdio.h>
+#include <cstdint>
 #include <vector>
 
 // C, h-BN, TMD


### PR DESCRIPTION
**Summary**
Some macros (i.e., UINTPTR_MAX, uintptr_t) defined in **stdint.h** lib are missing in **ilp_nep.cuh** file.

**Modification**
Add this lib.

**Others**
None.