### PR TITLE
still set rc_inner=rc_outer/2

### DIFF
--- a/doc/nep/input_parameters/use_typewise_cutoff_zbl.rst
+++ b/doc/nep/input_parameters/use_typewise_cutoff_zbl.rst
@@ -12,6 +12,6 @@ The syntax is::
 
 with one optional (dimensionless) parameter :attr:`<factor>` that defaults to 0.65.
 
-If this keyword is present, the outer ZBL cutoff between two elements is the minimum between the global outer ZBL cutoff :math:`r_\mathrm{outer}^\mathrm{ZBL}` and :attr:`<factor>` times of the sum of the covalent radii of the two elements, and the inner ZBL cutoff is always set to 0.
+If this keyword is present, the outer ZBL cutoff between two elements is the minimum between the global outer ZBL cutoff :math:`r_\mathrm{outer}^\mathrm{ZBL}` and :attr:`<factor>` times of the sum of the covalent radii of the two elements, and the inner ZBL cutoff is half of the outer one.
 
 By default, this keyword is not in effect.

--- a/src/force/nep.cu
+++ b/src/force/nep.cu
@@ -960,7 +960,7 @@ static __global__ void find_force_ZBL(
           rc_outer = min(
             (COVALENT_RADIUS[zi - 1] + COVALENT_RADIUS[zj - 1]) * paramb.typewise_cutoff_zbl_factor,
             rc_outer);
-          rc_inner = 0.0f;
+          rc_inner = rc_outer * 0.5f;
         }
         find_f_and_fp_zbl(zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
       }

--- a/src/force/nep_charge.cu
+++ b/src/force/nep_charge.cu
@@ -1292,7 +1292,7 @@ static __global__ void find_force_ZBL(
           rc_outer = min(
             (COVALENT_RADIUS[zi - 1] + COVALENT_RADIUS[zj - 1]) * paramb.typewise_cutoff_zbl_factor,
             rc_outer);
-          rc_inner = 0.0f;
+          rc_inner = rc_outer * 0.5f;
         }
         find_f_and_fp_zbl(zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
       }

--- a/src/force/nep_charge_small_box.cuh
+++ b/src/force/nep_charge_small_box.cuh
@@ -994,7 +994,7 @@ static __global__ void find_force_ZBL_small_box(
           rc_outer = min(
             (COVALENT_RADIUS[zi - 1] + COVALENT_RADIUS[zj - 1]) * paramb.typewise_cutoff_zbl_factor,
             rc_outer);
-          rc_inner = 0.0f;
+          rc_inner = rc_outer * 0.5f;
         }
         find_f_and_fp_zbl(zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
       }

--- a/src/force/nep_multigpu.cu
+++ b/src/force/nep_multigpu.cu
@@ -1206,7 +1206,7 @@ static __global__ void find_force_ZBL(
           rc_outer = min(
             (COVALENT_RADIUS[zi - 1] + COVALENT_RADIUS[zj - 1]) * paramb.typewise_cutoff_zbl_factor,
             rc_outer);
-          rc_inner = 0.0f;
+          rc_inner = rc_outer * 0.5f;
         }
         find_f_and_fp_zbl(zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
       }

--- a/src/force/nep_small_box.cuh
+++ b/src/force/nep_small_box.cuh
@@ -669,7 +669,7 @@ static __global__ void find_force_ZBL_small_box(
           rc_outer = min(
             (COVALENT_RADIUS[zi - 1] + COVALENT_RADIUS[zj - 1]) * paramb.typewise_cutoff_zbl_factor,
             rc_outer);
-          rc_inner = 0.0f;
+          rc_inner = rc_outer * 0.5f;
         }
         find_f_and_fp_zbl(zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
       }

--- a/src/main_nep/nep.cu
+++ b/src/main_nep/nep.cu
@@ -670,7 +670,7 @@ static __global__ void find_force_ZBL(
           rc_outer = min(
             (COVALENT_RADIUS[zi - 1] + COVALENT_RADIUS[zj - 1]) * paramb.typewise_cutoff_zbl_factor,
             rc_outer);
-          rc_inner = 0.0f;
+          rc_inner = rc_outer * 0.5f;
         }
         find_f_and_fp_zbl(zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
       }

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -916,7 +916,7 @@ static __global__ void find_force_ZBL(
           rc_outer = min(
             (COVALENT_RADIUS[zi - 1] + COVALENT_RADIUS[zj - 1]) * paramb.typewise_cutoff_zbl_factor,
             rc_outer);
-          rc_inner = 0.0f;
+          rc_inner = rc_outer * 0.5f;
         }
         find_f_and_fp_zbl(zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
       }

--- a/src/mc/nep_energy.cu
+++ b/src/mc/nep_energy.cu
@@ -452,7 +452,7 @@ static __global__ void find_energy_zbl(
           rc_outer = min(
             (COVALENT_RADIUS[zi - 1] + COVALENT_RADIUS[zj - 1]) * paramb.typewise_cutoff_zbl_factor,
             rc_outer);
-          rc_inner = 0.0f;
+          rc_inner = rc_outer * 0.5f;
         }
         find_f_and_fp_zbl(zizj, a_inv, rc_inner, rc_outer, d12, d12inv, f, fp);
       }


### PR DESCRIPTION
Based on some real tests, seems this is still better.

Wait, this might not be the problem...

I might close this PR.

Yes, the problem is something else. A good combination is:
```
zbl 3
use_typewise_cutoff_zbl 0.7
```