### PR TITLE
reduce upper bounds of hyperparameters

### DIFF
--- a/doc/nep/input_parameters/basis_size.rst
+++ b/doc/nep/input_parameters/basis_size.rst
@@ -11,7 +11,7 @@ The syntax is::
   basis_size <N_bas_R> <N_bas_A>
 
 where :attr:`<N_bas_R>` and :attr:`<N_bas_A>` set :math:`N_\mathrm{bas}^\mathrm{R}` and :math:`N_\mathrm{bas}^\mathrm{A}`, respectively.
-The parameters must satisfy :math:`0 \leq N_\mathrm{bas}^\mathrm{R},N_\mathrm{bas}^\mathrm{A} \leq 19`.
+The parameters must satisfy :math:`0 \leq N_\mathrm{bas}^\mathrm{R} \leq 16` and :math:`0 \leq N_\mathrm{bas}^\mathrm{A} \leq 12`.
 
 The default values of :math:`N_\mathrm{bas}^\mathrm{R}=8` and :math:`N_\mathrm{bas}^\mathrm{A}=8` are usually sufficient.
 

--- a/doc/nep/input_parameters/l_max.rst
+++ b/doc/nep/input_parameters/l_max.rst
@@ -16,6 +16,6 @@ The latter two arguments are optional (as indicated by the curly brackets).
 If there is one value :math:`l_\mathrm{max}^\mathrm{4b}=l_\mathrm{max}^\mathrm{5b}=0`.
 If there are two values :math:`l_\mathrm{max}^\mathrm{5b}=0`.
 
-:math:`l_\mathrm{max}^\mathrm{3b}` can take values from 0 to 8, :math:`l_\mathrm{max}^\mathrm{4b}` can be 0 or 2, and :math:`l_\mathrm{max}^\mathrm{5b}` can be 0 or 1. It is also required to have :math:`l_\mathrm{max}^\mathrm{3b} \geq l_\mathrm{max}^\mathrm{4b} \geq l_\mathrm{max}^\mathrm{5b}`.
+:math:`l_\mathrm{max}^\mathrm{3b}` can take values from 0 to 4, :math:`l_\mathrm{max}^\mathrm{4b}` can be 0 or 2, and :math:`l_\mathrm{max}^\mathrm{5b}` can be 0 or 1. It is also required to have :math:`l_\mathrm{max}^\mathrm{3b} \geq l_\mathrm{max}^\mathrm{4b} \geq l_\mathrm{max}^\mathrm{5b}`.
 
 The default values are :math:`l_\mathrm{max}^\mathrm{3b}=4`, :math:`l_\mathrm{max}^\mathrm{4b}=2`, and :math:`l_\mathrm{max}^\mathrm{5b}=0`.

--- a/doc/nep/input_parameters/l_max.rst
+++ b/doc/nep/input_parameters/l_max.rst
@@ -16,6 +16,6 @@ The latter two arguments are optional (as indicated by the curly brackets).
 If there is one value :math:`l_\mathrm{max}^\mathrm{4b}=l_\mathrm{max}^\mathrm{5b}=0`.
 If there are two values :math:`l_\mathrm{max}^\mathrm{5b}=0`.
 
-:math:`l_\mathrm{max}^\mathrm{3b}` can take values from 0 to 4, :math:`l_\mathrm{max}^\mathrm{4b}` can be 0 or 2, and :math:`l_\mathrm{max}^\mathrm{5b}` can be 0 or 1. It is also required to have :math:`l_\mathrm{max}^\mathrm{3b} \geq l_\mathrm{max}^\mathrm{4b} \geq l_\mathrm{max}^\mathrm{5b}`.
+:math:`l_\mathrm{max}^\mathrm{3b}` can take values from 0 to 8, :math:`l_\mathrm{max}^\mathrm{4b}` can be 0 or 2, and :math:`l_\mathrm{max}^\mathrm{5b}` can be 0 or 1. It is also required to have :math:`l_\mathrm{max}^\mathrm{3b} \geq l_\mathrm{max}^\mathrm{4b} \geq l_\mathrm{max}^\mathrm{5b}`.
 
 The default values are :math:`l_\mathrm{max}^\mathrm{3b}=4`, :math:`l_\mathrm{max}^\mathrm{4b}=2`, and :math:`l_\mathrm{max}^\mathrm{5b}=0`.

