### PR TITLE
fix a typo

### DIFF
--- a/doc/gpumd/output_files/index.rst
+++ b/doc/gpumd/output_files/index.rst
@@ -113,7 +113,7 @@ Output files
      - :ref:`compute_phonon <kw_compute_phonon>`
      - Phonon frequency squared :math:`\omega^2(\boldsymbol{k})` for the input :math:`\boldsymbol{k}`-points
      - Overwrite
-   * - :ref:`viscosity_out <viscosity_out>`
+   * - :ref:`viscosity.out <viscosity_out>`
      - :ref:`compute_viscosity <kw_compute_viscosity>`
      - Viscosity and stress auto-correlation function
      - Append


### PR DESCRIPTION
This pull request makes a minor update to the documentation for output files. The change corrects the reference name for the viscosity output file to ensure consistency and clarity.

* Documentation correction:
  * Changed the reference from `viscosity_out` to `viscosity.out` in `doc/gpumd/output_files/index.rst` to match the actual output file name.