### PR TITLE
Fix the bug where the Total-Loss column contains nan values during training

### DIFF
--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -120,6 +120,18 @@ void Parameters::set_default_parameters()
   }
   enable_zbl = false;   // default is not to include ZBL
   flexible_zbl = false; // default Universal ZBL
+
+
+
+  // ------------new--------------
+  int deviceCount;  
+  CHECK(gpuGetDeviceCount(&deviceCount));  
+  int fully_used_device = population_size % deviceCount;  
+  if (fully_used_device != 0) {  
+    int population_should_increase = deviceCount - fully_used_device;  
+    population_size += population_should_increase;  
+    printf("Default population size adjusted from 50 to %d for GPU compatibility.\n", population_size);  
+  }  
 }
 
 void Parameters::read_nep_in()


### PR DESCRIPTION
**Summary**

* Modified the `set_default_parameters()` function in `src/main_nep/parameters.cu`.
* Added a GPU divisibility check after setting the default `population_size = 50`, to prevent NaN values in the `Total-Loss` column when the `population` parameter is not explicitly set in `nep.in`.

**Modification**

* Previously, when `population_size` was not specified by the user, the default value `50` was used without checking if it could be evenly divided by the number of GPUs.
* This caused occasional NaNs in `Total-Loss` during training, especially when using 3 or 4 GPUs.
* The fix ensures that the GPU check and adjustment logic also applies to the default value, improving robustness.

**Others**

* This issue has been reported by multiple users and has existed for a long time but was hard to reproduce.
* Verified the fix on multiple GPU configurations (e.g., 3 and 4 GPUs) where the issue previously occurred.


---

Dear Prof. Fan,
  I downloaded and successfully compiled the GPUMD-4.2 version on a high-performance computing platform. While testing the examples in the `GPUMD-4.2/examples/nep_train` directory, I encountered an issue where the `Total-Loss` column occasionally contained `NaN` values during training.

After some investigation and debugging, I identified the root cause. This appears to be a long-standing but hard-to-reproduce bug that several other users have also encountered.

#### Bug Explanation:

1. **Default Value Setting**
    The file `parameters.cu` sets a default value of `population_size = 50`.
2. **Automatic Adjustment Trigger**
    The GPU count check and automatic adjustment logic in the `parse_population` function of `parameters.cu` is only triggered when `population` is explicitly specified in the `nep.in` file.
3. **How the Bug Happens**
    If `population` is not explicitly defined in `nep.in`, the system uses the default value of 50 without triggering the GPU compatibility check. This may result in `population_size = 50` not being divisible by the number of GPUs (e.g., 3 or 4 GPUs), which leads to numerical instability and eventually causes the `Total-Loss` column to output `nan` values during training.

#### Solution:

I fixed the logic to ensure that even when the default `population_size` is used, the GPU divisibility check and adjustment are still performed. This guarantees the `population_size` is always compatible with the number of available GPUs, avoiding `nan` outputs in the training loss.


---
# Additional Notes

Below, I will reproduce the bug where `nan` appears in the `Total-Loss` column and provide a suggested fix.

## (1) Reproducing the `nan` bug in the `Total-Loss` column

