### PR TITLE
speed up `compute_small_box`

### DIFF
--- a/src/force/nep.cuh
+++ b/src/force/nep.cuh
@@ -108,6 +108,14 @@ public:
     float h[18];
   };
 
+  struct Small_Box_Data {
+        GPU_Vector<int> NN_radial;
+        GPU_Vector<int> NL_radial;
+        GPU_Vector<int> NN_angular;
+        GPU_Vector<int> NL_angular;
+        GPU_Vector<float> r12;
+    } small_box_data;
+
   NEP(const char* file_potential, const int num_atoms);
   virtual ~NEP(void);
   virtual void compute(


### PR DESCRIPTION
**Summary**
In the original implementation of `compute_small_box()` in the `NEP` class, several new `GPU_Vector` objects are created using `cudaMalloc` and then destroyed by `cudaFree`, which introduces a significant computational cost:

https://github.com/brucefan1983/GPUMD/blob/ef316570250748a0d5ca96f80638a7c09cc33385/src/force/nep.cu#L1387-L1391

**Modification**
I added a new member variable `small_box_data` to store the relative information at the beginning to avoid recreating these new `GPU_Vector`s:

https://github.com/MoseyQAQ/GPUMD/blob/c00ef6d62c4a33cc922d2779b12f22d8e64753e1/src/force/nep.cuh#L111-L117

**Verifications**

For a given `model.xyz`, and a given `nep.txt`, I performed the following calculations using the old and new implementations separately :
* predict energy, force and virial, and compare them
* perform minimization, and compare optimized position, and corresponding energy, force, virial.
* perform 1ps-NPT simulation (1000 steps), and compare the position, cell, energy, force, and virial along the 1000 configurations.
All the tests mentioned above have been passed, yielding the same results. All original input files and output files are attached.

[Small_Cell_PR_test_upload.zip](https://github.com/user-attachments/files/21760621/Small_Cell_PR_test_upload.zip)
(Note: raw trajectory files for NPT simulations are deleted, since they are too huge to be uploaded in GitHub issue)

**Speed Benchmark**

<img width="1143" height="487" alt="image" src="https://github.com/user-attachments/assets/d8dee7f3-4699-4f5e-bda0-fb6ff932bf04" />



