### PR TITLE
fix a bug introduced in 4.9

### DIFF
--- a/src/force/nep.cu
+++ b/src/force/nep.cu
@@ -1263,13 +1263,13 @@ static bool get_expanded_box(const double rc, const Box& box, NEP::ExpandedBox& 
   ebox.num_cells[2] = box.pbc_z ? int(ceil(2.0 * rc / thickness_z)) : 1;
 
   bool is_small_box = false;
-  if (box.pbc_x && thickness_x <= 2.5 * rc) {
+  if (box.pbc_x && thickness_x <= 2.5 * (rc + 1.0)) {
     is_small_box = true;
   }
-  if (box.pbc_y && thickness_y <= 2.5 * rc) {
+  if (box.pbc_y && thickness_y <= 2.5 * (rc + 1.0)) {
     is_small_box = true;
   }
-  if (box.pbc_z && thickness_z <= 2.5 * rc) {
+  if (box.pbc_z && thickness_z <= 2.5 * (rc + 1.0)) {
     is_small_box = true;
   }
 

--- a/src/force/nep_charge.cu
+++ b/src/force/nep_charge.cu
@@ -1938,13 +1938,13 @@ static bool get_expanded_box(const double rc, const Box& box, NEP_Charge::Expand
   ebox.num_cells[2] = box.pbc_z ? int(ceil(2.0 * rc / thickness_z)) : 1;
 
   bool is_small_box = false;
-  if (box.pbc_x && thickness_x <= 2.5 * rc) {
+  if (box.pbc_x && thickness_x <= 2.5 * (rc + 1.0)) {
     is_small_box = true;
   }
-  if (box.pbc_y && thickness_y <= 2.5 * rc) {
+  if (box.pbc_y && thickness_y <= 2.5 * (rc + 1.0)) {
     is_small_box = true;
   }
-  if (box.pbc_z && thickness_z <= 2.5 * rc) {
+  if (box.pbc_z && thickness_z <= 2.5 * (rc + 1.0)) {
     is_small_box = true;
   }
 


### PR DESCRIPTION
**Summary**

GPUMD-v4.9 introduced a bug which is relevant when a periodic box thickness is between $2.5 r_c$ and $2.5 (r_c+1)$ for NEP and qNEP models, running in a single GPU, where $r_c$ is the radial cutoff radius, and the number $1$ refers to the skin distance of 1 Angstrom. In this case, some neighbor atoms were counted twice.