I still use the `examples/nep_train` directory as an example. To fix the random seed during training, I added the `-DDEBUG` flag in `makefile.hip` (note: this step is not essential for reproducing the issue), as shown below:
```sh
CC = hipcc
#CFLAGS = -std=c++14 -O3 --offload-arch=gfx90a -DUSE_HIP
CFLAGS = -std=c++14 -O3  --offload-arch=gfx906,gfx908 -DUSE_HIP  -DDEBUG
```
Compiled as follows using `hipcc` with `-DDEBUG` flag:
```txt
[chenhongjian@login08 src]$ make -f makefile.hip -j8
hipcc -std=c++14 -O3  --offload-arch=gfx906,gfx908 -DUSE_HIP  -DDEBUG -I./ -c main_gpumd/cohesive.cu -o main_gpumd/cohesive.o
hipcc -std=c++14 -O3  --offload-arch=gfx906,gfx908 -DUSE_HIP  -DDEBUG -I./ -c main_gpumd/add_random_force.cu -o main_gpumd/add_random_force.o
hipcc -std=c++14 -O3  --offload-arch=gfx906,gfx908 -DUSE_HIP  -DDEBUG -I./ -c main_gpumd/replicate.cu -o main_gpumd/replicate.o

...
...

hipcc  main_nep/structure.o main_nep/nep.o main_nep/fitness.o main_nep/tnep.o main_nep/dataset.o main_nep/snes.o main_nep/parameters.o main_nep/main.o main_nep/nep_charge.o utilities/cusolver_wrapper.o utilities/error.o utilities/read_file.o utilities/main_common.o -o nep -lhipblas -lhipsolver

=================================================
The nep executable is successfully compiled!
=================================================
```
## case1: Using the settings from `nep.in` in `examples/nep_train`.
```txt
type         2 Te Pb
generation   20000
```
### Training with 4 GPUs
```txt
[chenhongjian@login05 debug_train_4dcu]$ cat slurm-34539664.out 

***************************************************************
*                 Welcome to use GPUMD                        *
*    (Graphics Processing Units Molecular Dynamics)           *
*                     version 4.2                             *
*              This is the nep executable                     *
***************************************************************


---------------------------------------------------------------
GPU information:
---------------------------------------------------------------

number of GPUs = 4
Device id:                   0
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   1
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   2
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   3
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
GPU-0 can access GPU-1.
GPU-0 can access GPU-2.
GPU-0 can access GPU-3.
GPU-1 can access GPU-0.
GPU-1 can access GPU-2.
GPU-1 can access GPU-3.
GPU-2 can access GPU-0.
GPU-2 can access GPU-1.
GPU-2 can access GPU-3.
GPU-3 can access GPU-0.
GPU-3 can access GPU-1.
GPU-3 can access GPU-2.

---------------------------------------------------------------
Started running nep.
---------------------------------------------------------------


---------------------------------------------------------------
Started reading nep.in.
---------------------------------------------------------------

Input or default parameters:
    (default) model_type = potential.
    (default) calculation mode = train.
    (default) use NEP version 4.
    (input)   number of atom types = 2.
        (default) type 0 (Te with Z = 52) has force weight of 1.
        (default) type 1 (Pb with Z = 82) has force weight of 1.
    (default) will not add the ZBL potential.
    (default) radial cutoff = 8 A.
    (default) angular cutoff = 4 A.
    (default) use global cutoff for NEP.
    (default) use global cutoff for ZBL.
    (default) n_max_radial = 4.
    (default) n_max_angular = 4.
    (default) basis_size_radial = 8.
    (default) basis_size_angular = 8.
    (default) l_max_3body = 4.
    (default) l_max_4body = 2.
    (default) l_max_5body = 0.
    (default) number of neurons = 30.
    (default) lambda_1 = 0.0337713.
    (default) lambda_2 = 0.0337713.
    (default) lambda_e = 1.
    (default) lambda_f = 1.
    (default) lambda_v = 0.1.
    (default) atomic_v = 0.
    (default) lambda_shear = 1.
    (default) force_delta = 0.
    (default) batch size = 1000.
    (default) population size = 50.
    (input)   maximum number of generations = 20000.
    (input)   save potential every N = 100000 generations.
Some calculated parameters:
    number of radial descriptor components = 5.
    number of angular descriptor components = 25.
    total number of descriptor components = 30.
    NN architecture = 30-30-1.
    number of NN parameters to be optimized = 1921.
    number of descriptor parameters to be optimized = 360.
    total number of parameters to be optimized = 2281.

---------------------------------------------------------------
Finished reading nep.in.
---------------------------------------------------------------


---------------------------------------------------------------
Started reading train.xyz
Launch params (1024, 1, 1) are larger than launch bounds (256) for kernel _ZL12find_max_miniPKfPf please add __launch_bounds__ to kernel define or use --gpu-max-threads-per-block recompile program ! 
---------------------------------------------------------------

Number of configurations = 25.
Number of devices = 4
Number of batches = 1
Hello, I changed the batch_size from 1000 to 25.

Batch 0:
Number of configurations = 25.

---------------------------------------------------------------
Constructing train_set in device  0.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  1.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  2.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  3.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Time used for initialization = 1.681025 s.
---------------------------------------------------------------


---------------------------------------------------------------
Started training.
---------------------------------------------------------------

Step    Total-Loss L1Reg-Loss L2Reg-Loss RMSE-E-Train RMSE-F-Train RMSE-V-Train RMSE-E-Test  RMSE-F-Test  RMSE-V-Test  
100     nan        0.01756    0.02073    0.01127      0.16666      0.00000      0.00000      0.00000      0.00000      
200     nan        0.01818    0.02181    0.02147      0.20643      0.00000      0.00000      0.00000      0.00000      
300     nan        0.01864    0.02249    0.00377      0.11068      0.00000      0.00000      0.00000      0.00000      
400     nan        0.01924    0.02341    0.00759      0.10325      0.00000      0.00000      0.00000      0.00000      
500     nan        0.01976    0.02418    0.00430      0.10101      0.00000      0.00000      0.00000      0.00000      
600     nan        0.02036    0.02497    0.00337      0.10742      0.00000      0.00000      0.00000      0.00000      
700     nan        0.02061    0.02536    0.00290      0.12042      0.00000      0.00000      0.00000      0.00000      
800     nan        0.02104    0.02594    0.00782      0.12382      0.00000      0.00000      0.00000      0.00000      
900     nan        0.02145    0.02661    0.00333      0.09993      0.00000      0.00000      0.00000      0.00000      
1000    nan        0.02192    0.02719    0.00314      0.09468      0.00000      0.00000      0.00000      0.00000      
1100    nan        0.02216    0.02759    0.00527      0.07656      0.00000      0.00000      0.00000      0.00000      
1200    nan        0.02232    0.02788    0.00196      0.06621      0.00000      0.00000      0.00000      0.00000     
...
...
[chenhongjian@login05 debug_train_4dcu]$ 
```
### Training with 3 GPUs
```txt
[chenhongjian@login05 debug_train_3dcu]$ cat slurm-34539785.out 

***************************************************************
*                 Welcome to use GPUMD                        *
*    (Graphics Processing Units Molecular Dynamics)           *
*                     version 4.2                             *
*              This is the nep executable                     *
***************************************************************


---------------------------------------------------------------
GPU information:
---------------------------------------------------------------

number of GPUs = 3
Device id:                   0
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   1
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   2
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
GPU-0 can access GPU-1.
GPU-0 can access GPU-2.
GPU-1 can access GPU-0.
GPU-1 can access GPU-2.
GPU-2 can access GPU-0.
GPU-2 can access GPU-1.

---------------------------------------------------------------
Started running nep.
---------------------------------------------------------------


---------------------------------------------------------------
Started reading nep.in.
---------------------------------------------------------------

Input or default parameters:
    (default) model_type = potential.
    (default) calculation mode = train.
    (default) use NEP version 4.
    (input)   number of atom types = 2.
        (default) type 0 (Te with Z = 52) has force weight of 1.
        (default) type 1 (Pb with Z = 82) has force weight of 1.
    (default) will not add the ZBL potential.
    (default) radial cutoff = 8 A.
    (default) angular cutoff = 4 A.
    (default) use global cutoff for NEP.
    (default) use global cutoff for ZBL.
    (default) n_max_radial = 4.
    (default) n_max_angular = 4.
    (default) basis_size_radial = 8.
    (default) basis_size_angular = 8.
    (default) l_max_3body = 4.
    (default) l_max_4body = 2.
    (default) l_max_5body = 0.
    (default) number of neurons = 30.
    (default) lambda_1 = 0.0337713.
    (default) lambda_2 = 0.0337713.
    (default) lambda_e = 1.
    (default) lambda_f = 1.
    (default) lambda_v = 0.1.
    (default) atomic_v = 0.
    (default) lambda_shear = 1.
    (default) force_delta = 0.
    (default) batch size = 1000.
    (default) population size = 50.
    (input)   maximum number of generations = 20000.
    (input)   save potential every N = 100000 generations.
Some calculated parameters:
    number of radial descriptor components = 5.
    number of angular descriptor components = 25.
    total number of descriptor components = 30.
    NN architecture = 30-30-1.
    number of NN parameters to be optimized = 1921.
    number of descriptor parameters to be optimized = 360.
    total number of parameters to be optimized = 2281.

---------------------------------------------------------------
Finished reading nep.in.
---------------------------------------------------------------


---------------------------------------------------------------
Started reading train.xyz
Launch params (1024, 1, 1) are larger than launch bounds (256) for kernel _ZL12find_max_miniPKfPf please add __launch_bounds__ to kernel define or use --gpu-max-threads-per-block recompile program ! 
---------------------------------------------------------------

Number of configurations = 25.
Number of devices = 3
Number of batches = 1
Hello, I changed the batch_size from 1000 to 25.

Batch 0:
Number of configurations = 25.

---------------------------------------------------------------
Constructing train_set in device  0.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  1.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  2.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Time used for initialization = 1.256181 s.
---------------------------------------------------------------


---------------------------------------------------------------
Started training.
---------------------------------------------------------------

Step    Total-Loss L1Reg-Loss L2Reg-Loss RMSE-E-Train RMSE-F-Train RMSE-V-Train RMSE-E-Test  RMSE-F-Test  RMSE-V-Test  
100     nan        0.01737    0.02056    0.00163      0.13056      0.00000      0.00000      0.00000      0.00000      
200     nan        0.01794    0.02151    0.01285      0.17179      0.00000      0.00000      0.00000      0.00000      
300     nan        0.01851    0.02253    0.00180      0.09005      0.00000      0.00000      0.00000      0.00000      
400     nan        0.01900    0.02320    0.00230      0.08634      0.00000      0.00000      0.00000      0.00000      
500     nan        0.01939    0.02387    0.00320      0.12457      0.00000      0.00000      0.00000      0.00000      
600     nan        0.01997    0.02475    0.00725      0.12287      0.00000      0.00000      0.00000      0.00000      
700     nan        0.02038    0.02545    0.00224      0.07785      0.00000      0.00000      0.00000      0.00000      
...
...
[chenhongjian@login05 debug_train_3dcu]$ 
```
## case2: Explicitly set `population_size = 50` in `nep.in`.
```txt
type         2 Te Pb
generation   20000
population   50
```

