### PR TITLE
dump charge

### DIFF
--- a/src/main_gpumd/add_efield.cu
+++ b/src/main_gpumd/add_efield.cu
@@ -35,29 +35,6 @@ static void __global__ add_efield(
   const double Ex,
   const double Ey,
   const double Ez,
-  const double* g_charge,
-  double* g_fx,
-  double* g_fy,
-  double* g_fz)
-{
-  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
-  if (tid < group_size) {
-    const int atom_id = g_group_contents[group_size_sum + tid];
-    const double charge = g_charge[atom_id];
-    g_fx[atom_id] += charge * Ex;
-    g_fy[atom_id] += charge * Ey;
-    g_fz[atom_id] += charge * Ez;
-  }
-}
-
-// for NEP-charge
-static void __global__ add_efield(
-  const int group_size,
-  const int group_size_sum,
-  const int* g_group_contents,
-  const double Ex,
-  const double Ey,
-  const double Ez,
   const float* g_charge,
   double* g_fx,
   double* g_fy,

--- a/src/measure/dump_xyz.cuh
+++ b/src/measure/dump_xyz.cuh
@@ -64,12 +64,14 @@ public:
     bool has_potential_ = false;
     bool has_unwrapped_position_ = false;
     bool has_mass_ = false;
+    bool has_charge_ = false;
     bool has_virial_ = false;
     bool has_group_ = false;
   };
 
 private:
 
+  bool is_nep_charge = false;
   int grouping_method_ = -1;
   int group_id_ = -1;
   int dump_interval_ = 1;

--- a/src/model/atom.cuh
+++ b/src/model/atom.cuh
@@ -25,13 +25,13 @@ public:
   std::vector<int> cpu_type;
   std::vector<int> cpu_type_size;
   std::vector<double> cpu_mass;
-  std::vector<double> cpu_charge;
+  std::vector<float> cpu_charge; // float is sufficient for charge
   std::vector<double> cpu_position_per_atom;
   std::vector<double> cpu_velocity_per_atom;
   std::vector<std::string> cpu_atom_symbol;
   GPU_Vector<int> type;                  // per-atom type (1 component)
   GPU_Vector<double> mass;               // per-atom mass (1 component)
-  GPU_Vector<double> charge;             // per-atom charge (1 component)
+  GPU_Vector<float> charge;              // per-atom charge (1 component)
   GPU_Vector<double> position_per_atom;  // per-atom position (3 components)
   GPU_Vector<double> position_temp;      // used to calculated unwrapped_position
   GPU_Vector<double> unwrapped_position; // unwrapped per-atom position (3 components)

--- a/src/model/read_xyz.cu
+++ b/src/model/read_xyz.cu
@@ -322,7 +322,7 @@ void read_xyz_in_line_3(
   std::vector<std::string>& cpu_atom_symbol,
   std::vector<int>& cpu_type,
   std::vector<double>& cpu_mass,
-  std::vector<double>& cpu_charge,
+  std::vector<float>& cpu_charge,
   std::vector<double>& cpu_position_per_atom,
   std::vector<double>& cpu_velocity_per_atom,
   std::vector<Group>& group)


### PR DESCRIPTION
**Summary**

Allow for dumping `charge` into a file using the `dump_xyz` keyword.

When an NEP-charge potential model is used, the charges output will be those predicted by the NEP-Charge model; otherwise they will be simply those specified in the `model.xyz` file.