### PR TITLE
Output uncertainty per atom during active learning

### DIFF
--- a/doc/gpumd/input_parameters/active.rst
+++ b/doc/gpumd/input_parameters/active.rst
@@ -14,7 +14,7 @@ The uncertainty :math:`\sigma_f` is estimated as the maximum force sample standa
 
 where :math:`\sigma_{i,k}^2`, :math:`k\in{x,y,z}`, are the sample variances in the :math:`k` Cartesian direction calculated over the :math:`M` models. If the uncertainty exceeds the specified threshold, :math:`\sigma_f>\delta`, for a structure in a step of an molecular dynamics simulation, then that structure is appended to the file `active.xyz` in the `extended XYZ format <https://github.com/libAtoms/extxyz>`_. Additionally, the simulation time :math:`t` and :math:`\sigma_f` are written to the file `active.out` regardless of if :math:`\sigma_f>\delta`.
 
-`active` takes four arguments. The first three are the same as for :ref:`dump_exyz <kw_dump_exyz>`, with the fourth keyword being the threshold :math:`\delta` in units of eV/Å.
+`active` takes five arguments. The first four sets the interval for uncertainty estimation and what per atom quantities are outputted in `active.xyz`, the fifth keyword sets the threshold :math:`\delta` in units of eV/Å.
       
 
 Syntax
@@ -22,11 +22,12 @@ Syntax
 
 .. code::
 
-   active <interval> <has_velocity> <has_force> <threshold>
+   active <interval> <has_velocity> <has_force> <has_uncertainty> <threshold>
 
 :attr:`interval` is the interval (number of steps) between checking the uncertainty. If set to 1, the uncertainty will be computed for every step of the MD simulation.
 :attr:`has_velocity` can be 1 or 0, which means the velocities will or will not be included in the exyz output.
 :attr:`has_force` can be 1 or 0, which means the forces will or will not be included in the exyz output.
+:attr:`has_uncertainty` can be 1 or 0, which means the per atom uncertainties will or will not be included in the exyz output.
 :attr:`threshold` is a non-negative float, and corresponds to the threshold :math:`\delta` in units of eV/Å.
 
 Examples
@@ -42,7 +43,7 @@ To run on-the-fly active learning using a committee of 5 NEP potentials, checkin
   potential nep3
   potential nep4
   ...
-  active 10 1 1 0.01
+  active 10 1 1 1 0.01
 
 before the :ref:`run keyword <kw_run>`. This will generate two output files, `active.xyz` and `active.out`. 
 

--- a/doc/gpumd/output_files/active_xyz.rst
+++ b/doc/gpumd/output_files/active_xyz.rst
@@ -5,7 +5,7 @@
 ``active.xyz``
 ================
 
-File containing atomistic positions, velocities and forces for structures written during on-the-fly active learning.
+File containing atomistic positions, velocities, forces and uncertainties for structures written during on-the-fly active learning.
 It is generated when invoking the :ref:`active <kw_active>` keyword.
 Only structures with uncertainty exceeding the threshold :math:`\delta` will be written; thus, if no such structure is encountered during the MD simulation, this file will be missing.
 

--- a/src/measure/active.cu
+++ b/src/measure/active.cu
@@ -120,8 +120,8 @@ void Active::parse(const char** param, int num_param)
   check_ = true;
   printf("Active learning.\n");
 
-  if (num_param != 5) {
-    PRINT_INPUT_ERROR("active should have 4 parameters.");
+  if (num_param != 6) {
+    PRINT_INPUT_ERROR("active should have 5 parameters.");
   }
   if (!is_valid_int(param[1], &check_interval_)) {
     PRINT_INPUT_ERROR("check interval should be an integer.");
@@ -148,7 +148,17 @@ void Active::parse(const char** param, int num_param)
   } else {
     printf("    with force data.\n");
   }
-  if (!is_valid_real(param[4], &threshold_)) {
+
+  if (!is_valid_int(param[4], &has_uncertainty_)) {
+    PRINT_INPUT_ERROR("has_uncertainty should be an integer.");
+  }
+  if (has_uncertainty_ == 0) {
+    printf("    without uncertainty data.\n");
+  } else {
+    printf("    with uncertainty data.\n");
+  }
+
+  if (!is_valid_real(param[5], &threshold_)) {
     PRINT_INPUT_ERROR("threshold should be a real number.\n");
   }
 
@@ -363,6 +373,9 @@ void Active::output_line2(
   if (has_force_) {
     fprintf(fid_, ":forces:R:3");
   }
+  if (has_uncertainty_) {
+    fprintf(fid_, ":uncertainty:R:1");
+  }
 
   // Over
   fprintf(fid_, "\n");
@@ -421,6 +434,9 @@ void Active::write_exyz(
       for (int d = 0; d < 3; ++d) {
         fprintf(fid_, " %.8f", cpu_force_per_atom_[n + num_atoms_total * d]);
       }
+    }
+    if (has_uncertainty_) {
+      fprintf(fid_, " %.8f", cpu_uncertainty_[n]);
     }
     fprintf(fid_, "\n");
   }

--- a/src/measure/active.cuh
+++ b/src/measure/active.cuh
@@ -64,6 +64,7 @@ private:
   int check_interval_ = 1;
   int has_velocity_ = 0;
   int has_force_ = 0;
+  int has_uncertainty_ = 0;
   double threshold_ = 0.0;
   FILE* exyz_file_;
   FILE* out_file_;


### PR DESCRIPTION
**Summary**
Update the `active` command to support outputting the per atom uncertainties to `active.xyz`.
This is useful for visualizing the uncertainties e.g. using OVITO and for extracting local environments (with large model deviations) from simulations of big systems.

**Modification**
Add an extra flag `has_uncertainty` to the `active` command to enable this.
Modified the parsing and xyz output of the `active` command accordingly.
Updated the docs. to reflect this change.