### PR TITLE
fix typo in ensemble_mttk

### DIFF
--- a/src/integrate/ensemble_mttk.cu
+++ b/src/integrate/ensemble_mttk.cu
@@ -105,11 +105,11 @@ Ensemble_MTTK::Ensemble_MTTK(const char** params, int num_params)
       i += 1;
     } else if (strcmp(params[i], "tperiod") == 0) {
       if (!is_valid_real(params[i + 1], &t_period))
-        PRINT_INPUT_ERROR("Wrong inputs for t_period keyword.");
+        PRINT_INPUT_ERROR("Wrong inputs for tperiod keyword.");
       i += 2;
     } else if (strcmp(params[i], "pperiod") == 0) {
       if (!is_valid_real(params[i + 1], &p_period[0][0]))
-        PRINT_INPUT_ERROR("Wrong inputs for p_period keyword.");
+        PRINT_INPUT_ERROR("Wrong inputs for pperiod keyword.");
       i += 2;
       for (int i = 0; i < 3; i++) {
         for (int j = 0; j < 3; j++) {


### PR DESCRIPTION
**Summary**(https://github.com/brucefan1983/GPUMD/blob/cb753f43a95a22ed41aa59e257e258a430fcee05/src/integrate/ensemble_mttk.cu#L106-L112)
The order of `p_period` and `t_period` is reversed in `PRINT_INPUT_ERROR`

**Modification**

Swapping the order to make sure it's printed as expected