### PR TITLE
Update pca_sampling.py

### DIFF
--- a/tools/Analysis_and_Processing/pca_sampling/pca_sampling.py
+++ b/tools/Analysis_and_Processing/pca_sampling/pca_sampling.py
@@ -22,6 +22,9 @@ from scipy.spatial.distance import cdist
 # Farthest Point Sampling
 def farthest_point_sampling(points, n_samples):
     n_points = points.shape[0]
+    if n_samples >= n_points:
+        print(f"Requested {n_samples} samples, but only {n_points} data points are available. Returning all points.")
+        return list(range(n_points))  
     selected_indices = [np.random.randint(n_points)]
     for _ in range(1, n_samples):
         distances = cdist(points, points[selected_indices])


### PR DESCRIPTION
When I run the script in batches, some structures are extracted repeatedly because their `n_points` are less than `n_sample`.
For this reason, I added a logic to return all sample points when `n_points` is less than `n_sample`.
