### PR TITLE
Update dump_thermo.cu to make the header of thermo.out output a single line

### DIFF
--- a/src/measure/dump_thermo.cu
+++ b/src/measure/dump_thermo.cu
@@ -58,24 +58,25 @@ void Dump_Thermo::preprocess(
 {
   fid_ = my_fopen("thermo.out", "a");
   // header
-  fprintf(fid_, "# col 1: T K\n");
-  fprintf(fid_, "# col 2: K eV\n");
-  fprintf(fid_, "# col 3: U eV\n");
-  fprintf(fid_, "# col 4: Pxx GPa\n");
-  fprintf(fid_, "# col 5: Pyy GPa\n");
-  fprintf(fid_, "# col 6: Pzz GPa\n");
-  fprintf(fid_, "# col 7: Pyz GPa\n");
-  fprintf(fid_, "# col 8: Pzx GPa\n");
-  fprintf(fid_, "# col 9: Pxy GPa\n");
-  fprintf(fid_, "# col 10: ax A\n");
-  fprintf(fid_, "# col 11: ay A\n");
-  fprintf(fid_, "# col 12: az A\n");
-  fprintf(fid_, "# col 13: bx A\n");
-  fprintf(fid_, "# col 14: by A\n");
-  fprintf(fid_, "# col 15: bz A\n");
-  fprintf(fid_, "# col 16: cx A\n");
-  fprintf(fid_, "# col 17: cy A\n");
-  fprintf(fid_, "# col 18: cz A\n");
+  fprintf(fid_, "# ");
+  fprintf(fid_, "T(K) "); // col 1
+  fprintf(fid_, "K(eV) "); // col 2
+  fprintf(fid_, "U(eV) "); // col 3
+  fprintf(fid_, "Pxx(GPa) "); // col 4
+  fprintf(fid_, "Pyy(GPa) "); // col 5
+  fprintf(fid_, "Pzz(GPa) "); // col 6
+  fprintf(fid_, "Pyz(GPa) "); // col 7
+  fprintf(fid_, "Pzx(GPa) "); // col 8
+  fprintf(fid_, "Pxy(GPa) "); // col 9
+  fprintf(fid_, "ax(A) "); // col 10
+  fprintf(fid_, "ay(A) "); // col 11
+  fprintf(fid_, "az(A) "); // col 12
+  fprintf(fid_, "bx(A) "); // col 13
+  fprintf(fid_, "by(A) "); // col 14
+  fprintf(fid_, "bz(A) "); // col 15
+  fprintf(fid_, "cx(A) "); // col 16
+  fprintf(fid_, "cy(A) "); // col 17
+  fprintf(fid_, "cz(A)\n"); // col 18
 }
 
 void Dump_Thermo::process(

--- a/src/measure/dump_thermo.cu
+++ b/src/measure/dump_thermo.cu
@@ -57,26 +57,6 @@ void Dump_Thermo::preprocess(
   Force& force)
 {
   fid_ = my_fopen("thermo.out", "a");
-  // header
-  fprintf(fid_, "# ");
-  fprintf(fid_, "T(K) "); // col 1
-  fprintf(fid_, "K(eV) "); // col 2
-  fprintf(fid_, "U(eV) "); // col 3
-  fprintf(fid_, "Pxx(GPa) "); // col 4
-  fprintf(fid_, "Pyy(GPa) "); // col 5
-  fprintf(fid_, "Pzz(GPa) "); // col 6
-  fprintf(fid_, "Pyz(GPa) "); // col 7
-  fprintf(fid_, "Pzx(GPa) "); // col 8
-  fprintf(fid_, "Pxy(GPa) "); // col 9
-  fprintf(fid_, "ax(A) "); // col 10
-  fprintf(fid_, "ay(A) "); // col 11
-  fprintf(fid_, "az(A) "); // col 12
-  fprintf(fid_, "bx(A) "); // col 13
-  fprintf(fid_, "by(A) "); // col 14
-  fprintf(fid_, "bz(A) "); // col 15
-  fprintf(fid_, "cx(A) "); // col 16
-  fprintf(fid_, "cy(A) "); // col 17
-  fprintf(fid_, "cz(A)\n"); // col 18
 }
 
 void Dump_Thermo::process(


### PR DESCRIPTION
the header of thermo.out is changed from
```# col 1: T K
# col 2: K eV
# col 3: U eV
# col 4: Pxx GPa
# col 5: Pyy GPa
# col 6: Pzz GPa
# col 7: Pyz GPa
# col 8: Pzx GPa
# col 9: Pxy GPa
# col 10: ax A
# col 11: ay A
# col 12: az A
# col 13: bx A
# col 14: by A
# col 15: bz A
# col 16: cx A
# col 17: cy A
# col 18: cz A```
<img width="1061" alt="微信图片_20250425135911" src="https://github.com/user-attachments/assets/41f3ae31-ddca-4617-a947-938157166211" />

to

```# T(K) K(eV) U(eV) Pxx(GPa) Pyy(GPa) Pzz(GPa) Pyz(GPa) Pzx(GPa) Pxy(GPa) ax(A) ay(A) az(A) bx(A) by(A) bz(A) cx(A) cy(A) cz(A)```
<img width="1067" alt="1微信图片_20250425140014" src="https://github.com/user-attachments/assets/9219c1b0-6a7b-4be9-9073-bed691ea063f" />


The test directory is ${GPUMD}/examples/gpumd_dynamic