### PR TITLE
Fix a bug of SD minimizer position step and update output of minimizers

### DIFF
--- a/src/minimize/minimizer_fire.cu
+++ b/src/minimize/minimizer_fire.cu
@@ -131,10 +131,10 @@ void Minimizer_FIRE::compute(
     const double force_max = sqrt(cpu_force_square_max_[0]);
     calculate_total_potential(potential_per_atom);
 
-    if (step % base == 0 || force_max < force_tolerance_) {
+    if (step == 0 || (step + 1) % base == 0 || force_max < force_tolerance_) {
       printf(
         "    step %d: total_potential = %.10f eV, f_max = %.10f eV/A.\n",
-        step,
+        step == 0 ? 0 : (step + 1),
         cpu_total_potential_[0],
         force_max);
       if (force_max < force_tolerance_)

--- a/src/minimize/minimizer_fire_box_change.cu
+++ b/src/minimize/minimizer_fire_box_change.cu
@@ -474,10 +474,10 @@ void Minimizer_FIRE_Box_Change::compute(
     const double force_max = sqrt(cpu_force_square_max_[0]);
     calculate_total_potential(potential_per_atom);
 
-    if (step % base == 0 || force_max < force_tolerance_) {
+    if (step == 0 || (step + 1) % base == 0 || force_max < force_tolerance_) {
       printf(
         "    step %d: total_potential = %.10f eV, f_max = %.10f eV/A, pressure = %.10f GPa.\n",
-        step,
+        step == 0 ? 0 : (step + 1),
         cpu_total_potential_[0],
         force_max,
         (virial_cpu[0] + virial_cpu[4] + virial_cpu[8]) / 3. / box.get_volume() * 160.2176621);

--- a/src/minimize/minimizer_sd.cu
+++ b/src/minimize/minimizer_sd.cu
@@ -22,6 +22,8 @@ The SD (steepest decent) minimizer.
 #include "utilities/gpu_macro.cuh"
 #include <cstring>
 
+#define MIN_POSITION_STEP 1e-8
+
 const double decreasing_factor = 0.2;
 const double increasing_factor = 1.2;
 
@@ -59,6 +61,7 @@ void Minimizer_SD::compute(
 
   int number_of_force_evaluations = 1;
   double position_step = 0.1;
+  int base = (number_of_steps_ >= 10) ? (number_of_steps_ / 10) : 1;
 
   printf("\nEnergy minimization started.\n");
 
@@ -101,11 +104,20 @@ void Minimizer_SD::compute(
       position_step *= increasing_factor;
     }
 
-    int base = (number_of_steps_ >= 10) ? (number_of_steps_ / 10) : 1;
 
     double total_potential_smaller = (cpu_total_potential_[1] > cpu_total_potential_[0])
                                        ? cpu_total_potential_[0]
                                        : cpu_total_potential_[1];
+
+    if (position_step < MIN_POSITION_STEP) {
+      printf(
+        "    step %d: total_potential = %.10f eV, f_max = %.10f eV/A.\n",
+        step + 1,
+        total_potential_smaller,
+        force_max);
+      printf("    Position step is 0, SD minimizer can't find a better solution\n");
+      break;
+    }
 
     if (step == 0) {
       printf(


### PR DESCRIPTION
**Summary**

In SD minimize algorithm, the position step is variable, and will become smaller near the extremum point. In GPUMD, the position step may reduce to 0, resulting that the positions will not be updated again while the minimizer is still working. Maybe there should  be a check statement to avoid this situation.
The FIRE and FIRE with relaxed box minimizers will not print the status in the last step. Update them in this PR as well.

**Modification**

- `minimizer_sd.cu`: add check statement to break if position step is 0.
- `minimizer_fire.cu` and `minimizer_fire_box_change.cu`: uniform output format with `minimizer_sd.cu`.

**Test**

SD:
- raw
![image](https://github.com/user-attachments/assets/8ba8cc9f-5ad5-4d69-b1d0-1e68c2d9c624)
![image](https://github.com/user-attachments/assets/9c083af2-6888-4402-97d8-eeb34add1a29)
- modified
![image](https://github.com/user-attachments/assets/4c3919ba-94bd-4cbe-b9ef-6421e9d3c33e)
![image](https://github.com/user-attachments/assets/5d0ceb26-0d69-4ef8-8d78-6269fdd95f04)

FIRE:
- raw
![image](https://github.com/user-attachments/assets/e557bd5a-74f5-4320-9bb2-0cfc101bd29f)
- modified
![image](https://github.com/user-attachments/assets/27b1a5b5-5187-4f5e-9ef7-981a548fe87f)

FIRE with variable box:
- raw
![image](https://github.com/user-attachments/assets/53795de1-3306-46b8-88bf-5ad232d260ec)
- modified
![image](https://github.com/user-attachments/assets/41733de5-80f3-4dc8-969c-2779b120aa13)


**Others**
None.