### PR TITLE
Fix a bug for reading EAM/alloy file

### DIFF
--- a/src/force/eam_alloy.cuh
+++ b/src/force/eam_alloy.cuh
@@ -60,10 +60,6 @@ struct EAMAlloy_Data {
   std::vector<double> phi_r_b;
   std::vector<double> phi_r_c;
   std::vector<double> phi_r_d;
-  std::vector<int> atomic_number;
-  std::vector<double> atomic_mass;
-  std::vector<double> lattice_constant;
-  std::vector<std::string> lattice_type;
 };
 
 class EAMAlloy : public Potential


### PR DESCRIPTION
I modified the code for reading EAM/alloy files so that it can now correctly handle files containing comments or other irregular content, making it more robust and general.