### PR TITLE
fix typos

### DIFF
--- a/tools/Analysis_and_Processing/energy-reference-aligner/Energy-Reference-Aligner.py
+++ b/tools/Analysis_and_Processing/energy-reference-aligner/Energy-Reference-Aligner.py
@@ -25,7 +25,7 @@ It supports three distinct energy alignment modes, configurable via the 'ALIGNME
 
 3.  'DFT_TO_NEP_ALIGNMENT':
     Purpose: To align the original DFT energies (read from 'energy=' field) to the energies
-             calculated by a Neural Exchange-correlation Potential (NEP) model. This is useful
+             calculated by a Neuroevolution Potential (NEP) model. This is useful
              for standardizing DFT data to the scale of a force field or machine learning potential.
     Method: First, NEP energies are calculated for all structures using an external NEP model file.
             Then, for each 'config_type' group, atomic energy baselines are optimized to minimize

--- a/tools/Analysis_and_Processing/energy-reference-aligner/README.md
+++ b/tools/Analysis_and_Processing/energy-reference-aligner/README.md
@@ -8,21 +8,21 @@ This script provides a flexible tool for aligning energies within multi-frame XY
 
 ### 1. REF_GROUP_ALIGNMENT
 
-**Purpose**: Aligns the energies of specified shift_groups to the average energy baseline of a designated reference_group. This is useful when you have a high-accuracy dataset (reference_group) and want to shift other datasets (shift_groups) to its scale.
-**Method**: For each shift group, atomic energy baselines (one per element type) are optimized by minimizing the mean squared error (MSE) between shifted group energies and the mean energy of the reference group.
-**Settings Used**: reference_group, shift_groups. nep_model_file is ignored.
+- **Purpose**: Aligns the energies of specified shift_groups to the average energy baseline of a designated reference_group. This is useful when you have a high-accuracy dataset (reference_group) and want to shift other datasets (shift_groups) to its scale.
+- **Method**: For each shift group, atomic energy baselines (one per element type) are optimized by minimizing the mean squared error (MSE) between shifted group energies and the mean energy of the reference group.
+- **Settings Used**: reference_group, shift_groups. nep_model_file is ignored.
 
 ### 2. ZERO_BASELINE_ALIGNMENT
 
-**Purpose**: Shifts all energies in the XYZ file such that the calculated energy of free atoms (based on optimized atomic baselines) would be zero. This is a common practice for standardizing energies to a vacuum reference.
-**Method**: For each detected config_type group, atomic energy baselines are optimized by minimizing the MSE of the shifted energies themselves (effectively aligning to zero).
-**Settings Used**: None of reference_group, shift_groups, or nep_model_file are used for logic.
+- **Purpose**: Shifts all energies in the XYZ file such that the calculated energy of free atoms (based on optimized atomic baselines) would be zero. This is a common practice for standardizing energies to a vacuum reference.
+- **Method**: For each detected config_type group, atomic energy baselines are optimized by minimizing the MSE of the shifted energies themselves (effectively aligning to zero).
+- **Settings Used**: None of reference_group, shift_groups, or nep_model_file are used for logic.
 
 ### 3. DFT_TO_NEP_ALIGNMENT
 
-**Purpose**: Aligns the original DFT energies (read from energy= field) to the energies calculated by a Neural Exchange-correlation Potential (NEP) model. This is useful for standardizing DFT data to the scale of a force field or machine learning potential.
-**Method**: First, NEP energies are calculated for all structures using an external NEP model file. Then, for each config_type group, atomic energy baselines are optimized to minimize the MSE between the shifted DFT energies and the calculated NEP energies.
-**Settings Used**: nep_model_file. reference_group and shift_groups are ignored.
+- **Purpose**: Aligns the original DFT energies (read from energy= field) to the energies calculated by a Neuroevolution Potential (NEP) model. This is useful for standardizing DFT data to the scale of a force field or machine learning potential.
+- **Method**: First, NEP energies are calculated for all structures using an external NEP model file. Then, for each config_type group, atomic energy baselines are optimized to minimize the MSE between the shifted DFT energies and the calculated NEP energies.
+- **Settings Used**: nep_model_file. reference_group and shift_groups are ignored.
 
 ## Key Features
 


### PR DESCRIPTION
This pull request updates the terminology and formatting in the `Energy-Reference-Aligner` tool to improve clarity and consistency. The most important changes include renaming "Neural Exchange-correlation Potential" to "Neuroevolution Potential" and standardizing markdown formatting in the README file.

### Terminology Update:
* Renamed "Neural Exchange-correlation Potential (NEP)" to "Neuroevolution Potential (NEP)" in the `DFT_TO_NEP_ALIGNMENT` description in `Energy-Reference-Aligner.py` and `README.md` for consistency with updated terminology. [[1]](diffhunk://#diff-5a275b2578d62c06e8bcd554fa98890d1e17fffadedd504ed82c51137b911a32L28-R28) [[2]](diffhunk://#diff-27673158afbdeff56541735b7763d7d2df0aad9baeeb7afabe2a6e17ca3e36d4L11-R25)

### Documentation Formatting:
* Standardized markdown formatting in the `README.md` file by adding consistent bullet points (`-`) and bold text for section headers under alignment methods. This improves readability and aligns with documentation best practices.