### PR TITLE
add index for doc atomic_v

### DIFF
--- a/doc/nep/input_parameters/atomic_v.rst
+++ b/doc/nep/input_parameters/atomic_v.rst
@@ -5,7 +5,7 @@
 :attr:`atomic_v`
 ================
 
-This keyword sets the mode :math:`\atomic_v` of whether to fit atomic or global quantities for dipole (`model_type = 1`) or polarizability (`model_type = 2`). Only one of atomic and global can be fitted at a time. Fitting both simultaneously is not supported. For the virial tensor (`model_type = 0`), only the global model is supported. 
+This keyword sets the mode `\atomic_v` of whether to fit atomic or global quantities for dipole (`model_type = 1`) or polarizability (`model_type = 2`). Only one of atomic and global can be fitted at a time. Fitting both simultaneously is not supported. For the virial tensor (`model_type = 0`), only the global model is supported. 
 The syntax is::
 
   atomic_v <mode>

--- a/doc/nep/input_parameters/index.rst
+++ b/doc/nep/input_parameters/index.rst
@@ -29,6 +29,7 @@ Below you can find a listing of keywords for the ``nep.in`` input file.
    lambda_e
    lambda_f
    lambda_v
+   atomic_v
    lambda_shear
    force_delta
    batch


### PR DESCRIPTION
**Summary**
This PR fixes the issue that `atomic_v` is not included in `index.rst` of `input_parameters` of the document.

**Modification**
Changed `doc/nep/input_parameters/index.rst`.

**Others**
