### PR TITLE
Modify the script for extracting the training set from Abacus' log file

### DIFF
--- a/tools/Format_Conversion/abacus2xyz/multipleFrames-abacus2nep-exyz.sh
+++ b/tools/Format_Conversion/abacus2xyz/multipleFrames-abacus2nep-exyz.sh
@@ -2,13 +2,13 @@
 ### HOW TO USE #################################################################################
 ### SYNTAX: ./multipleFrames-abacus2nep-exyz.sh dire_name
 ###     NOTE: 1).'dire_name' is the directory containing running_md.log and MD_dump file.
-### Email: tang070205@proton.me if any questions
-### Modified by Yuwen Zhang, Shunda Chen, Zihan Yan
+### Email: yanzhowang@gmail.com if any questions
+### Modified by multipleFrames-outcars2nep-exyz.sh
 ### Modified by Benrui Tang
 ################################################################################################
 #--- DEFAULT ASSIGNMENTS ---------------------------------------------------------------------
 isol_ener=0     # Shifted energy, specify the value?
-stress_logi=0     # Logical value for virial, true=1, false=0
+viri_logi=1     # Logical value for virial, true=1, false=0
 #--------------------------------------------------------------------------------------------
 read_dire=$1
 if [ -z "$read_dire" ]; then
@@ -22,37 +22,45 @@ rm -rf $writ_dire; mkdir $writ_dire
 configuration=$(pwd | awk -F'/' '{print $(NF-2)"/"$(NF-1)"/"$NF}')
 syst_numb_atom=$(grep "TOTAL ATOM NUMBER" running_md.log |awk '{print $5}')
 ener_values=($(grep 'etot' running_md.log |awk '{print $4}'))