In this case,`Total-Loss` will not have NaN issues. Since the population value is explicitly set to `50`, the training report shows that the population size will be increased to a multiple of the number of cards used. For example, for 4 GPUs, it is increased to 52, and for 3 GPUs, it is increased to 51. Just as you previously handled in the code,the corresponding messages are displayed:"The population size has therefore been increased to 52." and "The population size has therefore been increased to 51."

### Training with 4 GPUs
```txt
[chenhongjian@login05 population_setting]$ cat slurm-34540934.out 

***************************************************************
*                 Welcome to use GPUMD                        *
*    (Graphics Processing Units Molecular Dynamics)           *
*                     version 4.2                             *
*              This is the nep executable                     *
***************************************************************


---------------------------------------------------------------
GPU information:
---------------------------------------------------------------

number of GPUs = 4
Device id:                   0
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   1
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   2
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   3
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
GPU-0 can access GPU-1.
GPU-0 can access GPU-2.
GPU-0 can access GPU-3.
GPU-1 can access GPU-0.
GPU-1 can access GPU-2.
GPU-1 can access GPU-3.
GPU-2 can access GPU-0.
GPU-2 can access GPU-1.
GPU-2 can access GPU-3.
GPU-3 can access GPU-0.
GPU-3 can access GPU-1.
GPU-3 can access GPU-2.

---------------------------------------------------------------
Started running nep.
---------------------------------------------------------------


---------------------------------------------------------------
Started reading nep.in.
---------------------------------------------------------------

The input population size is not divisible by the number of GPUs.
This causes an inefficient use of resources.
The population size has therefore been increased to 52.
Input or default parameters:
    (default) model_type = potential.
    (default) calculation mode = train.
    (default) use NEP version 4.
    (input)   number of atom types = 2.
        (default) type 0 (Te with Z = 52) has force weight of 1.
        (default) type 1 (Pb with Z = 82) has force weight of 1.
    (default) will not add the ZBL potential.
    (default) radial cutoff = 8 A.
    (default) angular cutoff = 4 A.
    (default) use global cutoff for NEP.
    (default) use global cutoff for ZBL.
    (default) n_max_radial = 4.
    (default) n_max_angular = 4.
    (default) basis_size_radial = 8.
    (default) basis_size_angular = 8.
    (default) l_max_3body = 4.
    (default) l_max_4body = 2.
    (default) l_max_5body = 0.
    (default) number of neurons = 30.
    (default) lambda_1 = 0.0337713.
    (default) lambda_2 = 0.0337713.
    (default) lambda_e = 1.
    (default) lambda_f = 1.
    (default) lambda_v = 0.1.
    (default) atomic_v = 0.
    (default) lambda_shear = 1.
    (default) force_delta = 0.
    (default) batch size = 1000.
    (input)   population size = 52.
    (input)   maximum number of generations = 20000.
    (input)   save potential every N = 100000 generations.
Some calculated parameters:
    number of radial descriptor components = 5.
    number of angular descriptor components = 25.
    total number of descriptor components = 30.
    NN architecture = 30-30-1.
    number of NN parameters to be optimized = 1921.
    number of descriptor parameters to be optimized = 360.
    total number of parameters to be optimized = 2281.

---------------------------------------------------------------
Finished reading nep.in.
---------------------------------------------------------------


---------------------------------------------------------------
Started reading train.xyz
Launch params (1024, 1, 1) are larger than launch bounds (256) for kernel _ZL12find_max_miniPKfPf please add __launch_bounds__ to kernel define or use --gpu-max-threads-per-block recompile program ! 
---------------------------------------------------------------

Number of configurations = 25.
Number of devices = 4
Number of batches = 1
Hello, I changed the batch_size from 1000 to 25.

Batch 0:
Number of configurations = 25.

---------------------------------------------------------------
Constructing train_set in device  0.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  1.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  2.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  3.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Time used for initialization = 1.631552 s.
---------------------------------------------------------------


---------------------------------------------------------------
Started training.
---------------------------------------------------------------

Step    Total-Loss L1Reg-Loss L2Reg-Loss RMSE-E-Train RMSE-F-Train RMSE-V-Train RMSE-E-Test  RMSE-F-Test  RMSE-V-Test  
100     0.12959    0.01757    0.02075    0.00313      0.08814      0.00000      0.00000      0.00000      0.00000      
200     0.11769    0.01825    0.02184    0.00212      0.07548      0.00000      0.00000      0.00000      0.00000      
300     0.11304    0.01871    0.02257    0.00096      0.07079      0.00000      0.00000      0.00000      0.00000      
400     0.11603    0.01917    0.02324    0.00212      0.07149      0.00000      0.00000      0.00000      0.00000      
500     0.11162    0.01974    0.02404    0.00086      0.06698      0.00000      0.00000      0.00000      0.00000      
600     0.11451    0.02027    0.02469    0.00110      0.06845      0.00000      0.00000      0.00000      0.00000      
700     0.11261    0.02066    0.02535    0.00089      0.06571      0.00000      0.00000      0.00000      0.00000     
...
...
```