--- a/doc/nep/input_parameters/n_max.rst
+++ b/doc/nep/input_parameters/n_max.rst
@@ -11,7 +11,7 @@ The syntax is::
   n_max <n_max_R> <n_max_A>
 
 where :attr:`n_max_R` and :attr:`n_max_A` are :math:`n_\mathrm{max}^\mathrm{R}` and :math:`n_\mathrm{max}^\mathrm{A}`, respectively.
-The two parameters must satisfy :math:`0 \leq n_\mathrm{max}^\mathrm{R},n_\mathrm{max}^\mathrm{A} \leq 19`.
+The two parameters must satisfy :math:`0 \leq n_\mathrm{max}^\mathrm{R} \leq 12` and :math:`0 \leq n_\mathrm{max}^\mathrm{A} \leq 8`.
 
 The default values of :math:`n_\mathrm{max}^\mathrm{R}=4` and :math:`n_\mathrm{max}^\mathrm{A}=4` are relatively small but typically yield high speed.
 

--- a/doc/nep/input_parameters/neuron.rst
+++ b/doc/nep/input_parameters/neuron.rst
@@ -11,7 +11,7 @@ The syntax is::
   neuron <number_of_neurons>
 
 where :attr:`<number_of_neurons>` corresponds to :math:`N_\mathrm{neu}` in the :ref:`NEP formalism <nep_formalism>` [Fan2022b]_.
-Values must satisfy :math:`1 \leq N_\mathrm{neu} \leq 200`.
+Values must satisfy :math:`1 \leq N_\mathrm{neu} \leq 120`.
 
 The default value is 30, which is relatively small but can lead to relatively high speed.
 Larger values rarely lead to a notable improvement.

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -886,8 +886,8 @@ void Parameters::parse_l_max(const char** param, int num_param)
   if (L_max < 0) {
     PRINT_INPUT_ERROR("l_max for 3-body descriptors should >= 0.");
   }
-  if (L_max > 4) {
-    PRINT_INPUT_ERROR("l_max for 3-body descriptors should <= 4.");
+  if (L_max > 8) {
+    PRINT_INPUT_ERROR("l_max for 3-body descriptors should <= 8.");
   }
 
   if (num_param >= 3) {

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -838,13 +838,13 @@ void Parameters::parse_n_max(const char** param, int num_param)
   }
   if (n_max_radial < 0) {
     PRINT_INPUT_ERROR("n_max_radial should >= 0.");
-  } else if (n_max_radial > 19) {
-    PRINT_INPUT_ERROR("n_max_radial should <= 19.");
+  } else if (n_max_radial > 12) {
+    PRINT_INPUT_ERROR("n_max_radial should <= 12.");
   }
   if (n_max_angular < 0) {
     PRINT_INPUT_ERROR("n_max_angular should >= 0.");
-  } else if (n_max_angular > 19) {
-    PRINT_INPUT_ERROR("n_max_angular should <= 19.");
+  } else if (n_max_angular > 8) {
+    PRINT_INPUT_ERROR("n_max_angular should <= 8.");
   }
 }
 
@@ -863,13 +863,13 @@ void Parameters::parse_basis_size(const char** param, int num_param)
   }
   if (basis_size_radial < 0) {
     PRINT_INPUT_ERROR("basis_size_radial should >= 0.");
-  } else if (basis_size_radial > 19) {
-    PRINT_INPUT_ERROR("basis_size_radial should <= 19.");
+  } else if (basis_size_radial > 16) {
+    PRINT_INPUT_ERROR("basis_size_radial should <= 16.");
   }
   if (basis_size_angular < 0) {
     PRINT_INPUT_ERROR("basis_size_angular should >= 0.");
-  } else if (basis_size_angular > 19) {
-    PRINT_INPUT_ERROR("basis_size_angular should <= 19.");
+  } else if (basis_size_angular > 12) {
+    PRINT_INPUT_ERROR("basis_size_angular should <= 12.");
   }
 }
 
@@ -886,8 +886,8 @@ void Parameters::parse_l_max(const char** param, int num_param)
   if (L_max < 0) {
     PRINT_INPUT_ERROR("l_max for 3-body descriptors should >= 0.");
   }
