### PR TITLE
feat: improve parameter handling and add descriptor output interface

### DIFF
--- a/src/main_gnep/dataset.cu
+++ b/src/main_gnep/dataset.cu
@@ -205,9 +205,7 @@ void Dataset::initialize_gpu_data(Parameters& para)
   r.resize(N * 3);
   type.resize(N);
   type_sum.resize(para.num_types);
-  for (int n = 0; n < para.num_types; ++n) {
-    printf("Number of atoms type %d = %d\n", n, type_sum_cpu[n]);
-  }
+
   box.copy_from_host(box_cpu.data());
   box_original.copy_from_host(box_original_cpu.data());
   num_cell.copy_from_host(num_cell_cpu.data());

--- a/src/main_gnep/gnep.cu
+++ b/src/main_gnep/gnep.cu
@@ -1733,6 +1733,37 @@ void GNEP::find_force(
       gnep_data[device_id].sum_fxyz.data());
     GPU_CHECK_KERNEL
 
+    if (para.prediction == 1 && para.output_descriptor >= 1) {
+      FILE* fid_descriptor = my_fopen("descriptor.out", "a");
+      std::vector<float> descriptor_cpu(gnep_data[device_id].descriptors.size());
+      gnep_data[device_id].descriptors.copy_to_host(descriptor_cpu.data());
+      for (int nc = 0; nc < dataset[device_id].Nc; ++nc) {
+        float q_structure[MAX_DIM] = {0.0f};
+        for (int na = 0; na < dataset[device_id].Na_cpu[nc]; ++na) {
+          int n = dataset[device_id].Na_sum_cpu[nc] + na;
+          for (int d = 0; d < annmb[device_id].dim; ++d) {
+            float q = descriptor_cpu[n + d * dataset[device_id].N] * para.q_scaler_cpu[d];
+            q_structure[d] += q;
+            if (para.output_descriptor == 2) {
+              fprintf(fid_descriptor, "%g ", q);
+            }
+          }
+          if (para.output_descriptor == 2) {
+            fprintf(fid_descriptor, "\n");
+          }
+        }
+        if (para.output_descriptor == 1) {
+          for (int d = 0; d < annmb[device_id].dim; ++d) {
+            fprintf(fid_descriptor, "%g ", q_structure[d] / dataset[device_id].Na_cpu[nc]);
+          }
+        }
+        if (para.output_descriptor == 1) {
+          fprintf(fid_descriptor, "\n");
+        }
+      }
+      fclose(fid_descriptor);
+    }
+
     if (calculate_q_scaler) {
       find_max_min<<<annmb[device_id].dim, 1024>>>(
         dataset[device_id].N,

--- a/src/main_gnep/parameters.cu
+++ b/src/main_gnep/parameters.cu
@@ -58,7 +58,7 @@ void Parameters::set_default_parameters()
   is_l_max_set = false;
   is_neuron_set = false;
   is_weight_decay_set = false;
-  is_lr_set = false;
+  is_start_lr_set = false;
   is_stop_lr_set = false;
   is_lambda_shear_set = false;
   is_batch_set = false;
@@ -97,6 +97,7 @@ void Parameters::set_default_parameters()
   typewise_cutoff_angular_factor = -1.0f;
   typewise_cutoff_zbl_factor = -1.0f;
   energy_shift = 0;
+  output_descriptor = false;
 
   type_weight_cpu.resize(NUM_ELEMENTS);
   zbl_para.resize(550); // Maximum number of zbl parameters
@@ -295,7 +296,7 @@ void Parameters::report_inputs()
     printf("    (default) weight_decay = %g.\n", weight_decay);
   }
 
-  if (is_lr_set) {
+  if (is_start_lr_set) {
     printf("    (input)   start learning rate = %g.\n", start_lr);
   } else {
     printf("    (default) start learning rate = %g.\n", start_lr);
@@ -390,8 +391,8 @@ void Parameters::parse_one_keyword(std::vector<std::string>& tokens)
     parse_epoch(param, num_param);
   } else if (strcmp(param[0], "weight_decay") == 0) {
     parse_weight_decay(param, num_param);
-  } else if (strcmp(param[0], "learning_rate") == 0) {
-    parse_lr(param, num_param);
+  } else if (strcmp(param[0], "start_lr") == 0) {
+    parse_start_lr(param, num_param);
   } else if (strcmp(param[0], "stop_lr") == 0) {
     parse_stop_lr(param, num_param);
   } else if (strcmp(param[0], "lambda_e") == 0) {
@@ -414,6 +415,8 @@ void Parameters::parse_one_keyword(std::vector<std::string>& tokens)
     parse_use_typewise_cutoff_zbl(param, num_param);
   } else if (strcmp(param[0], "energy_shift") == 0) {
     parse_energy_shift(param, num_param);
+  } else if (strcmp(param[0], "output_descriptor") == 0) {
+    parse_output_descriptor(param, num_param);
   } else {
     PRINT_KEYWORD_ERROR(param[0]);
   }
@@ -664,12 +667,12 @@ void Parameters::parse_weight_decay(const char** param, int num_param)
   }
 }
 
