### PR TITLE
Resolve HIP build failure from PPPM FFT aliases

### DIFF
--- a/src/force/pppm.cuh
+++ b/src/force/pppm.cuh
@@ -57,17 +57,17 @@ private:
   GPU_Vector<float> ky;
   GPU_Vector<float> kz;
   GPU_Vector<float> G;
-  GPU_Vector<cufftComplex> mesh;
-  GPU_Vector<cufftComplex> mesh_G;
-  GPU_Vector<cufftComplex> mesh_x;
-  GPU_Vector<cufftComplex> mesh_y;
-  GPU_Vector<cufftComplex> mesh_z;
+  GPU_Vector<gpufftComplex> mesh;
+  GPU_Vector<gpufftComplex> mesh_G;
+  GPU_Vector<gpufftComplex> mesh_x;
+  GPU_Vector<gpufftComplex> mesh_y;
+  GPU_Vector<gpufftComplex> mesh_z;
   gpufftHandle plan;
   void allocate_memory();
   void find_para(const int N, const Box& box);
   void find_k_and_G(const double* box);
 
   bool need_peratom_virial = false;
-  GPU_Vector<cufftComplex> mesh_virial;
+  GPU_Vector<gpufftComplex> mesh_virial;
   gpufftHandle plan_virial;
 };

--- a/src/utilities/gpu_macro.cuh
+++ b/src/utilities/gpu_macro.cuh
@@ -16,7 +16,7 @@
 #pragma once
 
 #ifdef USE_HIP // HIP for AMD card
-
+#include <hipfft/hipfft.h>
 #include <hip/hip_runtime.h>
 
 // memory manipulation
@@ -103,7 +103,7 @@
 #define GPUFFT_SUCCESS HIPFFT_SUCCESS
 #define GPUFFT_C2C HIPFFT_C2C
 #define GPUFFT_FORWARD HIPFFT_FORWARD
-#define GPUFFT_INVERSE HIPFFT_INVERSE
+#define GPUFFT_INVERSE HIPFFT_BACKWARD
 
 #else // CUDA for Nvidia card
 


### PR DESCRIPTION
**Summary**
- Update PPPM to use the gpufft abstraction instead of CUDA-only `cufftComplex`, so HIP builds resolve the FFT types correctly.
- Map `GPUFFT_INVERSE` to `HIPFFT_BACKWARD`, aligning the HIP FFT constants with the existing CUDA mapping.

**Modification**
- `src/force/pppm.cuh`: switch all PPPM FFT buffers (`mesh`, `mesh_G`, `mesh_{x,y,z}`, `mesh_virial`) to `GPU_Vector<gpufftComplex>`, so both HIP and CUDA builds share the same alias.
- `src/utilities/gpu_macro.cuh`: in the HIP branch, map `GPUFFT_INVERSE` to `HIPFFT_BACKWARD` while leaving the CUDA branch on `CUFFT_INVERSE`.

**Others**
- Built with `make -f makefile.hip -j4` using HIP toolchains configured with `GCC 9.3.0` and `GCC 12.2.0` on `DTK 24.04/25.04`; no FFT-related build errors remain.