### PR TITLE
fix in minimize

### DIFF
--- a/src/main_gpumd/cohesive.cu
+++ b/src/main_gpumd/cohesive.cu
@@ -240,7 +240,7 @@ void Cohesive::compute(
     Box new_box;
     deform_box(num_atoms, cpu_D[n], box, new_box, position_per_atom);
 
-    Minimizer_SD minimizer(num_atoms, 1000, 1.0e-5);
+    Minimizer_SD minimizer(-1, num_atoms, 1000, 1.0e-5);
     minimizer.compute(
       force,
       new_box,

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -368,6 +368,7 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
     minimize.parse_minimize(
       param,
       num_param,
+      integrate.fixed_group,
       force,
       box,
       atom.position_per_atom,

--- a/src/minimize/minimize.cu
+++ b/src/minimize/minimize.cu
@@ -31,6 +31,7 @@ The driver class for minimizers.
 void Minimize::parse_minimize(
   const char** param,
   int num_param,
+  int fixed_group,
   Force& force,
   Box& box,
   GPU_Vector<double>& position_per_atom,
@@ -117,7 +118,7 @@ void Minimize::parse_minimize(
       printf("    with a force tolerance of %g eV/A.\n", force_tolerance);
       printf("    for maximally %d steps.\n", number_of_steps);
 
-      minimizer.reset(new Minimizer_SD(number_of_atoms, number_of_steps, force_tolerance));
+      minimizer.reset(new Minimizer_SD(fixed_group, number_of_atoms, number_of_steps, force_tolerance));
 
       minimizer->compute(
         force,

--- a/src/minimize/minimize.cuh
+++ b/src/minimize/minimize.cuh
@@ -26,6 +26,7 @@ public:
   void parse_minimize(
     const char** param,
     int num_param,
+    int fixed_group,
     Force& force,
     Box& box,
     GPU_Vector<double>& position_per_atom,

--- a/src/minimize/minimizer.cuh
+++ b/src/minimize/minimizer.cuh
@@ -23,8 +23,13 @@ class Force;
 class Minimizer
 {
 public:
-  Minimizer(const int number_of_atoms, const int number_of_steps, const double force_tolerance)
-    : number_of_atoms_(number_of_atoms),
+  Minimizer(
+    const int fixed_group, 
+    const int number_of_atoms, 
+    const int number_of_steps, 
+    const double force_tolerance)
+    : fixed_group_(fixed_group),
+      number_of_atoms_(number_of_atoms),
       number_of_steps_(number_of_steps),
       force_tolerance_(force_tolerance)
   {
@@ -56,6 +61,7 @@ protected:
 
   void calculate_force_square_max(const GPU_Vector<double>& force_per_atom);
 
+  int fixed_group_ = -1;
   int number_of_steps_ = 1000;
   int number_of_atoms_ = 0;
   double force_tolerance_ = 1.0e-6;

--- a/src/minimize/minimizer_fire.cuh
+++ b/src/minimize/minimizer_fire.cuh
@@ -37,7 +37,7 @@ private:
 
 public:
   Minimizer_FIRE(const int number_of_atoms, const int number_of_steps, const double force_tolerance)
-    : Minimizer(number_of_atoms, number_of_steps, force_tolerance)
+    : Minimizer(-1, number_of_atoms, number_of_steps, force_tolerance)
   {
   }
 

--- a/src/minimize/minimizer_fire_box_change.cuh
+++ b/src/minimize/minimizer_fire_box_change.cuh
@@ -39,7 +39,7 @@ private:
 public:
   Minimizer_FIRE_Box_Change(
     const int number_of_atoms, const int number_of_steps, const double force_tolerance)
-    : Minimizer(number_of_atoms, number_of_steps, force_tolerance)
+    : Minimizer(-1, number_of_atoms, number_of_steps, force_tolerance)
   {
   }
 
@@ -48,7 +48,7 @@ public:
     const int number_of_steps,
     const double force_tolerance,
     const int _hydrostatic_strain)
-    : Minimizer(number_of_atoms, number_of_steps, force_tolerance)
+    : Minimizer(-1, number_of_atoms, number_of_steps, force_tolerance)
   {
     hydrostatic_strain = _hydrostatic_strain;
   }

--- a/src/minimize/minimizer_sd.cuh
+++ b/src/minimize/minimizer_sd.cuh
@@ -19,8 +19,12 @@
 class Minimizer_SD : public Minimizer
 {
 public:
-  Minimizer_SD(const int number_of_atoms, const int number_of_steps, const double force_tolerance)
-    : Minimizer(number_of_atoms, number_of_steps, force_tolerance)
+  Minimizer_SD(
+    const int fixed_group, 
+    const int number_of_atoms, 
+    const int number_of_steps, 
+    const double force_tolerance)
+    : Minimizer(fixed_group, number_of_atoms, number_of_steps, force_tolerance)
   {
   }
 


### PR DESCRIPTION
**Summary**

To solve issue #1306 

**Usage**

Still use the `fix` keyword; just put it before `minimize`.

Example usage
```
fix <group_id>                # must use grouping method 0 (extension is left for future)
minimize sd 0.0001 1000       # only works for sd (fire is more complicated and is left for future)
```

**Test results**

<img width="600" height="840" alt="untitled" src="https://github.com/user-attachments/assets/174c7adc-3c40-4c02-93ae-adba744f5530" />

* Using `fix 0` the fixed  atoms (second half of the atoms) still have nonzero force after minimizing, and the unfixed atoms have small forces.
* Using `fix 1`, the results revserse.
* Not using a `fix`, all the forces are small after minimizing.