-if [[ $stress_logi -eq 1 ]]; then
-    mdstep_lines=($(grep -n 'MDSTEP' MD_dump | awk -F: '{print $1+12+'$syst_numb_atom'}'))
-else
-    mdstep_lines=($(grep -n 'MDSTEP' MD_dump | awk -F: '{print $1+9+'$syst_numb_atom'}'))
-fi
-N_counts=$(( ${#mdstep_lines[@]} - 1 ))
+scf_lines=($(grep -n 'STEP OF MOLECULAR DYNAMICS' running_md.log | awk -F: '{print $1}'))
+scf_last=$(wc -l < running_md.log)
+scf_lines+=($scf_last)
+scf_nmax=$(grep 'scf_nmax' INPUT | awk '{print $2}')
+mdstep_lines=($(grep -n 'MDSTEP' MD_dump | awk -F: '{print $1}'))
+mdstep_last=$(wc -l < MD_dump)
+mdstep_lines+=($mdstep_last)
+N_counts=$(( ${#mdstep_lines[@]} - 2 ))
 
 
-for ((i=1; i<${#mdstep_lines[@]}; i++)); do
-    start_line=${mdstep_lines[i-1]}
-    end_line=${mdstep_lines[i]}
+for ((i=1; i<$(( ${#mdstep_lines[@]} - 1 )); i++)); do
     ener=${ener_values[i]}
 
-    sed -n "${start_line},${end_line}p" MD_dump > temp.file
+    scf_start=${scf_lines[i]}
+    scf_end=${scf_lines[i+1]}
+    scf_act=$(sed -n "${scf_start},${scf_end}p" running_md.log | grep -c "ALGORITHM")
+    if [ "$scf_act" -eq "$scf_nmax" ]; then
+        echo "Skipping the $i structure due to non convergence"
+        echo -ne "Process: ${i}/${N_counts}\r"
+        continue
+    fi
+
+    md_start=${mdstep_lines[i]}
+    md_end=${mdstep_lines[i+1]}
+    sed -n "${md_start},${md_end}p" MD_dump > temp.file
     echo "$syst_numb_atom" >> "$writ_dire/$writ_file"
     latt=$(grep -A 3 "LATTICE_VECTORS" temp.file | tail -n 3 | awk '{for (i = 1; i <= NF; i++) {printf "%.8f ", $i}}' |xargs)
-    if [[ $stress_logi -eq 1 ]]; then
-        stress=$(grep -A 3 "VIRIAL (kbar)" temp.file | tail -n 3 | awk '{for (i = 1; i <= NF; i++) {printf "%.8f ", $i * 0.1}}' |xargs)
-        echo "Config_type=$configuration Weight=1.0 Lattice=\"$latt\" Energy=$ener Stress=\"$stress\" pbc=\"T T T\" Properties=species:S:1:pos:R:3:forces:R:3" >> "$writ_dire/$writ_file"
+    conversion_value=$(echo "$latt" | awk '{a1=$1; a2=$2; a3=$3; b1=$4; b2=$5; b3=$6; c1=$7; c2=$8; c3=$9;
+        V=a1*(b2*c3 - b3*c2) + a2*(b3*c1 - b1*c3) + a3*(b1*c2 - b2*c1); if (V < 0) V=-V; printf "%.8f", V/1602.1766208}')
+    if [[ $viri_logi -eq 1 ]]; then
+        viri=$(grep -A 3 "VIRIAL (kbar)" temp.file | tail -n 3 | awk '{for (i = 1; i <= NF; i++) {printf "%.8f ", $i * '$conversion_value'}}' |xargs)
+        echo "Energy=$ener Lattice=\"$latt\" Virial=\"$viri\" Config_type=$configuration-$i Weight=1.0 Properties=species:S:1:pos:R:3:forces:R:3" >> "$writ_dire/$writ_file"
     else
-        echo "Config_type=$configuration Weight=1.0 Lattice=\"$latt\" Energy=$ener Properties=species:S:1:pos:R:3:forces:R:3 pbc=\"T T T\"" >> "$writ_dire/$writ_file"
+        echo "Energy=$ener Lattice=\"$latt\" Config_type=$configuration-$i Weight=1.0 Properties=species:S:1:pos:R:3:forces:R:3" >> "$writ_dire/$writ_file"
     fi
-    grep -A $(($syst_numb_atom)) "INDEX" temp.file | tail -n $syst_numb_atom | awk '{print $2}' >$writ_dire/symb.tem
-    grep -A $(($syst_numb_atom)) "INDEX" temp.file | tail -n $syst_numb_atom | awk '{for (i=3; i<=8; i++) printf "%.8f ", $i; printf "\n"}' > $writ_dire/posi_force.tem
-    paste $writ_dire/symb.tem $writ_dire/posi_force.tem >> $writ_dire/$writ_file
-    #grep -A $(($syst_numb_atom)) "INDEX" temp.file | tail -n $syst_numb_atom | awk '{print $2,$3,$4,$5,$6,$7,$8}' >$writ_dire/$writ_file
-    rm -f $writ_dire/*.tem
+    grep -A $syst_numb_atom "INDEX" temp.file | tail -n $syst_numb_atom | awk '{print $2,$3,$4,$5,$6,$7,$8}' >> $writ_dire/$writ_file
     echo -ne "Process: ${i}/${N_counts}\r"
-    
+    rm -f temp.file
 done
-rm -f temp.file
 
 echo
 dos2unix "$writ_dire/$writ_file"

--- a/tools/Format_Conversion/abacus2xyz/singleFrame-abacus2nep-exyz.sh
+++ b/tools/Format_Conversion/abacus2xyz/singleFrame-abacus2nep-exyz.sh
@@ -8,7 +8,7 @@
 ################################################################################################
 #--- DEFAULT ASSIGNMENTSts ---------------------------------------------------------------------
 isol_ener=0     # Shifted energy, specify the value?
-stress_logi=1     # Logical value for virial, true=1, false=0
+viri_logi=1     # Logical value for virial, true=1, false=0
 #--------------------------------------------------------------------------------------------
 read_dire=$1
 if [ -z $read_dire ]; then
@@ -20,44 +20,46 @@ rm -rf $writ_dire; mkdir $writ_dire
 
 N_case=$(find -L $read_dire -name "running_scf.log" | wc -l)
 N_count=1
-for i in `find -L $read_dire -name "running_scf.log"`
-do
-	     configuration=$(echo "$i" |sed 's/\/running_scf.log//g' | awk -F'/' '{print $(NF-2)"/"$(NF-1)"/"$NF}')
-             syst_numb_atom=$(grep "TOTAL ATOM NUMBER" $i |awk '{print $5}')
-             echo $syst_numb_atom >> $writ_dire/$writ_file
-             latt=$(grep -A 3 "Lattice vectors" $i | tail -n 3 | sed 's/+//g' | awk '{ for (i=1; i<=NF; i++) printf "%.8f ", $i}')
-             ener=$(grep "FINAL_ETOT_IS" $i | awk '{printf "%.6f\n", $2 - '$syst_numb_atom' * '$isol_ener'}')
-             if [ $stress_logi -eq 1 ]
-             then
-                   stress=$(grep -A 4 "TOTAL-STRESS" $i | tail -n 3 | awk '{for (i = 1; i <= NF; i++) {printf "%.8f ", $i * 0.1}}' |xargs)
-                   echo Energy=$ener Lattice=\"$latt\" Stress=\"$stress\" "Config_type=$configuration Weight=1.0 Properties=species:S:1:pos:R:3:forces:R:3" >> $writ_dire/$writ_file
-             else
-                   echo Energy=$ener Lattice=\"$latt\" "Config_type=$configuration Weight=1.0 Properties=species:S:1:pos:R:3:forces:R:3" >> $writ_dire/$writ_file
-             fi
-             if grep -q "taud" "$i"
-             then
-               if grep -q "NORM" "$i"
-               then
-                 cell_a=$(grep "NORM_A" $i | awk '{print $3}')
-                 cell_b=$(grep "NORM_B" $i | awk '{print $3}')
-                 cell_c=$(grep "NORM_C" $i | awk '{print $3}')
-               else
-                 cell_a=$(grep "_cell_length_a" "$(dirname "$i")/STRU.cif" | awk '{print $2}')
-                 cell_b=$(grep "_cell_length_b" "$(dirname "$i")/STRU.cif" | awk '{print $2}')
-                 cell_c=$(grep "_cell_length_c" "$(dirname "$i")/STRU.cif" | awk '{print $2}')
-               fi
-               grep "tauc" $i | awk '{printf "%.8f %.8f %.8f\n", $2*'$cell_a', $3*'$cell_b', $4*'$cell_c'}' > $writ_dire/position.tem
-             else
-               grep "tauc" $i | awk '{printf "%.8f %.8f %.8f\n", $2, $3, $4}' > $writ_dire/position.tem
-             fi
-             grep -A $(($syst_numb_atom + 1)) "TOTAL-FORCE" $i | tail -n $syst_numb_atom | awk '{print $1}' | sed 's/[0-9]//g' >>$writ_dire/symb.tem
-             grep -A $(($syst_numb_atom + 1)) "TOTAL-FORCE" $i | tail -n $syst_numb_atom |awk '{printf "%.8f %.8f %.8f\n", $2,$3,$4}' > $writ_dire/force.tem
-             paste $writ_dire/symb.tem $writ_dire/position.tem $writ_dire/force.tem >> $writ_dire/$writ_file
-             rm -f $writ_dire/*.tem
-             echo -ne "Progress: $N_count/$N_case \r"
-             N_count=$((N_count + 1))
+for i in `find -L "$read_dire" -name "running_scf.log"`; do
+    configuration=$(echo "$i" | sed 's/\/running_scf.log//g' | awk -F'/' '{print $(NF-2)"/"$(NF-1)"/"$NF}')
+    scf_act=$(grep -c "ALGORITHM" "$i")
+    scf_nmax=$(grep 'scf_nmax' "$(dirname "$i")/INPUT" | awk '{print $2}')
+    if [ "$scf_act" -eq "$scf_nmax" ] || ! grep -q "FINAL_ETOT_IS" "$i"; then
+    echo "Directory of incomplete or non-converged locations: $(dirname "$(realpath "$i")")"
+    continue
+    fi
+
+    syst_numb_atom=$(grep "TOTAL ATOM NUMBER" "$i" | awk '{print $5}')
+    echo "$syst_numb_atom" >> "$writ_dire/$writ_file"
+    latt=$(grep -A 3 "Lattice vectors" "$i" | tail -n 3 | sed 's/+//g' | awk '{ for (i=1; i<=NF; i++) printf "%.8f ", $i}')
+    ener=$(grep "FINAL_ETOT_IS" "$i" | awk '{printf "%.6f\n", $2 - '$syst_numb_atom' * '$isol_ener'}')
+
+    if [ "$viri_logi" -eq 1 ]; then
+        conversion_value=$(grep "Volume (A^3)" "$i" | awk '{print $4/1602.1766208}')
+        viri=$(grep -A 4 "TOTAL-STRESS" "$i" | tail -n 3 | awk '{for (i = 1; i <= NF; i++) {printf "%.8f ", $i * '$conversion_value'}}' | xargs)
+        echo "Energy=$ener Lattice=\"$latt\" Virial=\"$viri\" Config_type=$configuration Weight=1.0 Properties=species:S:1:pos:R:3:forces:R:3" >> "$writ_dire/$writ_file"
+    else
+        echo "Energy=$ener Lattice=\"$latt\" Config_type=$configuration Weight=1.0 Properties=species:S:1:pos:R:3:forces:R:3" >> "$writ_dire/$writ_file"
+    fi
+
+    if grep -q "taud" "$i"; then
+        cell_a=$(grep "_cell_length_a" "$(dirname "$i")/STRU.cif" | awk '{print $2}')
+        cell_b=$(grep "_cell_length_b" "$(dirname "$i")/STRU.cif" | awk '{print $2}')
+        cell_c=$(grep "_cell_length_c" "$(dirname "$i")/STRU.cif" | awk '{print $2}')
+        grep "taud" "$i" | awk '{printf "%.8f %.8f %.8f\n", $2*'$cell_a', $3*'$cell_b', $4*'$cell_c'}' > "$writ_dire/position.tem"
+    else
+        grep "tauc" "$i" | awk '{printf "%.8f %.8f %.8f\n", $2, $3, $4}' > "$writ_dire/position.tem"
+    fi
+
+    grep -A $(($syst_numb_atom + 1)) "TOTAL-FORCE" "$i" | tail -n "$syst_numb_atom" | awk '{print $1}' | sed 's/[0-9]//g' >> "$writ_dire/symb.tem"
+    grep -A $(($syst_numb_atom + 1)) "TOTAL-FORCE" "$i" | tail -n "$syst_numb_atom" | awk '{printf "%.8f %.8f %.8f\n", $2,$3,$4}' > "$writ_dire/force.tem"
+    paste "$writ_dire/symb.tem" "$writ_dire/position.tem" "$writ_dire/force.tem" >> "$writ_dire/$writ_file"
+
+    rm -f "$writ_dire"/*.tem
+    echo -ne "Progress: $N_count/$N_case \r"
+    N_count=$((N_count + 1))
 done
+
 echo
 dos2unix $writ_dire/$writ_file
 echo "All done."
-

--- a/tools/Format_Conversion/abacus2xyz/singleFrame-abacus2nep-exyz.sh
+++ b/tools/Format_Conversion/abacus2xyz/singleFrame-abacus2nep-exyz.sh
@@ -3,7 +3,7 @@
 ### SYNTAX: ./singleFrame-abacus2nep-exyz.sh dire_name   
 ###     NOTE: 1).'dire_name' is the directory containing running_scf.logs
 ### Email: tang070205@proton.me if have questions
-### Modified by Yanzhou Wang Shunda Chen 
+### Modified by singleFrame-outcars2nep-exyz.sh
 ### Modified by Benrui Tang
 ################################################################################################
 #--- DEFAULT ASSIGNMENTSts ---------------------------------------------------------------------


### PR DESCRIPTION
1、Change singleFrame-abacus2nep-exyz.sh to specify reading lattice constants from STRU.cif.
2、Add restrictions on whether the ion step converges or the calculation is completed in both files.