### PR TITLE
fix virial mismatch in nep-charge

### DIFF
--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -560,9 +560,9 @@ static __global__ void find_force_radial(
     g_virial[n1] += s_virial_xx;
     g_virial[n1 + N] += s_virial_yy;
     g_virial[n1 + N * 2] += s_virial_zz;
-    g_virial[n1 + N * 3] = s_virial_xy;
-    g_virial[n1 + N * 4] = s_virial_yz;
-    g_virial[n1 + N * 5] = s_virial_zx;
+    g_virial[n1 + N * 3] += s_virial_xy;
+    g_virial[n1 + N * 4] += s_virial_yz;
+    g_virial[n1 + N * 5] += s_virial_zx;
   }
 }
 


### PR DESCRIPTION
**Summary**

Fix small mismatch on the off-diagonal virial components between `nep` and `gpumd` executables for NEP-charge.
