### PR TITLE
Add "ghost atom" and "couple com" modes for more flexible spring settings

### DIFF
--- a/doc/gpumd/input_parameters/add_spring.rst
+++ b/doc/gpumd/input_parameters/add_spring.rst
@@ -5,53 +5,78 @@
 :attr:`add_spring`
 ==================
 
-This keyword is used to add a spring between a ghost atom and the centroid of atoms in a selected group.
+This keyword adds spring interactions to selected atom groups at each step of a run.
+
+It supports three modes: :attr:`ghost_com`, :attr:`ghost_atom`, and :attr:`com_com`, which add spring forces between a ghost atom and the center of mass (COM) of a group, between ghost atoms and their corresponding atoms in a group, and between the COMs of two groups, respectively. The ghost atom(s) can be static or move at a constant velocity. Each mode supports two spring types: :attr:`couple` (a single radial spring) and :attr:`decouple` (three independent springs along the x, y, and z directions).
 
 Syntax
 ------
 
-This keyword is used in one of the following two ways::
+The complete syntax for the six combinations is::
 
-  add_spring ghost_com <group_method> <group_id> <ghost_vx> <ghost_vy> <ghost_vz> couple <k_couple> <R0> <offset_x> <offset_y> <offset_z>  # usage 1
-  add_spring ghost_com <group_method> <group_id> <ghost_vx> <ghost_vy> <ghost_vz> decouple <k_decouple_x> <k_decouple_y> <k_decouple_z> <offset_x> <offset_y> <offset_z>  # usage 2
+  add_spring ghost_com <group_method> <group_id> <ghost_vx> <ghost_vy> <ghost_vz> couple <k_couple> <R0> <offset_x> <offset_y> <offset_z>
+  add_spring ghost_com <group_method> <group_id> <ghost_vx> <ghost_vy> <ghost_vz> decouple <k_decouple_x> <k_decouple_y> <k_decouple_z> <offset_x> <offset_y> <offset_z>
+  add_spring ghost_atom <group_method> <group_id> <ghost_vx> <ghost_vy> <ghost_vz> couple <k_couple> <R0> <offset_x> <offset_y> <offset_z>
+  add_spring ghost_atom <group_method> <group_id> <ghost_vx> <ghost_vy> <ghost_vz> decouple <k_decouple_x> <k_decouple_y> <k_decouple_z> <offset_x> <offset_y> <offset_z>
+  add_spring com_com <group_method> <group_id_1> <group_id_2> couple <k_couple> <R0>
+  add_spring com_com <group_method> <group_id_1> <group_id_2> decouple <k_decouple_x> <k_decouple_y> <k_decouple_z>
 
-The function of the coupled spring potential is given by the equation:
+The coupled spring potential is:
 
 .. math::
 
    U_{\mathrm{couple}} = \frac{1}{2} k_{\mathrm{couple}} (R - R_0)^2
-   
-where :math:`R` is the distance between the ghost atom and the centroid of the selected group. The function of the decoupled spring potential is given by the equation:
+
+where :math:`R` is the distance between the two points connected by the spring.
+
+The decoupled spring potential is:
 
 .. math::
 
-   U_{\mathrm{decouple}} = \frac{1}{2} k_{\mathrm{decouple},x} (x - x_{\mathrm{ghost}})^2 + \frac{1}{2} k_{\mathrm{decouple},y} (y - y_{\mathrm{ghost}})^2 + \frac{1}{2} k_{\mathrm{decouple},z} (z - z_{\mathrm{ghost}})^2
-   
-where :math:`(x_{\mathrm{ghost}}, y_{\mathrm{ghost}}, z_{\mathrm{ghost}})` is the position of the ghost atom and :math:`(x, y, z)` is the position of the centroid of the selected group.
+   U_{\mathrm{decouple}} = \frac{1}{2} k_{\mathrm{decouple},x} (x_2 - x_1)^2 + \frac{1}{2} k_{\mathrm{decouple},y} (y_2 - y_1)^2 + \frac{1}{2} k_{\mathrm{decouple},z} (z_2 - z_1)^2
 
