### PR TITLE
Fixed syntax error in publications.bib

### DIFF
--- a/doc/publications.bib
+++ b/doc/publications.bib
@@ -2556,8 +2556,8 @@ doi = {10.1103/PhysRevMaterials.9.023801}
 }
 
 @article{ZhaLuoWu25,
-doi:10.1126/sciadv.adx5007,
-author = {ZhongTing Zhang  and Jian Luo  and HengAn Wu  and Hao Ma  and YinBo Zhu },
+doi = {10.1126/sciadv.adx5007},
+author = {ZhongTing Zhang  and Jian Luo  and HengAn Wu  and Hao Ma  and YinBo Zhu},
 title = {Unveiling the microscopic origin of anomalous thermal conductivity in amorphous carbon},
 journal = {Science Advances},
 volume = {11},


### PR DESCRIPTION
Fixed a syntax error in `doc/publications.bib` that broke the CI.