### PR TITLE
Fixed documentation of ADP

### DIFF
--- a/doc/bibliography.rst
+++ b/doc/bibliography.rst
@@ -178,6 +178,13 @@ Bibliography
    | The Journal of Chemical Physics, **101**, 4177-4189 (1994)
    | DOI: `10.1063/1.467468 <https://doi.org/10.1063/1.467468>`
 
+
+.. [Mishin2005]
+   | Y. Mishin, M. J. Mehl, and D. A. Papaconstantopoulos
+   | *Phase stability in the Fe–Ni system: Investigation by first-principles calculations and atomistic simulations*
+   | Acta Materialia **53**, 4029 (2005)
+   | DOI: `10.1016/j.actamat.2005.05.001 <https://doi.org/10.1016/j.actamat.2005.05.001>`
+
 .. [Parrinello1981]
    | M. Parrinello and A. Rahman
    | *Polymorphic transitions in single crystals: A new molecular dynamics method*

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -11,6 +11,9 @@ Glossary
    ADF
         angular distribution function
 
+   ADP
+        angular-dependent potential [Mishin2005]_
+
    ARDF
         angular-dependent radial distribution function
 

--- a/doc/potentials/adp.rst
+++ b/doc/potentials/adp.rst
@@ -182,10 +182,6 @@ Examples
 References
 ----------
 
-.. [Mishin2005] Y. Mishin, M. J. Mehl, and D. A. Papaconstantopoulos, "Phase stability in the Fe–Ni system: Investigation by first-principles calculations and atomistic simulations," Acta Mater. 53, 4029 (2005).
-
-.. [Apostol2011] F. Apostol and Y. Mishin, "Interatomic potential for the Al-Cu system," Phys. Rev. B 83, 054116 (2011).
-
 .. [Pun2015] G. P. Pun, K. A. Darling, L. J. Kecskes, and Y. Mishin, "Angular-dependent interatomic potential for the Cu–Ta system and its application to structural stability of nano-crystalline alloys," Acta Mater. 100, 377 (2015).
 
 .. [Starikov2018] S. V. Starikov, L. N. Kolotova, A. Y. Kuksin, D. E. Smirnova, and V. I. Tseplyaev, "Atomistic simulation of cubic and tetragonal phases of U-Mo alloy: Structure and thermodynamic properties," J. Nucl. Mater. 499, 451 (2018).

--- a/doc/potentials/index.rst
+++ b/doc/potentials/index.rst
@@ -20,3 +20,4 @@ Interatomic potentials
    nep_ilp
    sw_ilp
    tersoff_ilp
+   adp


### PR DESCRIPTION
Fixes the errors in the documentation that cause the [`pages` job](https://gitlab.com/materials-theory/gpumd-fork/-/jobs/11718282712) to fail atm.