### Training with 3 GPUs
```txt
[chenhongjian@login05 population_setting]$ cat slurm-34540717.out 

***************************************************************
*                 Welcome to use GPUMD                        *
*    (Graphics Processing Units Molecular Dynamics)           *
*                     version 4.2                             *
*              This is the nep executable                     *
***************************************************************


---------------------------------------------------------------
GPU information:
---------------------------------------------------------------

number of GPUs = 3
Device id:                   0
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   1
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   2
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
GPU-0 can access GPU-1.
GPU-0 can access GPU-2.
GPU-1 can access GPU-0.
GPU-1 can access GPU-2.
GPU-2 can access GPU-0.
GPU-2 can access GPU-1.

---------------------------------------------------------------
Started running nep.
---------------------------------------------------------------


---------------------------------------------------------------
Started reading nep.in.
---------------------------------------------------------------

The input population size is not divisible by the number of GPUs.
This causes an inefficient use of resources.
The population size has therefore been increased to 51.
Input or default parameters:
    (default) model_type = potential.
    (default) calculation mode = train.
    (default) use NEP version 4.
    (input)   number of atom types = 2.
        (default) type 0 (Te with Z = 52) has force weight of 1.
        (default) type 1 (Pb with Z = 82) has force weight of 1.
    (default) will not add the ZBL potential.
    (default) radial cutoff = 8 A.
    (default) angular cutoff = 4 A.
    (default) use global cutoff for NEP.
    (default) use global cutoff for ZBL.
    (default) n_max_radial = 4.
    (default) n_max_angular = 4.
    (default) basis_size_radial = 8.
    (default) basis_size_angular = 8.
    (default) l_max_3body = 4.
    (default) l_max_4body = 2.
    (default) l_max_5body = 0.
    (default) number of neurons = 30.
    (default) lambda_1 = 0.0337713.
    (default) lambda_2 = 0.0337713.
    (default) lambda_e = 1.
    (default) lambda_f = 1.
    (default) lambda_v = 0.1.
    (default) atomic_v = 0.
    (default) lambda_shear = 1.
    (default) force_delta = 0.
    (default) batch size = 1000.
    (input)   population size = 51.
    (input)   maximum number of generations = 20000.
    (input)   save potential every N = 100000 generations.
Some calculated parameters:
    number of radial descriptor components = 5.
    number of angular descriptor components = 25.
    total number of descriptor components = 30.
    NN architecture = 30-30-1.
    number of NN parameters to be optimized = 1921.
    number of descriptor parameters to be optimized = 360.
    total number of parameters to be optimized = 2281.

---------------------------------------------------------------
Finished reading nep.in.
---------------------------------------------------------------


---------------------------------------------------------------
Started reading train.xyz
Launch params (1024, 1, 1) are larger than launch bounds (256) for kernel _ZL12find_max_miniPKfPf please add __launch_bounds__ to kernel define or use --gpu-max-threads-per-block recompile program ! 
---------------------------------------------------------------

Number of configurations = 25.
Number of devices = 3
Number of batches = 1
Hello, I changed the batch_size from 1000 to 25.

Batch 0:
Number of configurations = 25.

---------------------------------------------------------------
Constructing train_set in device  0.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  1.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  2.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Time used for initialization = 1.314366 s.
---------------------------------------------------------------


---------------------------------------------------------------
Started training.
---------------------------------------------------------------

Step    Total-Loss L1Reg-Loss L2Reg-Loss RMSE-E-Train RMSE-F-Train RMSE-V-Train RMSE-E-Test  RMSE-F-Test  RMSE-V-Test  
100     0.14475    0.01767    0.02087    0.00258      0.10363      0.00000      0.00000      0.00000      0.00000      
200     0.12649    0.01844    0.02200    0.00198      0.08408      0.00000      0.00000      0.00000      0.00000      
300     0.11393    0.01896    0.02286    0.00206      0.07005      0.00000      0.00000      0.00000      0.00000      
400     0.11715    0.01942    0.02356    0.00212      0.07206      0.00000      0.00000      0.00000      0.00000      
500     0.11453    0.01979    0.02429    0.00140      0.06906      0.00000      0.00000      0.00000      0.00000      
600     0.11360    0.02044    0.02511    0.00083      0.06723      0.00000      0.00000      0.00000      0.00000      
700     0.11117    0.02072    0.02556    0.00079      0.06410      0.00000      0.00000      0.00000      0.00000      
...
...
```