-* Force is added to atoms in group :attr:`group_id` of group method :attr:`group_method`.
-* In the first usage, a spring is coupled to the ghost atom with spring constant :attr:`k_couple` and equilibrium distance :attr:`R0`.
-* In the second usage, a spring is decoupled from the ghost atom with spring constants :attr:`k_decouple_x`, :attr:`k_decouple_y`, and :attr:`k_decouple_z` in the x, y, and z directions, respectively.
-* The ghost atom starts at the position of the centroid of the selected group plus the offset vector (:attr:`offset_x`, :attr:`offset_y`, :attr:`offset_z`), and moves with velocity (:attr:`ghost_vx`, :attr:`ghost_vy`, :attr:`ghost_vz`).
+where :math:`(x_1, y_1, z_1)` and :math:`(x_2, y_2, z_2)` are the Cartesian coordinates of the two points connected by the spring.
+
+* In :attr:`ghost_com` mode, force is added to atoms in group :attr:`group_id` of group method :attr:`group_method` with mass-weighted distribution. The ghost is initially placed at the COM + (:attr:`offset_x`, :attr:`offset_y`, :attr:`offset_z`) and is displaced by (:attr:`ghost_vx`, :attr:`ghost_vy`, :attr:`ghost_vz`) at each step.
+* In :attr:`ghost_atom` mode, each atom in group :attr:`group_id` is attached to its own ghost anchor. The anchor is initially placed at the atom position + (:attr:`offset_x`, :attr:`offset_y`, :attr:`offset_z`) and is displaced by (:attr:`ghost_vx`, :attr:`ghost_vy`, :attr:`ghost_vz`) at each step. The input spring constant(s) (:attr:`k_couple` or :attr:`k_decouple_x`, :attr:`k_decouple_y`, :attr:`k_decouple_z`) represent the total stiffness of the entire group and are divided internally by the number of atoms in the group. Thus, each atom experiences a spring with an effective stiffness of :attr:`k / N_atoms`.
+* In :attr:`com_com` mode, a spring interaction is applied between the COM of group :attr:`group_id_1` and the COM of group :attr:`group_id_2` under the same :attr:`group_method`. Equal and opposite forces are applied to the two groups with mass-weighted distribution within each group.
+* In :attr:`couple` mode, :attr:`k_couple` must be positive and :attr:`R0` must be non-negative.
+* In :attr:`decouple` mode, :attr:`k_decouple_x`, :attr:`k_decouple_y`, and :attr:`k_decouple_z` must be non-negative.
+* In :attr:`com_com` mode, :attr:`group_id_1` and :attr:`group_id_2` must be different.
 * Force is in units of eV/Å, distance is in units of Å, velocity is in units of Å/step, and spring constant is in units of eV/Å².
-* Spring forces are written to `spring_force_*.out`, where the asterisk is replaced by a zero-based index that increments with each invocation of the command. The meaning of each column in the file is::
+* Spring forces are written to the file :attr:`spring_force_*.out`, where the asterisk is replaced by a zero-based index that increments with each invocation of the command. The meaning of each column in the file is::
 
-  # step  call  mode  Fx  Fy  Fz  energy  spring_force
+   # step  mode  Fx  Fy  Fz  Ftotal  energy
 
+where :attr:`mode` is an integer flag: 0 = ghost_com, 1 = ghost_atom, 2 = com_com. In :attr:`com_com` mode, the reported :attr:`Fx`, :attr:`Fy`, and :attr:`Fz` correspond to the net spring force applied to :attr:`group_id_1`.
 
-Example 1
----------
+Example 1 (ghost_com + couple)
+------------------------------
 
-Add a coupled spring with spring constant 10 eV/Å² and equilibrium distance 0 Å between a static ghost atom and the centroid of atoms in group 2 of group method 0. The ghost atom is initially in the same position as the centroid::
+Add a coupled spring with spring constant 10 eV/Å² and equilibrium distance 0 Å between a static ghost atom and the COM of atoms in group 2 defined by group method 0. The ghost atom is initially located at the COM::
 
