### PR TITLE
RDF output file header uses element symbols

### DIFF
--- a/src/measure/rdf.cu
+++ b/src/measure/rdf.cu
@@ -214,10 +214,22 @@ void RDF::postprocess(
 
   FILE* fid = fopen("rdf.out", "a");
 
+  std::vector<std::string> type_symbols(rdf_para.num_types);
+  for (int a = 0; a < rdf_para.num_types; a++) {
+    int type_idx = rdf_para.type_index[a];
+    for (int n = 0; n < atom.number_of_atoms; n++) {
+      if (atom.cpu_type[n] == type_idx) {
+        type_symbols[a] = atom.cpu_atom_symbol[n];
+        break;
+      }
+    }
+  }
+
   fprintf(fid, "#radius total");
   for (int a = 0; a < rdf_para.num_types; a++) {
     for (int b = a; b < rdf_para.num_types; b++) {
       fprintf(fid, " type_%d_%d", rdf_para.type_index[a], rdf_para.type_index[b]);
+      fprintf(fid, " %s-%s", type_symbols[a].c_str(), type_symbols[b].c_str());
     }
   }
   fprintf(fid, "\n");


### PR DESCRIPTION
The code prior to this change used element indices from the nep.txt file at the beginning of the output file. 
MoSi2N4
<img width="554" height="180" alt="fdff065b-b913-4460-9bf8-c600c31b5f4c" src="https://github.com/user-attachments/assets/0458182a-576b-403b-8841-987a7dc09b62" />
PbTe
<img width="497" height="165" alt="image" src="https://github.com/user-attachments/assets/947a55ff-60f5-4b96-81f0-1c33be5c02e8" />


This has now been modified to use element symbols to facilitate subsequent data processing.
MoSi2N4
<img width="658" height="183" alt="09765361-9697-4ab2-9c3e-efce4ec10755" src="https://github.com/user-attachments/assets/234566cf-5381-4dab-8e19-fc831ec323d7" />
PbTe
<img width="421" height="160" alt="image" src="https://github.com/user-attachments/assets/ce5c58b6-b977-4e5d-a500-26a9c0655055" />


All simulations employ NEP89, with MoSi₂N₄ as the self-built structure and PbTe as the example model from examples/gpumd_dynamic/model.xyz.