# (2) Solution
To address this bug, I added GPU compatibility checks at the end of the `set_default_parameters()` method. This ensures that the `population_size` is always divisible by the number of GPUs during the default value setting phase.
```cpp
void Parameters::set_default_parameters()  
{  
  // ... ...  
  population_size = 50;        // almost optimal  
    
  // ------------new--------------
  int deviceCount;  
  CHECK(gpuGetDeviceCount(&deviceCount));  
  int fully_used_device = population_size % deviceCount;  
  if (fully_used_device != 0) {  
    int population_should_increase = deviceCount - fully_used_device;  
    population_size += population_should_increase;  
    printf("Default population size adjusted from 50 to %d for GPU compatibility.\n", population_size);  
  }  
    
}
```
# (3) Verification Results
Example of using`nep.in`
```txt
type         2 Te Pb
generation   20000
```
When training with 4 GPUs,the print message shows:"Default population size adjusted from 50 to 52 for GPU compatibility."
```txt
[chenhongjian@login05 nep_train_4dcu]$ cat slurm-34554538.out 

***************************************************************
*                 Welcome to use GPUMD                        *
*    (Graphics Processing Units Molecular Dynamics)           *
*                     version 4.2                             *
*              This is the nep executable                     *
***************************************************************


---------------------------------------------------------------
GPU information:
---------------------------------------------------------------

number of GPUs = 4
Device id:                   0
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   1
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   2
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   3
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
GPU-0 can access GPU-1.
GPU-0 can access GPU-2.
GPU-0 can access GPU-3.
GPU-1 can access GPU-0.
GPU-1 can access GPU-2.
GPU-1 can access GPU-3.
GPU-2 can access GPU-0.
GPU-2 can access GPU-1.
GPU-2 can access GPU-3.
GPU-3 can access GPU-0.
GPU-3 can access GPU-1.
GPU-3 can access GPU-2.

---------------------------------------------------------------
Started running nep.
---------------------------------------------------------------


---------------------------------------------------------------
Started reading nep.in.
---------------------------------------------------------------

Default population size adjusted from 50 to 52 for GPU compatibility.
Input or default parameters:
    (default) model_type = potential.
    (default) calculation mode = train.
    (default) use NEP version 4.
    (input)   number of atom types = 2.
        (default) type 0 (Te with Z = 52) has force weight of 1.
        (default) type 1 (Pb with Z = 82) has force weight of 1.
    (default) will not add the ZBL potential.
    (default) radial cutoff = 8 A.
    (default) angular cutoff = 4 A.
    (default) use global cutoff for NEP.
    (default) use global cutoff for ZBL.
    (default) n_max_radial = 4.
    (default) n_max_angular = 4.
    (default) basis_size_radial = 8.
    (default) basis_size_angular = 8.
    (default) l_max_3body = 4.
    (default) l_max_4body = 2.
    (default) l_max_5body = 0.
    (default) number of neurons = 30.
    (default) lambda_1 = 0.0337713.
    (default) lambda_2 = 0.0337713.
    (default) lambda_e = 1.
    (default) lambda_f = 1.
    (default) lambda_v = 0.1.
    (default) atomic_v = 0.
    (default) lambda_shear = 1.
    (default) force_delta = 0.
    (default) batch size = 1000.
    (default) population size = 52.
    (input)   maximum number of generations = 20000.
    (input)   save potential every N = 100000 generations.
Some calculated parameters:
    number of radial descriptor components = 5.
    number of angular descriptor components = 25.
    total number of descriptor components = 30.
    NN architecture = 30-30-1.
    number of NN parameters to be optimized = 1921.
    number of descriptor parameters to be optimized = 360.
    total number of parameters to be optimized = 2281.

---------------------------------------------------------------
Finished reading nep.in.
---------------------------------------------------------------


---------------------------------------------------------------
Started reading train.xyz
Launch params (1024, 1, 1) are larger than launch bounds (256) for kernel _ZL12find_max_miniPKfPf please add __launch_bounds__ to kernel define or use --gpu-max-threads-per-block recompile program ! 
---------------------------------------------------------------

Number of configurations = 25.
Number of devices = 4
Number of batches = 1
Hello, I changed the batch_size from 1000 to 25.

Batch 0:
Number of configurations = 25.

---------------------------------------------------------------
Constructing train_set in device  0.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  1.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  2.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  3.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Time used for initialization = 1.609000 s.
---------------------------------------------------------------


---------------------------------------------------------------
Started training.
---------------------------------------------------------------

Step    Total-Loss L1Reg-Loss L2Reg-Loss RMSE-E-Train RMSE-F-Train RMSE-V-Train RMSE-E-Test  RMSE-F-Test  RMSE-V-Test  
100     0.11010    0.02081    0.02573    0.00103      0.06253      0.00000      0.00000      0.00000      0.00000      
200     0.11089    0.02134    0.02645    0.00088      0.06222      0.00000      0.00000      0.00000      0.00000      
300     0.10857    0.02211    0.02732    0.00127      0.05786      0.00000      0.00000      0.00000      0.00000      
400     0.10846    0.02239    0.02794    0.00116      0.05697      0.00000      0.00000      0.00000      0.00000      
500     0.10701    0.02302    0.02856    0.00199      0.05343      0.00000      0.00000      0.00000      0.00000      
600     0.10808    0.02359    0.02929    0.00061      0.05460      0.00000      0.00000      0.00000      0.00000      
700     0.10867    0.02387    0.02974    0.00095      0.05410      0.00000      0.00000      0.00000      0.00000      
800     0.10711    0.02396    0.02996    0.00059      0.05260      0.00000      0.00000      0.00000      0.00000      
900     0.10857    0.02426    0.03025    0.00139      0.05267      0.00000      0.00000      0.00000      0.00000      
1000    0.10547    0.02417    0.03029    0.00079      0.05021      0.00000      0.00000      0.00000      0.00000      
1100    0.10822    0.02443    0.03060    0.00082      0.05237      0.00000      0.00000      0.00000      0.00000      
1200    0.10697    0.02434    0.03063    0.00159      0.05042      0.00000      0.00000      0.00000      0.00000      
1300    0.10631    0.02458    0.03090    0.00119      0.04964      0.00000      0.00000      0.00000      0.00000      
1400    0.10343    0.02455    0.03085    0.00098      0.04706      0.00000      0.00000      0.00000      0.00000      
...
...
```

