### PR TITLE
Update Doc

### DIFF
--- a/doc/gpumd/input_parameters/minimize.rst
+++ b/doc/gpumd/input_parameters/minimize.rst
@@ -67,7 +67,7 @@ means that one wants to optimize box using hydrostatic strain during the energy 
 
 Example 5
 ^^^^^^^^^^^^^
-If you want to ouput the optimized structure, use `dump_exyz` in the `nve` ensamble like the following command::
+If you want to ouput the optimized structure, use `dump_exyz` in the `nve` ensemble like the following command::
 
   minimize fire 1.0e-5 1000 1
   ensemble    nve

--- a/doc/gpumd/input_parameters/minimize.rst
+++ b/doc/gpumd/input_parameters/minimize.rst
@@ -70,8 +70,10 @@ Example 5
 If you want to ouput the optimized structure, use `dump_xyz` in the `nve` ensemble like the following command::
 
   minimize fire 1.0e-5 1000 1
+
   ensemble    nve
-  dump_xyz    -1 0 1 dump.xyz
+  time_step   0
+  dump_xyz    -1 0 1 relaxed.xyz
   run         1
 
 Caveats

--- a/doc/gpumd/input_parameters/minimize.rst
+++ b/doc/gpumd/input_parameters/minimize.rst
@@ -65,9 +65,16 @@ The command::
 
 means that one wants to optimize box using hydrostatic strain during the energy minimization process.
 
+Example 5
+^^^^^^^^^^^^^
+If you want to ouput the optimized structure, use `dump_exyz` in the `nve` ensamble like the following command::
+
+  minimize fire 1.0e-5 1000 1
+  ensemble    nve
+  dump_exyz   1
+  run         1
 
 Caveats
 -------
 
 * This keyword should occur after the :ref:`potential keyword <kw_potential>`.
-* Currently, the simulation box is fixed during the energy minimization.

--- a/doc/gpumd/input_parameters/minimize.rst
+++ b/doc/gpumd/input_parameters/minimize.rst
@@ -66,12 +66,12 @@ The command::
 means that one wants to optimize box using hydrostatic strain during the energy minimization process.
 
 Example 5
-^^^^^^^^^^^^^
-If you want to ouput the optimized structure, use `dump_exyz` in the `nve` ensemble like the following command::
+^^^^^^^^^
+If you want to ouput the optimized structure, use `dump_xyz` in the `nve` ensemble like the following command::
 
   minimize fire 1.0e-5 1000 1
   ensemble    nve
-  dump_exyz   1
+  dump_xyz    -1 0 1 dump.xyz
   run         1
 
 Caveats


### PR DESCRIPTION
This pull request updates the documentation for the `minimize` command in the `gpumd` project by adding an example and clarifying the output process. 

Documentation updates:

* [`doc/gpumd/input_parameters/minimize.rst`](diffhunk://#diff-a76cad8ca4c0f6ae916833b33ff6ef0048216dbbd58523e67bf913fcf2c8559cR68-L73): Added "Example 5" to demonstrate how to output the optimized structure using the `dump_exyz` command in the `nve` ensemble during energy minimization. This example includes a sample command sequence for clarity.