-   add_spring    ghost_com 0 2 0 0 0 couple 10 0 0 0 0
+   add_spring ghost_com 0 2 0 0 0 couple 10 0 0 0 0
 
-Example 2
----------
+Example 2 (ghost_com + decouple)
+--------------------------------
 
-Add a decoupled spring with spring constants 10 eV/Å² in the x direction and 0 eV/Å² in the y and z directions between a ghost atom moving with velocity (0.00005, 0, 0) Å/step and the centroid of atoms in group 2 of group method 0. The ghost atom is initially in the same position as the centroid::
+Add a decoupled spring with spring constants 10 eV/Å² in the x direction and 0 eV/Å² in the y and z directions between a ghost atom moving at velocity (0.00005, 0, 0) Å/step and the COM of atoms in group 2 defined by group method 0. The ghost atom is initially located at the COM::
 
-   add_spring    ghost_com 0 2 0.00005 0 0 decouple 10 0 0 0 0 0
+   add_spring ghost_com 0 2 0.00005 0 0 decouple 10 0 0 0 0 0
+
+Example 3 (ghost_atom + couple)
+-------------------------------
+
+Add a coupled spring between each atom in group 2 defined by group method 0 and its corresponding moving ghost anchor. Each anchor is initially placed at the corresponding atom position and moves at velocity (0.00005, 0, 0) Å/step::
+
+   add_spring ghost_atom 0 2 0.00005 0 0 couple 10 0 0 0 0
+
+Example 4 (com_com + decouple)
+------------------------------
+
+Add a decoupled Cartesian spring between the COM of group 1 and the COM of group 2 under the same group method 0::
+
+   add_spring com_com 0 1 2 decouple 10 0 0
 
 Note
 ----

--- a/src/main_gpumd/add_spring.cu
+++ b/src/main_gpumd/add_spring.cu
@@ -287,8 +287,8 @@ static void __global__ gpu_add_spring_ghost_atom_decouple(
   }
 }
 
