### PR TITLE
Removed empty documentation page on eigenvector input file

### DIFF
--- a/doc/gpumd/input_files/eigenvector_in.rst
+++ b/doc/gpumd/input_files/eigenvector_in.rst
@@ -1,7 +1,0 @@
-.. _eigenvector_in:
-.. index::
-   single: gpumd input files; Eigenvectors
-   single: eigenvector.in
-
-Eigenvectors for modal analysis
--------------------------------

--- a/doc/gpumd/input_files/index.rst
+++ b/doc/gpumd/input_files/index.rst
@@ -12,6 +12,5 @@ To run one a simulation using the ``gpumd`` executable, one has to prepare at le
 
    run_in
    model_xyz
-   eigenvector_in
    basis_in
    kpoints_in


### PR DESCRIPTION
Removed the page "Eigenvectors for modal analysis[](https://gpumd.org/gpumd/input_files/eigenvector_in.html#eigenvectors-for-modal-analysis)" from the documentation since it is empty.