When training with 3 GPUs,the print message shows:"Default population size adjusted from 50 to 51 for GPU compatibility."
```txt
[chenhongjian@login05 nep_train_3dcu]$ cat slurm-34554497.out 

***************************************************************
*                 Welcome to use GPUMD                        *
*    (Graphics Processing Units Molecular Dynamics)           *
*                     version 4.2                             *
*              This is the nep executable                     *
***************************************************************


---------------------------------------------------------------
GPU information:
---------------------------------------------------------------

number of GPUs = 3
Device id:                   0
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   1
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
Device id:                   2
    Device name:             Z100SM
    Compute capability:      9.0
    Amount of global memory: 15.9844 GB
    Number of SMs:           64
GPU-0 can access GPU-1.
GPU-0 can access GPU-2.
GPU-1 can access GPU-0.
GPU-1 can access GPU-2.
GPU-2 can access GPU-0.
GPU-2 can access GPU-1.

---------------------------------------------------------------
Started running nep.
---------------------------------------------------------------


---------------------------------------------------------------
Started reading nep.in.
---------------------------------------------------------------

Default population size adjusted from 50 to 51 for GPU compatibility.
Input or default parameters:
    (default) model_type = potential.
    (default) calculation mode = train.
    (default) use NEP version 4.
    (input)   number of atom types = 2.
        (default) type 0 (Te with Z = 52) has force weight of 1.
        (default) type 1 (Pb with Z = 82) has force weight of 1.
    (default) will not add the ZBL potential.
    (default) radial cutoff = 8 A.
    (default) angular cutoff = 4 A.
    (default) use global cutoff for NEP.
    (default) use global cutoff for ZBL.
    (default) n_max_radial = 4.
    (default) n_max_angular = 4.
    (default) basis_size_radial = 8.
    (default) basis_size_angular = 8.
    (default) l_max_3body = 4.
    (default) l_max_4body = 2.
    (default) l_max_5body = 0.
    (default) number of neurons = 30.
    (default) lambda_1 = 0.0337713.
    (default) lambda_2 = 0.0337713.
    (default) lambda_e = 1.
    (default) lambda_f = 1.
    (default) lambda_v = 0.1.
    (default) atomic_v = 0.
    (default) lambda_shear = 1.
    (default) force_delta = 0.
    (default) batch size = 1000.
    (default) population size = 51.
    (input)   maximum number of generations = 20000.
    (input)   save potential every N = 100000 generations.
Some calculated parameters:
    number of radial descriptor components = 5.
    number of angular descriptor components = 25.
    total number of descriptor components = 30.
    NN architecture = 30-30-1.
    number of NN parameters to be optimized = 1921.
    number of descriptor parameters to be optimized = 360.
    total number of parameters to be optimized = 2281.

---------------------------------------------------------------
Finished reading nep.in.
---------------------------------------------------------------


---------------------------------------------------------------
Started reading train.xyz
Launch params (1024, 1, 1) are larger than launch bounds (256) for kernel _ZL12find_max_miniPKfPf please add __launch_bounds__ to kernel define or use --gpu-max-threads-per-block recompile program ! 
---------------------------------------------------------------

Number of configurations = 25.
Number of devices = 3
Number of batches = 1
Hello, I changed the batch_size from 1000 to 25.

Batch 0:
Number of configurations = 25.

---------------------------------------------------------------
Constructing train_set in device  0.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  1.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Constructing train_set in device  2.
Total number of atoms = 6250.
Number of atoms in the largest configuration = 250.
Number of configurations having virial = 0.
Radial descriptor with a cutoff of 8 A:
    Minimum number of neighbors for one atom = 56.
    Maximum number of neighbors for one atom = 73.
Angular descriptor with a cutoff of 4 A:
    Minimum number of neighbors for one atom = 5.
    Maximum number of neighbors for one atom = 8.
---------------------------------------------------------------


---------------------------------------------------------------
Time used for initialization = 1.284461 s.
---------------------------------------------------------------


---------------------------------------------------------------
Started training.
---------------------------------------------------------------

Step    Total-Loss L1Reg-Loss L2Reg-Loss RMSE-E-Train RMSE-F-Train RMSE-V-Train RMSE-E-Test  RMSE-F-Test  RMSE-V-Test  
100     0.12357    0.01759    0.02084    0.00181      0.08333      0.00000      0.00000      0.00000      0.00000      
200     0.11414    0.01827    0.02184    0.00089      0.07314      0.00000      0.00000      0.00000      0.00000      
300     0.12443    0.01874    0.02261    0.00245      0.08063      0.00000      0.00000      0.00000      0.00000      
400     0.12409    0.01922    0.02343    0.00119      0.08025      0.00000      0.00000      0.00000      0.00000      
500     0.11075    0.01957    0.02393    0.00084      0.06640      0.00000      0.00000      0.00000      0.00000      
600     0.11323    0.02005    0.02463    0.00103      0.06752      0.00000      0.00000      0.00000      0.00000      
700     0.11125    0.02050    0.02524    0.00237      0.06314      0.00000      0.00000      0.00000      0.00000      
...
...
```

Please let me know if any additional information, test cases, or modifications are needed. I’d be happy to assist further.
