### PR TITLE
handle the `stress` tag in `shift_energy_to_zero.py`

### DIFF
--- a/tools/Analysis_and_Processing/shift_energy_to_zero/shift_energy_to_zero.py
+++ b/tools/Analysis_and_Processing/shift_energy_to_zero/shift_energy_to_zero.py
@@ -90,6 +90,11 @@ for i in range(len(all_frames)):
         all_frames[i].new_array('forces',forces)
     except:
         pass
+    try:
+        stress = all_frames[i].get_stress(voigt=False)
+        all_frames[i].info['stress'] = stress
+    except:
+        pass
     all_frames[i].calc = None
     all_frames[i].info['energy'] = shifted_energy[i]
 write("shifted.xyz",all_frames)


### PR DESCRIPTION
**Summary**
Fixes an issue in `shift_energy_to_zero.py` where `stress` data was dropped when processing `extxyz` files.

This clear will also delete the attached stress data:
https://github.com/brucefan1983/GPUMD/blob/52b9e6f927cfba2dee72bd22d73d1435fa6cdb46/tools/Analysis_and_Processing/shift_energy_to_zero/shift_energy_to_zero.py#L93


**Modification**
This change explicitly retrieves and saves the `stress` to `atoms.info` (if available) before the calculator is reset.

```python3
    try:
        stress = all_frames[i].get_stress(voigt=False)
        all_frames[i].info['stress'] = stress
    except:
        pass
```