### PR TITLE
add group for dump

### DIFF
--- a/doc/gpumd/input_parameters/dump_xyz.rst
+++ b/doc/gpumd/input_parameters/dump_xyz.rst
@@ -24,7 +24,7 @@ If :attr:`grouping_method` is negative, :attr:`group_id` will be ignored and dat
 
 If it is ended by a star (*), the data for one frame will be output to one file, named by changing the star to the step number.
 
-* Then one can write the properties to be output, and the allowed properties include: :attr:`mass`, :attr:`velocity`, :attr:`force`, :attr:`potential`, :attr:`virial`, and :attr:`unwrapped_position`.
+* Then one can write the properties to be output, and the allowed properties include: :attr:`mass`, :attr:`velocity`, :attr:`force`, :attr:`potential`, :attr:`virial`, :attr:`group`, and :attr:`unwrapped_position`.
 
 * The wrapped positions will always be included in the output.
 

--- a/src/measure/dump_xyz.cuh
+++ b/src/measure/dump_xyz.cuh
@@ -65,6 +65,7 @@ public:
     bool has_unwrapped_position_ = false;
     bool has_mass_ = false;
     bool has_virial_ = false;
+    bool has_group_ = false;
   };
 
 private:
@@ -87,6 +88,7 @@ private:
   void output_line2(
     const double time,
     const Box& box,
+    std::vector<Group>& group,
     const std::vector<std::string>& cpu_atom_symbol,
     GPU_Vector<double>& virial_per_atom,
     GPU_Vector<double>& gpu_thermo);


### PR DESCRIPTION
**Summary**

* Add option to dump all the grouping methods using the `dump_xyz` keyword.

* Example usage:
```
dump_xyz  0 0 100 part_system.xyz group      
dump_xyz  -1 0 1000 full_system.xyz group      
```

* Fix #1050 
