### PR TITLE
Fix compilation error of plumed plugin 

### DIFF
--- a/src/measure/plumed.cu
+++ b/src/measure/plumed.cu
@@ -185,8 +185,8 @@ void PLUMED::process(
   std::vector<double> tmp(6);
   step += interval;
 
-  atom.force.copy_to_host(cpu_f_vector.data());
-  atom.position.copy_to_host(cpu_q_vector.data());
+  atom.force_per_atom.copy_to_host(cpu_f_vector.data());
+  atom.position_per_atom.copy_to_host(cpu_q_vector.data());
 
   cpu_b_vector[0] = box.cpu_h[0];
   cpu_b_vector[1] = box.cpu_h[3];
@@ -198,7 +198,7 @@ void PLUMED::process(
   cpu_b_vector[7] = box.cpu_h[5];
   cpu_b_vector[8] = box.cpu_h[8];
 
-  gpu_sum<<<6, 1024>>>(n_atom, atom.virial.data(), gpu_v_vector.data());
+  gpu_sum<<<6, 1024>>>(n_atom, atom.virial_per_atom.data(), gpu_v_vector.data());
   GPU_CHECK_KERNEL
   gpu_v_vector.copy_to_host(tmp.data());
   fill(cpu_v_vector.begin(), cpu_v_vector.end(), 0.0);
@@ -218,7 +218,7 @@ void PLUMED::process(
   plumed_cmd(plumed_main, "getBias", &bias_energy);
   plumed_cmd(plumed_main, "setStopFlag", &stop_flag);
 
-  force.copy_from_host(cpu_f_vector.data());
+  atom.force_per_atom.copy_from_host(cpu_f_vector.data());
 
   cpu_v_factor[0] = (tmp[0] - cpu_v_vector[0]) / tmp[0];
   cpu_v_factor[1] = (tmp[3] - cpu_v_vector[1]) / tmp[3];
@@ -233,12 +233,12 @@ void PLUMED::process(
   gpu_scale_virial<<<(n_atom - 1) / 128 + 1, 128>>>(
     n_atom,
     gpu_v_factor.data(),
-    atom.virial.data() + n_atom * 0,
-    atom.virial.data() + n_atom * 1,
-    atom.virial.data() + n_atom * 2,
-    atom.virial.data() + n_atom * 3,
-    atom.virial.data() + n_atom * 4,
-    atom.virial.data() + n_atom * 5);
+    atom.virial_per_atom.data() + n_atom * 0,
+    atom.virial_per_atom.data() + n_atom * 1,
+    atom.virial_per_atom.data() + n_atom * 2,
+    atom.virial_per_atom.data() + n_atom * 3,
+    atom.virial_per_atom.data() + n_atom * 4,
+    atom.virial_per_atom.data() + n_atom * 5);
   GPU_CHECK_KERNEL
 }
 

--- a/src/measure/plumed.cuh
+++ b/src/measure/plumed.cuh
@@ -19,7 +19,6 @@
 #include "property.cuh"
 #include "integrate/integrate.cuh"
 #include "force/potential.cuh"
-#include "force/force.cuh"
 #include <plumed/wrapper/Plumed.h>
 #include <stdio.h>
 #include <vector>

--- a/src/measure/plumed.cuh
+++ b/src/measure/plumed.cuh
@@ -17,7 +17,9 @@
 
 #pragma once
 #include "property.cuh"
+#include "integrate/integrate.cuh"
 #include "force/potential.cuh"
+#include "force/force.cuh"
 #include <plumed/wrapper/Plumed.h>
 #include <stdio.h>
 #include <vector>


### PR DESCRIPTION
**Summary**
Aim to fix issue #1007 .

**Modification**
1. Add the head file path of class `Integrate` to `plumed.cuh` file.
2. Change the variables name of class `Atom`.

|before | force| position|virial|
|---|---|---|---|
|after|force_per_atom|position_per_atom|virial_per_atom|

**TODO**
More tests are needed to ensure consistent simulation results.