### PR TITLE
More compute msd bugs

### DIFF
--- a/src/measure/msd.cu
+++ b/src/measure/msd.cu
@@ -367,8 +367,14 @@ void MSD::write(const char* filename)
   // normalize by the number of atoms and number of time origins
   for (int group_id=0; group_id < num_groups_; group_id++) {
     int num_atoms = num_atoms_per_group_[group_id];
-    // num_time_origins_ should be different for each nc
-    const double msd_scaler = 1.0 / ((double)num_atoms * (double)num_time_origins_);
+    
+    // This is the case for empty groups
+    double msd_scaler = 0.0;
+    if (num_atoms > 0) {
+      // num_time_origins_ should be different for each nc
+      msd_scaler = 1.0 / ((double)num_atoms * (double)num_time_origins_);
+    } 
+
     int group_index = group_id * num_correlation_steps_;
 
     for (int nc = group_index + 0; nc < group_index + num_correlation_steps_; nc++) {

--- a/src/measure/msd.cu
+++ b/src/measure/msd.cu
@@ -368,15 +368,14 @@ void MSD::write(const char* filename)
   for (int group_id=0; group_id < num_groups_; group_id++) {
     int num_atoms = num_atoms_per_group_[group_id];
     
-    // This is the case for empty groups
+    // This is the case for empty groups and if the msd has yet to be computed
     double msd_scaler = 0.0;
-    if (num_atoms > 0) {
+    if (num_atoms > 0 && num_time_origins_ > 0) {
       // num_time_origins_ should be different for each nc
       msd_scaler = 1.0 / ((double)num_atoms * (double)num_time_origins_);
     } 
 
     int group_index = group_id * num_correlation_steps_;
-
     for (int nc = group_index + 0; nc < group_index + num_correlation_steps_; nc++) {
       msdx_out_[nc] = msdx_[nc] * msd_scaler;
       msdy_out_[nc] = msdy_[nc] * msd_scaler;


### PR DESCRIPTION
Fixes two bugs pointed out by @erhart1. 

- 1. msd will be `-nan` for empty groups
- 2. msd and sdc will be `-nan` when the msd correlation length is longer than the md run length in steps.

Both bugs comes from the `msd_scaler`, which is `1 / (num_atoms * num_time_origins)`. In bug 1 `num_atoms=0`, and in bug 2 `num_time_origins=0`. 

In both cases, the `msd_scaler` variable is now set to 0, leading to the msd and sdc to be 0 instead of nan.