### PR TITLE
Removed 'v:' label from version display in documentation

### DIFF
--- a/doc/_templates/versions.html
+++ b/doc/_templates/versions.html
@@ -1,7 +1,7 @@
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
       <span class="fa fa-book"> Documentation</span>
-      v: {{ current_version }}
+      {{ current_version }}
       <span class="fa fa-caret-down"></span>
     </span>
     <div class="rst-other-versions">


### PR DESCRIPTION
Removed the duplicated "v:" from the "Versions" display in the documentation.

## Old
<img width="285" alt="Screenshot 2025-05-13 at 09 33 07" src="https://github.com/user-attachments/assets/bc46f41b-76f5-44b9-8e00-b147833dc80b" />
