### PR TITLE
better usage of use_typewise_cutoff_zbl

### DIFF
--- a/doc/nep/input_parameters/use_typewise_cutoff_zbl.rst
+++ b/doc/nep/input_parameters/use_typewise_cutoff_zbl.rst
@@ -10,8 +10,13 @@ The syntax is::
 
   use_typewise_cutoff_zbl [<factor>]
 
-with one optional (dimensionless) parameter :attr:`<factor>` that defaults to 0.65.
+with one optional (dimensionless) parameter :attr:`<factor>` that defaults to 0.7.
 
 If this keyword is present, the outer ZBL cutoff between two elements is the minimum between the global outer ZBL cutoff :math:`r_\mathrm{outer}^\mathrm{ZBL}` and :attr:`<factor>` times of the sum of the covalent radii of the two elements, and the inner ZBL cutoff is always set to 0.
 
 By default, this keyword is not in effect.
+
+A good usage is to first set up a global ZBL cutoff of 2.5 Å and then enable this feature::
+
+  zbl 2.5
+  use_typewise_cutoff_zbl 0.7

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -1250,7 +1250,7 @@ void Parameters::parse_use_typewise_cutoff_zbl(const char** param, int num_param
   }
   use_typewise_cutoff_zbl = true;
   is_use_typewise_cutoff_zbl_set = true;
-  typewise_cutoff_zbl_factor = 0.65f;
+  typewise_cutoff_zbl_factor = 0.7f;
 
   if (num_param == 2) {
     double typewise_cutoff_zbl_factor_temp = 0.0;


### PR DESCRIPTION
Now we have found out a good combination:

```
  zbl 2.5
  use_typewise_cutoff_zbl 0.7
```

We are still testing 
```
  zbl 3
  use_typewise_cutoff_zbl 0.7
```