### PR TITLE
random-batch-ewald

### DIFF
--- a/src/force/nep_charge.cuh
+++ b/src/force/nep_charge.cuh
@@ -18,6 +18,7 @@
 #include "potential.cuh"
 #include "utilities/common.cuh"
 #include "utilities/gpu_vector.cuh"
+#include <random>
 
 struct NEP_Charge_Data {
   GPU_Vector<float> f12x; // 3-body or manybody partial forces
@@ -146,6 +147,7 @@ private:
   ExpandedBox ebox;
   DFTD3 dftd3;
   Charge_Para charge_para;
+  std::mt19937 rng;
 
   void update_potential(float* parameters, ANN& ann);
 #ifdef USE_TABLE


### PR DESCRIPTION
Might be a good approach, but requires extensive tests. Add `-DUSE_RBE` to enable this feature in MD simulations (only NPT and NVT, as energy is not conserved) with NEP-Charge.

Reference:
Shi Jin, Lei Li, Zhenli Xu, and Yue Zhao,
[A Random Batch Ewald Method for Particle Systems with Coulomb Interactions](https://epubs.siam.org/doi/10.1137/20M1371385), SIAM Journal on Scientific Computing, **43**, B937 (2021).