### PR TITLE
5-order-PPPM

### DIFF
--- a/src/force/pppm.cu
+++ b/src/force/pppm.cu
@@ -36,6 +36,14 @@ int get_best_K(const int m)
 }
 
 __constant__ float sinc_coeff[6] = {1.0f, -1.6666667e-1f, 8.3333333e-3f, -1.9841270e-4f, 2.7557319e-6f, -2.5052108e-8f};
+__constant__ float G_coeff[5] = {1.0000000e+00f, -1.6666667e+00f, 7.7777778e-01f, -8.9947090e-02f, 7.0546737e-04f};
+__constant__ float W_coeff[5][5] = {
+  {2.6041667e-03f, -2.0833333e-02f, 6.2500000e-02f, -8.3333333e-02f, 4.1666667e-02f},
+  {1.9791667e-01f, -4.5833333e-01f, 2.5000000e-01f, 1.6666667e-01f, -1.6666667e-01f},
+  {5.9895833e-01f, 0.0000000e+00f, -6.2500000e-01f, 0.0000000e+00f, 2.5000000e-01f},
+  {1.9791667e-01f, 4.5833333e-01f, 2.5000000e-01f, -1.6666667e-01f, -1.6666667e-01f},
+  {2.6041667e-03f, 2.0833333e-02f, 6.2500000e-02f, 8.3333333e-02f, 4.1666667e-02f}
+};
 
 __device__ inline float sinc(const float x)
 {
@@ -66,16 +74,16 @@ void __global__ find_k_and_G_opt(
     nk[1] = (n - nk[2] * para.K0K1) / para.K[0];
     nk[0] = n % para.K[0];
 
-    // Eq. (6.40) in Allen & Tildesley
+    // Eqs. (2.25) and (2.26) in V. Ballenegger, J. J. Cerda, and C. Holm, JCTC 8, 936 (2012)
     float denominator[3] = {0.0f};
     for (int d = 0; d < 3; ++d) {
       if (nk[d] >= para.K_half[d]) {
         nk[d] -= para.K[d];
       }
-      denominator[d] = sin(0.5f * para.two_pi_over_K[d] * nk[d]);
-      denominator[d] *= denominator[d];
-      denominator[d] = 1.0f - denominator[d] + 0.13333333f * denominator[d] * denominator[d];
-      denominator[d] *= denominator[d];
+      float t = sin(0.5f * para.two_pi_over_K[d] * nk[d]);
+      t *= t;
+      t = (((G_coeff[4] * t + G_coeff[3]) * t + G_coeff[2]) * t + G_coeff[1]) * t + G_coeff[0];
+      denominator[d] = t * t;
     }
     const float kx = nk[0] * para.b[0][0] + nk[1] * para.b[1][0] + nk[2] * para.b[2][0];
     const float ky = nk[0] * para.b[0][1] + nk[1] * para.b[1][1] + nk[2] * para.b[2][1];
@@ -85,14 +93,14 @@ void __global__ find_k_and_G_opt(
     g_kz[n] = kz;
     const float ksq = kx * kx + ky * ky + kz * kz;
 
-    // Eq. (6.39) in Allen & Tildesley
+    // Eqs. (2.21) and (2.25) in V. Ballenegger, J. J. Cerda, and C. Holm, JCTC 8, 936 (2012)
     float numerator = sinc(0.5f * para.two_pi_over_K[0] * nk[0]);
     numerator *= sinc(0.5f * para.two_pi_over_K[1] * nk[1]);
     numerator *= sinc(0.5f * para.two_pi_over_K[2] * nk[2]);
-    numerator *= numerator * numerator;
+    numerator = numerator * numerator * numerator * numerator * numerator;
     numerator *= numerator;
 
-    // Eq. (6.41) in Allen & Tildesley
+    // Eqs. (2.25) in V. Ballenegger, J. J. Cerda, and C. Holm, JCTC 8, 936 (2012)
     if (ksq == 0.0f) {
       g_G[n] = 0.0f;
     } else {
@@ -149,18 +157,23 @@ __global__ void find_mesh(
     const float dx = sx - ix; // (-0.5, 0.5)
     const float dy = sy - iy; // (-0.5, 0.5)
     const float dz = sz - iz; // (-0.5, 0.5)
-    // Eq. (6.29) in Allen & Tildesley
-    const float Wx[3] = {0.5f * (0.5f - dx) * (0.5f - dx), 0.75f - dx * dx, 0.5f * (0.5f + dx) * (0.5f + dx)};
-    const float Wy[3] = {0.5f * (0.5f - dy) * (0.5f - dy), 0.75f - dy * dy, 0.5f * (0.5f + dy) * (0.5f + dy)};
-    const float Wz[3] = {0.5f * (0.5f - dz) * (0.5f - dz), 0.75f - dz * dz, 0.5f * (0.5f + dz) * (0.5f + dz)};
-    for (int n0 = -1; n0 <= 1; ++n0) {
+    // Appendix E in M. Deserno and C. Holm, JCP 109, 7678 (1998)
+    float Wx[5] = {0.0f};
+    float Wy[5] = {0.0f};
+    float Wz[5] = {0.0f};
+    for (int d = 0; d < 5; ++d) {
+      Wx[d] = (((W_coeff[d][4] * dx + W_coeff[d][3]) * dx + W_coeff[d][2]) * dx + W_coeff[d][1]) * dx + W_coeff[d][0];
+      Wy[d] = (((W_coeff[d][4] * dy + W_coeff[d][3]) * dy + W_coeff[d][2]) * dy + W_coeff[d][1]) * dy + W_coeff[d][0];
+      Wz[d] = (((W_coeff[d][4] * dz + W_coeff[d][3]) * dz + W_coeff[d][2]) * dz + W_coeff[d][1]) * dz + W_coeff[d][0];
+    }
+    for (int n0 = -2; n0 <= 2; ++n0) {
       const int neighbor0 = get_index_within_mesh(para.K[0], ix + n0);  // can be 0, ..., K[0]-1
-      for (int n1 = -1; n1 <= 1; ++n1) {
+      for (int n1 = -2; n1 <= 2; ++n1) {
         const int neighbor1 = get_index_within_mesh(para.K[1], iy + n1);  // can be 0, ..., K[1]-1
-        for (int n2 = -1; n2 <= 1; ++n2) {
+        for (int n2 = -2; n2 <= 2; ++n2) {
           const int neighbor2 = get_index_within_mesh(para.K[2], iz + n2);  // can be 0, ..., K[2]-1
           const int neighbor012 = neighbor0 + para.K[0] * (neighbor1 + para.K[1] * neighbor2);
-          const float W = Wx[n0 + 1] * Wy[n1 + 1] * Wz[n2 + 1];
+          const float W = Wx[n0 + 2] * Wy[n1 + 2] * Wz[n2 + 2];
           atomicAdd(&g_mesh[neighbor012].x, q * W);
         }
       }
@@ -239,20 +252,25 @@ __global__ void find_force_from_field(
     const float dx = sx - ix; // (-0.5, 0.5)
     const float dy = sy - iy; // (-0.5, 0.5)
     const float dz = sz - iz; // (-0.5, 0.5)
-    // Eq. (6.29) in Allen & Tildesley
-    const float Wx[3] = {0.5f * (0.5f - dx) * (0.5f - dx), 0.75f - dx * dx, 0.5f * (0.5f + dx) * (0.5f + dx)};
-    const float Wy[3] = {0.5f * (0.5f - dy) * (0.5f - dy), 0.75f - dy * dy, 0.5f * (0.5f + dy) * (0.5f + dy)};
-    const float Wz[3] = {0.5f * (0.5f - dz) * (0.5f - dz), 0.75f - dz * dz, 0.5f * (0.5f + dz) * (0.5f + dz)};
+    // Appendix E in M. Deserno and C. Holm, JCP 109, 7678 (1998)
+    float Wx[5] = {0.0f};
+    float Wy[5] = {0.0f};
+    float Wz[5] = {0.0f};
+    for (int d = 0; d < 5; ++d) {
+      Wx[d] = (((W_coeff[d][4] * dx + W_coeff[d][3]) * dx + W_coeff[d][2]) * dx + W_coeff[d][1]) * dx + W_coeff[d][0];
+      Wy[d] = (((W_coeff[d][4] * dy + W_coeff[d][3]) * dy + W_coeff[d][2]) * dy + W_coeff[d][1]) * dy + W_coeff[d][0];
+      Wz[d] = (((W_coeff[d][4] * dz + W_coeff[d][3]) * dz + W_coeff[d][2]) * dz + W_coeff[d][1]) * dz + W_coeff[d][0];
+    }
     float D_real = 0.0f;
     float E[3] = {0.0f, 0.0f, 0.0f};
-    for (int n0 = -1; n0 <= 1; ++n0) {
+    for (int n0 = -2; n0 <= 2; ++n0) {
       const int neighbor0 = get_index_within_mesh(para.K[0], ix + n0);  // can be 0, ..., K[0]-1
-      for (int n1 = -1; n1 <= 1; ++n1) {
+      for (int n1 = -2; n1 <= 2; ++n1) {
         const int neighbor1 = get_index_within_mesh(para.K[1], iy + n1);  // can be 0, ..., K[1]-1
-        for (int n2 = -1; n2 <= 1; ++n2) {
+        for (int n2 = -2; n2 <= 2; ++n2) {
           const int neighbor2 = get_index_within_mesh(para.K[2], iz + n2);  // can be 0, ..., K[2]-1
           const int neighbor012 = neighbor0 + para.K[0] * (neighbor1 + para.K[1] * neighbor2);
-          const float W = Wx[n0 + 1] * Wy[n1 + 1] * Wz[n2 + 1];
+          const float W = Wx[n0 + 2] * Wy[n1 + 2] * Wz[n2 + 2];
           D_real += W * g_mesh_G[neighbor012].x;
           E[0] += W * g_mesh_fft_x_ifft[neighbor012].x;
           E[1] += W * g_mesh_fft_y_ifft[neighbor012].x;


### PR DESCRIPTION
Increase the interpolation order from 3 to 5 for PPPM. 

| Order| 3| 5|
| ----------- | ----------- | ------------|
| Accuracy| $\sim 3\times 10^{-3} $|  $\sim 10^{-4} $|
| Speed | $4.2 \times 10^6$      | $3.5 \times 10^6$ |

Sacrifice  20% speed for more than one order of magnitude accuracy.