-void Parameters::parse_lr(const char** param, int num_param)
+void Parameters::parse_start_lr(const char** param, int num_param)
 {
-  is_lr_set = true;
+  is_start_lr_set = true;
 
   if (num_param != 2) {
-    PRINT_INPUT_ERROR("learning_rate should have 1 parameter.\n");
+    PRINT_INPUT_ERROR("start_lr should have 1 parameter.\n");
   }
 
   double lr_tmp = 0.0;
@@ -886,5 +889,20 @@ void Parameters::parse_energy_shift(const char** param, int num_param)
   }
   if (energy_shift != 0 && energy_shift != 1) {
     PRINT_INPUT_ERROR("energy_shift should = 0 or 1.");
+  }
+}
+
+void Parameters::parse_output_descriptor(const char** param, int num_param)
+{
+  output_descriptor = true;
+
+  if (num_param != 2) {
+    PRINT_INPUT_ERROR("output_descriptor should have 1 parameter.\n");
+  }
+  if (!is_valid_int(param[1], &output_descriptor)) {
+    PRINT_INPUT_ERROR("output_descriptor should be an integer.\n");
+  }
+  if (output_descriptor < 0 || output_descriptor > 2) {
+    PRINT_INPUT_ERROR("output_descriptor should >= 0 and <= 2.");
   }
 }

--- a/src/main_gnep/parameters.cuh
+++ b/src/main_gnep/parameters.cuh
@@ -56,6 +56,7 @@ public:
   float typewise_cutoff_radial_factor;
   float typewise_cutoff_angular_factor;
   float typewise_cutoff_zbl_factor;
+  int output_descriptor;
 
   // check if a parameter has been set:
   bool is_prediction_set;
@@ -66,7 +67,7 @@ public:
   bool is_l_max_set;
   bool is_neuron_set;
   bool is_weight_decay_set;
-  bool is_lr_set;
+  bool is_start_lr_set;
   bool is_stop_lr_set;
   bool is_lambda_e_set;
   bool is_lambda_f_set;
@@ -121,7 +122,7 @@ private:
   void parse_l_max(const char** param, int num_param);
   void parse_neuron(const char** param, int num_param);
   void parse_weight_decay(const char** param, int num_param);
-  void parse_lr(const char** param, int num_param);
+  void parse_start_lr(const char** param, int num_param);
   void parse_stop_lr(const char** param, int num_param);
   void parse_lambda_e(const char** param, int num_param);
   void parse_lambda_f(const char** param, int num_param);
@@ -133,4 +134,5 @@ private:
   void parse_use_typewise_cutoff(const char** param, int num_param);
   void parse_use_typewise_cutoff_zbl(const char** param, int num_param);
   void parse_energy_shift(const char** param, int num_param);
+  void parse_output_descriptor(const char** param, int num_param);
 };


### PR DESCRIPTION
- Remove debug logging for atom type counts
- Update descriptor output interface for data extraction
- Rename learning_rate parameter to start_lr for clarity

Changes include removing printf statements that logged atom counts by type, implementing a new interface to output descriptor data, and updating the parameter name from learning_rate to start_lr to better reflect its purpose as the initial learning rate.
