### PR TITLE
Enforce minimum pperiod value in ensemble `mttk`

### DIFF
--- a/doc/gpumd/input_parameters/ensemble_mttk.rst
+++ b/doc/gpumd/input_parameters/ensemble_mttk.rst
@@ -36,7 +36,7 @@ Using ``x``, ``y``, ``z``, ``xy``, ``yz``, ``xz`` allows one to specify each str
 
 The parameters :attr:`<p_1>` and :attr:`<p_2>` specify the initial and final pressure, respectively.
 Finally, the optional parameter :attr:`<tau_press>`, which defaults to ``1000``, determines the period of the barostat in units of the timestep.
-It determines how strongly the system is coupled to the barostat.
+It determines how strongly the system is coupled to the barostat and should be :math:`\geq 200` timesteps.
 
 The :attr:`nph_mttk` keyword can be used in analoguous fashion to run simulations in the isenthalpic (NPH) ensemble::
 

--- a/src/integrate/ensemble_mttk.cu
+++ b/src/integrate/ensemble_mttk.cu
@@ -110,8 +110,9 @@ Ensemble_MTTK::Ensemble_MTTK(const char** params, int num_params)
     } else if (strcmp(params[i], "pperiod") == 0) {
       if (!is_valid_real(params[i + 1], &p_period[0][0]))
         PRINT_INPUT_ERROR("Wrong inputs for pperiod keyword.");
-      if (p_period[0][0] < 200) // Fix issue #1117
+      if (p_period[0][0] < 200) {
         PRINT_INPUT_ERROR("pperiod should >= 200 timestep."); 
+      }
       i += 2;
       for (int i = 0; i < 3; i++) {
         for (int j = 0; j < 3; j++) {

--- a/src/integrate/ensemble_mttk.cu
+++ b/src/integrate/ensemble_mttk.cu
@@ -110,6 +110,8 @@ Ensemble_MTTK::Ensemble_MTTK(const char** params, int num_params)
     } else if (strcmp(params[i], "pperiod") == 0) {
       if (!is_valid_real(params[i + 1], &p_period[0][0]))
         PRINT_INPUT_ERROR("Wrong inputs for pperiod keyword.");
+      if (p_period[0][0] < 200) // Fix issue #1117
+        PRINT_INPUT_ERROR("pperiod should >= 200 timestep."); 
       i += 2;
       for (int i = 0; i < 3; i++) {
         for (int j = 0; j < 3; j++) {


### PR DESCRIPTION
**Summary**
Fix issue #1117 

**Modification**
a minimum `pperiod` value is required:

```c++
      if (p_period[0][0] < 200) // Fix issue #1117
        PRINT_INPUT_ERROR("pperiod should >= 200 timestep."); 
```
**Others**
The corresponding document has also incorporated this requirement.
