### PR TITLE
Brought back eigenvector_in file (still empty) to fix pages

### DIFF
--- a/doc/gpumd/input_files/eigenvector_in.rst
+++ b/doc/gpumd/input_files/eigenvector_in.rst
@@ -1,0 +1,7 @@
+.. _eigenvector_in:
+.. index::
+   single: gpumd input files; Eigenvectors
+   single: eigenvector.in
+
+Eigenvectors for modal analysis
+-------------------------------

--- a/doc/gpumd/input_files/index.rst
+++ b/doc/gpumd/input_files/index.rst
@@ -14,3 +14,4 @@ To run one a simulation using the ``gpumd`` executable, one has to prepare at le
    model_xyz
    basis_in
    kpoints_in
+   eigenvector_in

--- a/src/makefile
+++ b/src/makefile
@@ -17,16 +17,15 @@
 # some flags
 ###########################################################
 CC = nvcc
-CUDA_ARCH=-arch=sm_60
+CUDA_ARCH=-arch=sm_80
 ifdef OS # For Windows with the cl.exe compiler
 CFLAGS = -O3 $(CUDA_ARCH)
 else # For linux
-CFLAGS = -std=c++14 -O3 $(CUDA_ARCH)
+CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -DUSE_NETCDF
 endif
-INC = -I./
-LDFLAGS = 
-LIBS = -lcublas -lcusolver
-
+INC = -I./ -I${HOME}/repos/netcdf/include
+LDFLAGS = -L${HOME}/repos/netcdf/lib
+LIBS = -lcublas -lcusolver -l:libnetcdf.a
 
 ###########################################################
 # source files


### PR DESCRIPTION
Added the `eigenvector_in.rst` file back to the documentation since the latter was broken due to a hanging link. In the future, we need to add an actual documentation of the file.