### PR TITLE
allow switching between ewald and pppm

### DIFF
--- a/src/force/nep_charge.cuh
+++ b/src/force/nep_charge.cuh
@@ -18,6 +18,7 @@
 #include "potential.cuh"
 #include "utilities/common.cuh"
 #include "utilities/gpu_vector.cuh"
+#include "ewald.cuh"
 #include "pppm.cuh"
 
 struct NEP_Charge_Data {
@@ -152,6 +153,7 @@ private:
   ExpandedBox ebox;
   DFTD3 dftd3;
   Charge_Para charge_para;
+  Ewald ewald;
   PPPM pppm;
 
   void update_potential(float* parameters, ANN& ann);
@@ -177,6 +179,8 @@ private:
 
   void find_k_and_G(const double* box);
 
+  bool use_pppm = true; // use PPPM by default
+  void check_ewald_pppm();
   bool has_dftd3 = false;
   void initialize_dftd3();
 };

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -566,6 +566,8 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
     add_efield.parse(param, num_param, group);
   } else if (strcmp(param[0], "mc") == 0) {
     mc.parse_mc(param, num_param, group, atom);
+  } else if (strcmp(param[0], "kspace") == 0) {
+    // nothing here; will be handled elsewhere
   } else if (strcmp(param[0], "dftd3") == 0) {
     // nothing here; will be handled elsewhere
   } else if (strcmp(param[0], "compute_lsqt") == 0) {


### PR DESCRIPTION
**Summary**

In `run.in`, use
```
kspace ewald
```
to enable Ewald for the k-space part of Coulomb interactions.

use
```
kspace ppm
```
to enable PPPM for the k-space part of Coulomb interactions.

The default is PPPM.