### PR TITLE
Solved problems for the calculation of cohesive energy

### DIFF
--- a/src/main_gpumd/cohesive.cu
+++ b/src/main_gpumd/cohesive.cu
@@ -135,7 +135,7 @@ void Cohesive::parse_cohesive(const char** param, int num_param)
   if (deform_d < 0 || deform_d > 6) {
     PRINT_INPUT_ERROR("deform direction should >=0 and <= 6.\n");
   }
-  num_points = (round((end_factor - start_factor) * 10) * 100) + 1;
+  num_points = round((end_factor - start_factor) * 1000) + 1;
   printf("    num_points = %d.\n", num_points);
 
   delta_factor = 0.001; // (end_factor - start_factor) / (num_points - 1);

--- a/src/main_gpumd/cohesive.cu
+++ b/src/main_gpumd/cohesive.cu
@@ -138,8 +138,10 @@ void Cohesive::parse_cohesive(const char** param, int num_param)
   num_points = round((end_factor - start_factor) * 1000) + 1;
   printf("    num_points = %d.\n", num_points);
 
-  const char* deform_names[] = {"x", "y", "z", "xy", "yz", "xz", "xyz"};
-  printf("    deform direction = %d (%s).\n", deform_d, deform_names[deform_d]);
+  const char* deform_mode[] = {"uniaxial", "uniaxial", "uniaxial", 
+                               "biaxial", "biaxial", "biaxial", "triaxial"};
+  const char* deform_dir[] = {"x", "y", "z", "xy", "yz", "xz", "xyz"};
+  printf("    deform mode = %s - %s .\n", deform_mode[deform_d], deform_dir[deform_d]);
 
   delta_factor = 0.001; // (end_factor - start_factor) / (num_points - 1);
   deformation_type = 0; // deformation for cohesive

--- a/src/main_gpumd/cohesive.cu
+++ b/src/main_gpumd/cohesive.cu
@@ -195,10 +195,11 @@ void Cohesive::compute_D()
         }
       } else if (deform_d > 2 && deform_d < 6) {
         for (int k = 3 * (deform_d - 3); k < 3 * (deform_d - 2) + 3; ++k) {
-          if (k > 8) {
-            k -= 9;
+          int ki = k;
+          if (ki > 8) {
+            ki -= 9;
           }
-          cpu_D[n].data[k] = factor;
+          cpu_D[n].data[ki] = factor;
         }
       } else {
         for (int k = 0; k < 9; ++k) {

--- a/src/main_gpumd/cohesive.cu
+++ b/src/main_gpumd/cohesive.cu
@@ -138,6 +138,9 @@ void Cohesive::parse_cohesive(const char** param, int num_param)
   num_points = round((end_factor - start_factor) * 1000) + 1;
   printf("    num_points = %d.\n", num_points);
 
+  const char* deform_names[] = {"x", "y", "z", "xy", "yz", "xz", "xyz"};
+  printf("    deform direction = %d (%s).\n", deform_d, deform_names[deform_d]);
+
   delta_factor = 0.001; // (end_factor - start_factor) / (num_points - 1);
   deformation_type = 0; // deformation for cohesive
 }


### PR DESCRIPTION
1、An error occurs in the calculation of `num_points` when the input range is very small.
2、Add an output for the deformation direction.
3、Resolve the issue where the calculation of the xz scaling factor gets stuck.

The images below show the before and after
<img width="585" height="217" alt="image" src="https://github.com/user-attachments/assets/900c9b56-b479-4ee6-88ff-e8acdcee5f79" />
<img width="635" height="372" alt="image" src="https://github.com/user-attachments/assets/7f7748c1-75da-4c7d-8749-ccfde08f4c05" />