-  if (L_max > 8) {
-    PRINT_INPUT_ERROR("l_max for 3-body descriptors should <= 8.");
+  if (L_max > 4) {
+    PRINT_INPUT_ERROR("l_max for 3-body descriptors should <= 4.");
   }
 
   if (num_param >= 3) {

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -928,8 +928,8 @@ void Parameters::parse_neuron(const char** param, int num_param)
   }
   if (num_neurons1 < 1) {
     PRINT_INPUT_ERROR("number of neurons should >= 1.");
-  } else if (num_neurons1 > 200) {
-    PRINT_INPUT_ERROR("number of neurons should <= 200.");
+  } else if (num_neurons1 > 120) {
+    PRINT_INPUT_ERROR("number of neurons should <= 120.");
   }
 }
 

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -15,14 +15,28 @@
 
 #pragma once
 
-const int NUM_OF_ABC = 24; // 3 + 5 + 7 + 9 for L_max = 4
+const int NUM_OF_ABC = 80; // 3 + 5 + 7 + 9 + 11 + 13 + 15 + 17 for L_max = 8
 __constant__ float C3B[NUM_OF_ABC] = {
   0.238732414637843f, 0.119366207318922f, 0.119366207318922f, 0.099471839432435f,
   0.596831036594608f, 0.596831036594608f, 0.149207759148652f, 0.149207759148652f,
   0.139260575205408f, 0.104445431404056f, 0.104445431404056f, 1.044454314040563f,
   1.044454314040563f, 0.174075719006761f, 0.174075719006761f, 0.011190581936149f,
   0.223811638722978f, 0.223811638722978f, 0.111905819361489f, 0.111905819361489f,
-  1.566681471060845f, 1.566681471060845f, 0.195835183882606f, 0.195835183882606f};
+  1.566681471060845f, 1.566681471060845f, 0.195835183882606f, 0.195835183882606f,
+  0.013677377921960f, 0.102580334414698f, 0.102580334414698f, 2.872249363611549f,
+  2.872249363611549f, 0.119677056817148f, 0.119677056817148f, 2.154187022708661f,
+  2.154187022708661f, 0.215418702270866f, 0.215418702270866f, 0.004041043476943f,
+  0.169723826031592f, 0.169723826031592f, 0.106077391269745f, 0.106077391269745f,
+  0.424309565078979f, 0.424309565078979f, 0.127292869523694f, 0.127292869523694f,
+  2.800443129521260f, 2.800443129521260f, 0.233370260793438f, 0.233370260793438f,
+  0.004662742473395f, 0.004079899664221f, 0.004079899664221f, 0.024479397985326f,
+  0.024479397985326f, 0.012239698992663f, 0.012239698992663f, 0.538546755677165f,
+  0.538546755677165f, 0.134636688919291f, 0.134636688919291f, 3.500553911901575f,
+  3.500553911901575f, 0.250039565135827f, 0.250039565135827f, 0.000082569397966f,
+  0.005944996653579f, 0.005944996653579f, 0.104037441437634f, 0.104037441437634f,
+  0.762941237209318f, 0.762941237209318f, 0.114441185581398f, 0.114441185581398f,
+  5.950941650232678f, 5.950941650232678f, 0.141689086910302f, 0.141689086910302f,
+  4.250672607309055f, 4.250672607309055f, 0.265667037956816f, 0.265667037956816f};
 __constant__ float C4B[5] = {
   -0.007499480826664f,
   -0.134990654879954f,
@@ -49,6 +63,44 @@ __constant__ float Z_COEFFICIENT_4[5][5] = {
   {0.0f, 1.0f, 0.0f, 0.0f, 0.0f},
   {1.0f, 0.0f, 0.0f, 0.0f, 0.0f}};
 
+__constant__ float Z_COEFFICIENT_5[6][6] = {
+  {0.0f, 15.0f, 0.0f, -70.0f, 0.0f, 63.0f},
+  {1.0f, 0.0f, -14.0f, 0.0f, 21.0f, 0.0f},
+  {0.0f, -1.0f, 0.0f, 3.0f, 0.0f, 0.0f},
+  {-1.0f, 0.0f, 9.0f, 0.0f, 0.0f, 0.0f},
+  {0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+  {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}};
+
+__constant__ float Z_COEFFICIENT_6[7][7] = {
+  {-5.0f, 0.0f, 105.0f, 0.0f, -315.0f, 0.0f, 231.0f},
+  {0.0f, 5.0f, 0.0f, -30.0f, 0.0f, 33.0f, 0.0f},
+  {1.0f, 0.0f, -18.0f, 0.0f, 33.0f, 0.0f, 0.0f},
+  {0.0f, -3.0f, 0.0f, 11.0f, 0.0f, 0.0f, 0.0f},
+  {-1.0f, 0.0f, 11.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+  {0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+  {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}};
+
+__constant__ float Z_COEFFICIENT_7[8][8] = {
+  {0.0f, -35.0f, 0.0f, 315.0f, 0.0f, -693.0f, 0.0f, 429.0f},
+  {-5.0f, 0.0f, 135.0f, 0.0f, -495.0f, 0.0f, 429.0f, 0.0f},
+  {0.0f, 15.0f, 0.0f, -110.0f, 0.0f, 143.0f, 0.0f, 0.0f},
+  {3.0f, 0.0f, -66.0f, 0.0f, 143.0f, 0.0f, 0.0f, 0.0f},
+  {0.0f, -3.0f, 0.0f, 13.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+  {-1.0f, 0.0f, 13.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+  {0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+  {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}};
+
+__constant__ float Z_COEFFICIENT_8[9][9] = {
+  {35.0f, 0.0f, -1260.0f, 0.0f, 6930.0f, 0.0f, -12012.0f, 0.0f, 6435.0f},
+  {0.0f, -35.0f, 0.0f, 385.0f, 0.0f, -1001.0f, 0.0f, 715.0f, 0.0f},
+  {-1.0f, 0.0f, 33.0f, 0.0f, -143.0f, 0.0f, 143.0f, 0.0f, 0.0f},
+  {0.0f, 3.0f, 0.0f, -26.0f, 0.0f, 39.0f, 0.0f, 0.0f, 0.0f},
+  {1.0f, 0.0f, -26.0f, 0.0f, 65.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+  {0.0f, -1.0f, 0.0f, 5.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+  {-1.0f, 0.0f, 15.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+  {0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+  {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}};
+
 __constant__ float COVALENT_RADIUS[94] = {
   0.426667f, 0.613333f, 1.6f,     1.25333f, 1.02667f, 1.0f,     0.946667f, 0.84f,    0.853333f,
   0.893333f, 1.86667f,  1.66667f, 1.50667f, 1.38667f, 1.46667f, 1.36f,     1.32f,    1.28f,
@@ -64,8 +116,8 @@ __constant__ float COVALENT_RADIUS[94] = {
 
 const int SIZE_BOX_AND_INVERSE_BOX = 18; // (3 * 3) * 2
 const int MAX_NUM_N = 17;                // basis_size_radial+1 = 16+1
-const int MAX_DIM = 67;                  // 13 + 9 * 6
-const int MAX_DIM_ANGULAR = 54;          // 9 * 6
+const int MAX_DIM = 103;                 // 13 + 9 * 10
+const int MAX_DIM_ANGULAR = 90;          // 9 * 10
 
 static __device__ __forceinline__ void
 complex_product(const float a, const float b, float& real_part, float& imag_part)
@@ -571,6 +623,30 @@ static __device__ __forceinline__ void accumulate_f12_one(
           dz_factor += Z_COEFFICIENT_4[n1][n2] * n2 * z_pow[n2 - 1];
         }
       }
+      if (L == 5) {
+        z_factor += Z_COEFFICIENT_5[n1][n2] * z_pow[n2];
+        if (n2 > 0) {
+          dz_factor += Z_COEFFICIENT_5[n1][n2] * n2 * z_pow[n2 - 1];
+        }
+      }
+      if (L == 6) {
+        z_factor += Z_COEFFICIENT_6[n1][n2] * z_pow[n2];
+        if (n2 > 0) {
+          dz_factor += Z_COEFFICIENT_6[n1][n2] * n2 * z_pow[n2 - 1];
+        }
+      }
+      if (L == 7) {
+        z_factor += Z_COEFFICIENT_7[n1][n2] * z_pow[n2];
+        if (n2 > 0) {
+          dz_factor += Z_COEFFICIENT_7[n1][n2] * n2 * z_pow[n2 - 1];
+        }
+      }
+      if (L == 8) {
+        z_factor += Z_COEFFICIENT_8[n1][n2] * z_pow[n2];
+        if (n2 > 0) {
+          dz_factor += Z_COEFFICIENT_8[n1][n2] * n2 * z_pow[n2 - 1];
+        }
+      }
     }
     if (n1 == 0) {
       for (int d = 0; d < 3; ++d) {
@@ -655,6 +731,30 @@ static __device__ __forceinline__ void accumulate_f12(
     calculate_s_one<4>(n, n_max_angular_plus_1, Fp, sum_fxyz, s4);
     accumulate_f12_one<4>(d12inv, fn_original, fnp_original, s4, r12unit, f12);
   }
+
+  if (L_max >= 5) {
+    float s5[11];
+    calculate_s_one<5>(n, n_max_angular_plus_1, Fp, sum_fxyz, s5);
+    accumulate_f12_one<5>(d12inv, fn_original, fnp_original, s5, r12unit, f12);
+  }
+
+  if (L_max >= 6) {
+    float s6[13];
+    calculate_s_one<6>(n, n_max_angular_plus_1, Fp, sum_fxyz, s6);
+    accumulate_f12_one<6>(d12inv, fn_original, fnp_original, s6, r12unit, f12);
+  }
+
+  if (L_max >= 7) {
+    float s7[15];
+    calculate_s_one<7>(n, n_max_angular_plus_1, Fp, sum_fxyz, s7);
+    accumulate_f12_one<7>(d12inv, fn_original, fnp_original, s7, r12unit, f12);
+  }
+
+  if (L_max >= 8) {
+    float s8[17];
+    calculate_s_one<8>(n, n_max_angular_plus_1, Fp, sum_fxyz, s8);
+    accumulate_f12_one<8>(d12inv, fn_original, fnp_original, s8, r12unit, f12);
+  }
 }
 
 template <int L>
@@ -683,6 +783,18 @@ accumulate_s_one(const float x12, const float y12, const float z12, const float 
       }
       if (L == 4) {
         z_factor += Z_COEFFICIENT_4[n1][n2] * z_pow[n2];
+      }
+      if (L == 5) {
+        z_factor += Z_COEFFICIENT_5[n1][n2] * z_pow[n2];
+      }
+      if (L == 6) {
+        z_factor += Z_COEFFICIENT_6[n1][n2] * z_pow[n2];
+      }
+      if (L == 7) {
+        z_factor += Z_COEFFICIENT_7[n1][n2] * z_pow[n2];
+      }
+      if (L == 8) {
+        z_factor += Z_COEFFICIENT_8[n1][n2] * z_pow[n2];
       }
     }
     z_factor *= fn;
@@ -714,6 +826,18 @@ static __device__ __forceinline__ void accumulate_s(
   }
   if (L_max >= 4) {
     accumulate_s_one<4>(x12, y12, z12, fn, s);
+  }
+  if (L_max >= 5) {
+    accumulate_s_one<5>(x12, y12, z12, fn, s);
+  }
+  if (L_max >= 6) {
+    accumulate_s_one<6>(x12, y12, z12, fn, s);
+  }
+  if (L_max >= 7) {
+    accumulate_s_one<7>(x12, y12, z12, fn, s);
+  }
+  if (L_max >= 8) {
+    accumulate_s_one<8>(x12, y12, z12, fn, s);
   }
 }
 
@@ -750,6 +874,18 @@ static __device__ __forceinline__ void find_q(
   }
   if (L_max >= 4) {
     q[3 * n_max_angular_plus_1 + n] = find_q_one<4>(s);
+  }
+  if (L_max >= 5) {
+    q[4 * n_max_angular_plus_1 + n] = find_q_one<5>(s);
+  }
+  if (L_max >= 6) {
+    q[5 * n_max_angular_plus_1 + n] = find_q_one<6>(s);
+  }
+  if (L_max >= 7) {
+    q[6 * n_max_angular_plus_1 + n] = find_q_one<7>(s);
+  }
+  if (L_max >= 8) {
+    q[7 * n_max_angular_plus_1 + n] = find_q_one<8>(s);
   }
   if (num_L >= L_max + 1) {
     q[L_max * n_max_angular_plus_1 + n] =

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -15,28 +15,14 @@
 
 #pragma once
 
-const int NUM_OF_ABC = 80; // 3 + 5 + 7 + 9 + 11 + 13 + 15 + 17 for L_max = 8
+const int NUM_OF_ABC = 24; // 3 + 5 + 7 + 9 for L_max = 4
 __constant__ float C3B[NUM_OF_ABC] = {
   0.238732414637843f, 0.119366207318922f, 0.119366207318922f, 0.099471839432435f,
   0.596831036594608f, 0.596831036594608f, 0.149207759148652f, 0.149207759148652f,
   0.139260575205408f, 0.104445431404056f, 0.104445431404056f, 1.044454314040563f,
   1.044454314040563f, 0.174075719006761f, 0.174075719006761f, 0.011190581936149f,
   0.223811638722978f, 0.223811638722978f, 0.111905819361489f, 0.111905819361489f,
-  1.566681471060845f, 1.566681471060845f, 0.195835183882606f, 0.195835183882606f,
-  0.013677377921960f, 0.102580334414698f, 0.102580334414698f, 2.872249363611549f,
-  2.872249363611549f, 0.119677056817148f, 0.119677056817148f, 2.154187022708661f,
-  2.154187022708661f, 0.215418702270866f, 0.215418702270866f, 0.004041043476943f,
-  0.169723826031592f, 0.169723826031592f, 0.106077391269745f, 0.106077391269745f,
-  0.424309565078979f, 0.424309565078979f, 0.127292869523694f, 0.127292869523694f,
-  2.800443129521260f, 2.800443129521260f, 0.233370260793438f, 0.233370260793438f,
-  0.004662742473395f, 0.004079899664221f, 0.004079899664221f, 0.024479397985326f,
-  0.024479397985326f, 0.012239698992663f, 0.012239698992663f, 0.538546755677165f,
-  0.538546755677165f, 0.134636688919291f, 0.134636688919291f, 3.500553911901575f,
-  3.500553911901575f, 0.250039565135827f, 0.250039565135827f, 0.000082569397966f,
-  0.005944996653579f, 0.005944996653579f, 0.104037441437634f, 0.104037441437634f,
-  0.762941237209318f, 0.762941237209318f, 0.114441185581398f, 0.114441185581398f,
-  5.950941650232678f, 5.950941650232678f, 0.141689086910302f, 0.141689086910302f,
-  4.250672607309055f, 4.250672607309055f, 0.265667037956816f, 0.265667037956816f};
+  1.566681471060845f, 1.566681471060845f, 0.195835183882606f, 0.195835183882606f};
 __constant__ float C4B[5] = {
   -0.007499480826664f,
   -0.134990654879954f,
@@ -63,44 +49,6 @@ __constant__ float Z_COEFFICIENT_4[5][5] = {
   {0.0f, 1.0f, 0.0f, 0.0f, 0.0f},
   {1.0f, 0.0f, 0.0f, 0.0f, 0.0f}};
 
-__constant__ float Z_COEFFICIENT_5[6][6] = {
-  {0.0f, 15.0f, 0.0f, -70.0f, 0.0f, 63.0f},
-  {1.0f, 0.0f, -14.0f, 0.0f, 21.0f, 0.0f},
-  {0.0f, -1.0f, 0.0f, 3.0f, 0.0f, 0.0f},
-  {-1.0f, 0.0f, 9.0f, 0.0f, 0.0f, 0.0f},
-  {0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-  {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}};
-
-__constant__ float Z_COEFFICIENT_6[7][7] = {
-  {-5.0f, 0.0f, 105.0f, 0.0f, -315.0f, 0.0f, 231.0f},
-  {0.0f, 5.0f, 0.0f, -30.0f, 0.0f, 33.0f, 0.0f},
-  {1.0f, 0.0f, -18.0f, 0.0f, 33.0f, 0.0f, 0.0f},
-  {0.0f, -3.0f, 0.0f, 11.0f, 0.0f, 0.0f, 0.0f},
-  {-1.0f, 0.0f, 11.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-  {0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-  {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}};
-
-__constant__ float Z_COEFFICIENT_7[8][8] = {
-  {0.0f, -35.0f, 0.0f, 315.0f, 0.0f, -693.0f, 0.0f, 429.0f},
-  {-5.0f, 0.0f, 135.0f, 0.0f, -495.0f, 0.0f, 429.0f, 0.0f},
-  {0.0f, 15.0f, 0.0f, -110.0f, 0.0f, 143.0f, 0.0f, 0.0f},
-  {3.0f, 0.0f, -66.0f, 0.0f, 143.0f, 0.0f, 0.0f, 0.0f},
-  {0.0f, -3.0f, 0.0f, 13.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-  {-1.0f, 0.0f, 13.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-  {0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-  {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}};
-
-__constant__ float Z_COEFFICIENT_8[9][9] = {
-  {35.0f, 0.0f, -1260.0f, 0.0f, 6930.0f, 0.0f, -12012.0f, 0.0f, 6435.0f},
-  {0.0f, -35.0f, 0.0f, 385.0f, 0.0f, -1001.0f, 0.0f, 715.0f, 0.0f},
-  {-1.0f, 0.0f, 33.0f, 0.0f, -143.0f, 0.0f, 143.0f, 0.0f, 0.0f},
-  {0.0f, 3.0f, 0.0f, -26.0f, 0.0f, 39.0f, 0.0f, 0.0f, 0.0f},
-  {1.0f, 0.0f, -26.0f, 0.0f, 65.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-  {0.0f, -1.0f, 0.0f, 5.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-  {-1.0f, 0.0f, 15.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-  {0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-  {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}};
-
 __constant__ float COVALENT_RADIUS[94] = {
   0.426667f, 0.613333f, 1.6f,     1.25333f, 1.02667f, 1.0f,     0.946667f, 0.84f,    0.853333f,
   0.893333f, 1.86667f,  1.66667f, 1.50667f, 1.38667f, 1.46667f, 1.36f,     1.32f,    1.28f,
@@ -115,9 +63,9 @@ __constant__ float COVALENT_RADIUS[94] = {
   2.02667f,  2.04f,     2.05333f, 2.06667f};
 
 const int SIZE_BOX_AND_INVERSE_BOX = 18; // (3 * 3) * 2
-const int MAX_NUM_N = 17;                // n_max+1 = 16+1
-const int MAX_DIM = MAX_NUM_N * 7;
-const int MAX_DIM_ANGULAR = MAX_NUM_N * 6;
+const int MAX_NUM_N = 17;                // basis_size_radial+1 = 16+1
+const int MAX_DIM = 67;                  // 13 + 9 * 6
+const int MAX_DIM_ANGULAR = 54;          // 9 * 6
 
 static __device__ __forceinline__ void
 complex_product(const float a, const float b, float& real_part, float& imag_part)
@@ -623,30 +571,6 @@ static __device__ __forceinline__ void accumulate_f12_one(
           dz_factor += Z_COEFFICIENT_4[n1][n2] * n2 * z_pow[n2 - 1];
         }
       }
-      if (L == 5) {
-        z_factor += Z_COEFFICIENT_5[n1][n2] * z_pow[n2];
-        if (n2 > 0) {
-          dz_factor += Z_COEFFICIENT_5[n1][n2] * n2 * z_pow[n2 - 1];
-        }
-      }
-      if (L == 6) {
-        z_factor += Z_COEFFICIENT_6[n1][n2] * z_pow[n2];
-        if (n2 > 0) {
-          dz_factor += Z_COEFFICIENT_6[n1][n2] * n2 * z_pow[n2 - 1];
-        }
-      }
-      if (L == 7) {
-        z_factor += Z_COEFFICIENT_7[n1][n2] * z_pow[n2];
-        if (n2 > 0) {
-          dz_factor += Z_COEFFICIENT_7[n1][n2] * n2 * z_pow[n2 - 1];
-        }
-      }
-      if (L == 8) {
-        z_factor += Z_COEFFICIENT_8[n1][n2] * z_pow[n2];
-        if (n2 > 0) {
-          dz_factor += Z_COEFFICIENT_8[n1][n2] * n2 * z_pow[n2 - 1];
-        }
-      }
     }
     if (n1 == 0) {
       for (int d = 0; d < 3; ++d) {
@@ -731,30 +655,6 @@ static __device__ __forceinline__ void accumulate_f12(
     calculate_s_one<4>(n, n_max_angular_plus_1, Fp, sum_fxyz, s4);
     accumulate_f12_one<4>(d12inv, fn_original, fnp_original, s4, r12unit, f12);
   }
-
-  if (L_max >= 5) {
-    float s5[11];
-    calculate_s_one<5>(n, n_max_angular_plus_1, Fp, sum_fxyz, s5);
-    accumulate_f12_one<5>(d12inv, fn_original, fnp_original, s5, r12unit, f12);
-  }
-
-  if (L_max >= 6) {
-    float s6[13];
-    calculate_s_one<6>(n, n_max_angular_plus_1, Fp, sum_fxyz, s6);
-    accumulate_f12_one<6>(d12inv, fn_original, fnp_original, s6, r12unit, f12);
-  }
-
-  if (L_max >= 7) {
-    float s7[15];
-    calculate_s_one<7>(n, n_max_angular_plus_1, Fp, sum_fxyz, s7);
-    accumulate_f12_one<7>(d12inv, fn_original, fnp_original, s7, r12unit, f12);
-  }
-
-  if (L_max >= 8) {
-    float s8[17];
-    calculate_s_one<8>(n, n_max_angular_plus_1, Fp, sum_fxyz, s8);
-    accumulate_f12_one<8>(d12inv, fn_original, fnp_original, s8, r12unit, f12);
-  }
 }
 
 template <int L>
@@ -783,18 +683,6 @@ accumulate_s_one(const float x12, const float y12, const float z12, const float 
       }
       if (L == 4) {
         z_factor += Z_COEFFICIENT_4[n1][n2] * z_pow[n2];
-      }
-      if (L == 5) {
-        z_factor += Z_COEFFICIENT_5[n1][n2] * z_pow[n2];
-      }
-      if (L == 6) {
-        z_factor += Z_COEFFICIENT_6[n1][n2] * z_pow[n2];
-      }
-      if (L == 7) {
-        z_factor += Z_COEFFICIENT_7[n1][n2] * z_pow[n2];
-      }
-      if (L == 8) {
-        z_factor += Z_COEFFICIENT_8[n1][n2] * z_pow[n2];
       }
     }
     z_factor *= fn;
@@ -826,18 +714,6 @@ static __device__ __forceinline__ void accumulate_s(
   }
   if (L_max >= 4) {
     accumulate_s_one<4>(x12, y12, z12, fn, s);
-  }
-  if (L_max >= 5) {
-    accumulate_s_one<5>(x12, y12, z12, fn, s);
-  }
-  if (L_max >= 6) {
-    accumulate_s_one<6>(x12, y12, z12, fn, s);
-  }
-  if (L_max >= 7) {
-    accumulate_s_one<7>(x12, y12, z12, fn, s);
-  }
-  if (L_max >= 8) {
-    accumulate_s_one<8>(x12, y12, z12, fn, s);
   }
 }
 
@@ -874,18 +750,6 @@ static __device__ __forceinline__ void find_q(
   }
   if (L_max >= 4) {
     q[3 * n_max_angular_plus_1 + n] = find_q_one<4>(s);
-  }
-  if (L_max >= 5) {
-    q[4 * n_max_angular_plus_1 + n] = find_q_one<5>(s);
-  }
-  if (L_max >= 6) {
-    q[5 * n_max_angular_plus_1 + n] = find_q_one<6>(s);
-  }
-  if (L_max >= 7) {
-    q[6 * n_max_angular_plus_1 + n] = find_q_one<7>(s);
-  }
-  if (L_max >= 8) {
-    q[7 * n_max_angular_plus_1 + n] = find_q_one<8>(s);
   }
   if (num_L >= L_max + 1) {
     q[L_max * n_max_angular_plus_1 + n] =

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -115,7 +115,7 @@ __constant__ float COVALENT_RADIUS[94] = {
   2.02667f,  2.04f,     2.05333f, 2.06667f};
 
 const int SIZE_BOX_AND_INVERSE_BOX = 18; // (3 * 3) * 2
-const int MAX_NUM_N = 20;                // n_max+1 = 19+1
+const int MAX_NUM_N = 17;                // n_max+1 = 16+1
 const int MAX_DIM = MAX_NUM_N * 7;
 const int MAX_DIM_ANGULAR = MAX_NUM_N * 6;
 


### PR DESCRIPTION
**Summary**

Reduce upper bounds of some hyperparameters to ensure optimal computational efficiency.

**Modification**

* Reduce the upper bound of `neuron` from `200` to `120`.
* Reduce the upper bound of `n_max` from `19 19` to `12 8`.
* Reduce the upper bound of `basis_size` from `19 19` to `16 12`.

**Others**