-// Couple COM: apply equal-opposite forces to two groups
-static void __global__ gpu_add_spring_couple_com_force(
+// COM to COM: apply equal-opposite forces to two groups
+static void __global__ gpu_add_spring_com_com_force(
   const int* __restrict__ g_group_contents,
   const int group1_size,
   const int group1_size_sum,
@@ -548,12 +548,12 @@ void Add_Spring::parse(const char** param, int num_param, const std::vector<Grou
     ghost_atom_pos_[id].resize(3 * ghost_atom_group_size_[id]);
     init_origin_[id] = 0;
 
-  } else if (strcmp(mode_str, "couple_com") == 0) {
+  } else if (strcmp(mode_str, "com_com") == 0) {
     // Syntax:
-    //   add_spring couple_com gm gid1 gid2 couple   k  R0
-    //   add_spring couple_com gm gid1 gid2 decouple kx ky kz
+    //   add_spring com_com gm gid1 gid2 couple   k  R0
+    //   add_spring com_com gm gid1 gid2 decouple kx ky kz
 
-    mode_[id] = MODE_COUPLE_COM;
+    mode_[id] = MODE_COM_COM;
 
     // Parse grouping method
     if (!is_valid_int(param[2], &grouping_method_[id])) {
@@ -594,7 +594,7 @@ void Add_Spring::parse(const char** param, int num_param, const std::vector<Grou
 
     if (strcmp(stiff_str, "couple") == 0) {
       if (num_param != 8) {
-        PRINT_INPUT_ERROR("add_spring couple_com couple requires 8 parameters.\n");
+        PRINT_INPUT_ERROR("add_spring com_com couple requires 8 parameters.\n");
       }
       stiffness_mode_[id] = STIFFNESS_COUPLE;
 
@@ -605,13 +605,13 @@ void Add_Spring::parse(const char** param, int num_param, const std::vector<Grou
         PRINT_INPUT_ERROR("R0 should be a non-negative number.\n");
       }
 
-      printf("    couple_com couple: gm=%d, gid1=%d, gid2=%d\n",
+      printf("    com_com couple: gm=%d, gid1=%d, gid2=%d\n",
              grouping_method_[id], group_id_[id], group_id_2_[id]);
       printf("    k=%g eV/Å^2, R0=%g Å\n", k_couple_[id], R0_[id]);
 
     } else if (strcmp(stiff_str, "decouple") == 0) {
       if (num_param != 9) {
-        PRINT_INPUT_ERROR("add_spring couple_com decouple requires 9 parameters.\n");
+        PRINT_INPUT_ERROR("add_spring com_com decouple requires 9 parameters.\n");
       }
       stiffness_mode_[id] = STIFFNESS_DECOUPLE;
 
@@ -623,7 +623,7 @@ void Add_Spring::parse(const char** param, int num_param, const std::vector<Grou
         PRINT_INPUT_ERROR("k components should be non-negative numbers.\n");
       }
 
-      printf("    couple_com decouple: gm=%d, gid1=%d, gid2=%d\n",
+      printf("    com_com decouple: gm=%d, gid1=%d, gid2=%d\n",
              grouping_method_[id], group_id_[id], group_id_2_[id]);
       printf("    k=(%g,%g,%g) eV/Å^2\n", k_decouple_[id][0], k_decouple_[id][1], k_decouple_[id][2]);
 
@@ -631,13 +631,13 @@ void Add_Spring::parse(const char** param, int num_param, const std::vector<Grou
       PRINT_INPUT_ERROR("stiffness mode should be 'couple' or 'decouple'.\n");
     }
 
-    // No velocity for couple_com
+    // No velocity for com_com
     velocity_[id][0] = 0.0;
     velocity_[id][1] = 0.0;
     velocity_[id][2] = 0.0;
 
   } else {
-    PRINT_INPUT_ERROR("Unknown mode. Use ghost_com, ghost_atom, or couple_com.\n");
+    PRINT_INPUT_ERROR("Unknown mode. Use ghost_com, ghost_atom, or com_com.\n");
   }
 
   // Initialize output file
@@ -857,7 +857,7 @@ void Add_Spring::compute(const int step, const std::vector<Group>& groups, Atom&
       // Total energy from all springs
       energy_[c] = h_energy;
 
-    } else if (mode_[c] == MODE_COUPLE_COM) {
+    } else if (mode_[c] == MODE_COM_COM) {
       // Zero out buffers before atomic reduction
       d_tmp_vec3_.fill(0.0);
       d_tmp_scalar_.fill(0.0);
@@ -946,7 +946,7 @@ void Add_Spring::compute(const int step, const std::vector<Group>& groups, Atom&
       // Apply equal-opposite forces
       int max_size = std::max(group_size, group2_size);
       int grid_size_max = (max_size - 1) / block_size + 1;
-      gpu_add_spring_couple_com_force<<<grid_size_max, block_size>>>(
+      gpu_add_spring_com_com_force<<<grid_size_max, block_size>>>(
         groups[grouping_method_[c]].contents.data(),
         group_size,
         groups[grouping_method_[c]].cpu_size_sum[group_id_[c]],

--- a/src/main_gpumd/add_spring.cuh
+++ b/src/main_gpumd/add_spring.cuh
@@ -40,7 +40,7 @@ private:
   enum SpringMode {
     MODE_GHOST_COM  = 0,
     MODE_GHOST_ATOM = 1,
-    MODE_COUPLE_COM = 2
+    MODE_COM_COM    = 2
   };
 
   enum StiffnessMode {


### PR DESCRIPTION
**Summary**
This PR add two different modes for `add_spring` (PR #1273 ): ghost_atom and couple_com. The former mode can create more ghost atoms and add the springs between the ghost atoms and the real atoms in selected group and couple_com mode can add a spring between the COMs(center of mass) of two selected groups in the same group method. 

**Modification**
- Modified two main files: `add_spring.cu` and `add_spring.cuh`.
- Docs will be updated later.

**Others**
None.