### PR TITLE
Added possibility to use simpler output file names for save_potential…

### DIFF
--- a/doc/nep/input_parameters/save_potential.rst
+++ b/doc/nep/input_parameters/save_potential.rst
@@ -5,12 +5,14 @@
 :attr:`save_potential`
 ======================
 
-This keyword sets the number of of generations between writing a ``nep.txt`` file, with the name formatted as ``nep_y[year]_m[month]_d[day]_h[hour]_m[minute]_s[second]_generation[generation].txt``.
+This keyword sets the number of of generations between writing a ``nep.txt`` checkpoint file.
+If ``<format>`` is set to ``0`` the output file name is formatted as ``nep_gen[generation].txt``.
+If ``<format>`` is set to ``1`` the output file name is formatted as ``nep_y[year]_m[month]_d[day]_h[hour]_m[minute]_s[second]_generation[generation].txt``.
 These model files can be used to monitor the training progress of your model.
 Note that the :ref:`nep.restart file <nep_restart>` is the file that is required to continue training.
 
 The syntax is::
 
-  save_potential <number_of_generations_between_save_potential>
+  save_potential <number_of_generations_between_save_potential> <format>
 
-The default number of generations between saved model files is :math:`N=10^5`.
+The default number of generations between saved model files is :math:`N=10^5` and the output file names use the extended format.

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -460,12 +460,17 @@ void Fitness::report_error(
     fclose(fid_nep);
 
     if (0 == (generation + 1) % para.save_potential) {
-      time_t rawtime;
-      time(&rawtime);
-      struct tm* timeinfo = localtime(&rawtime);
-      char buffer[200];
-      strftime(buffer, sizeof(buffer), "nep_y%Y_m%m_d%d_h%H_m%M_s%S_generation", timeinfo);
-      std::string filename(buffer + std::to_string(generation + 1) + ".txt");
+      std::string filename;
+      if (para.save_potential_format == 1) {
+        time_t rawtime;
+        time(&rawtime);
+        struct tm* timeinfo = localtime(&rawtime);
+        char buffer[200];
+        strftime(buffer, sizeof(buffer), "nep_y%Y_m%m_d%d_h%H_m%M_s%S_generation", timeinfo);
+        filename = std::string(buffer) + std::to_string(generation + 1) + ".txt";
+      } else {
+        filename = "nep_gen" + std::to_string(generation + 1) + ".txt";
+      }
 
       FILE* fid_nep = my_fopen(filename.c_str(), "w");
       write_nep_txt(fid_nep, para, elite);

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -100,7 +100,8 @@ void Parameters::set_default_parameters()
   use_full_batch = 0;          // default is not to enable effective full-batch
   population_size = 50;        // almost optimal
   maximum_generation = 100000; // a good starting point
-  save_potential = 100000;         // by default write a checkpoint nep.txt file every 100000 iterations
+  save_potential = 100000;     // write checkpoint nep.txt files at these intervals
+  save_potential_format = 1;   // 1 = include time stamp when writing checkpoint nep.txt files
   initial_para = 1.0f;
   sigma0 = 0.1f;
   atomic_v = 0;
@@ -1284,8 +1285,8 @@ void Parameters::parse_save_potential(const char** param, int num_param)
 {
   is_save_potential_set = true;
 
-  if (num_param != 2) {
-    PRINT_INPUT_ERROR("save_potential should have 1 parameter.\n");
+  if (num_param != 3) {
+    PRINT_INPUT_ERROR("save_potential should have 2 parameters.\n");
   }
   if (!is_valid_int(param[1], &save_potential)) {
     PRINT_INPUT_ERROR("save_potential interval should be an integer.\n");
@@ -1293,4 +1294,10 @@ void Parameters::parse_save_potential(const char** param, int num_param)
   if (save_potential < 0) {
     PRINT_INPUT_ERROR("save_potential interval should be >= 0.");
   }
+  if (!is_valid_int(param[2], &save_potential_format)) {
+    PRINT_INPUT_ERROR("save_potential format should be an integer.\n");
+  }
+  if (save_potential_format != 0 && save_potential_format != 1) {
+    PRINT_INPUT_ERROR("save_potential format should be 0 or 1.");
+  }  
 }

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -30,7 +30,8 @@ public:
   int num_types;          // number of atom types
   int population_size;    // population size for SNES
   int maximum_generation; // maximum number of generations for SNES;
-  int save_potential;         // number of generations between writing a checkpoint nep.txt file. 
+  int save_potential;     // number of generations between writing a checkpoint nep.txt file. 
+  int save_potential_format;  // format of checkpoint nep.txt file name
   int num_neurons1;       // number of nuerons in the 1st hidden layer (only one hidden layer)
   int basis_size_radial;  // for nep3
   int basis_size_angular; // for nep3


### PR DESCRIPTION
This is a convenience PR that adds a second parameter to the `save_potential` keyword in `nep.in` that allows the user to use a simpler output file name. The new format is `save_potential <number_of_generations_between_checkpoint_files> <format>`. If `<format>` is `0`, the checkpoint file name is `nep_gen<generation>.txt`. If `<format>` is `1` the current extended file name is used which includes the full date and time information. When writing in the latter format directories quickly fill up with long file names.