### PR TITLE
Integration of atomic calss for velocity file

### DIFF
--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -157,10 +157,7 @@ Run::Run()
   velocity.initialize(
     has_velocity_in_xyz,
     300,
-    atom.cpu_mass,
-    atom.cpu_position_per_atom,
-    atom.cpu_velocity_per_atom,
-    atom.velocity_per_atom,
+    atom,
     false,
     123);
   if (has_velocity_in_xyz) {
@@ -252,14 +249,7 @@ void Run::perform_a_run()
 
   for (int step = 0; step < number_of_steps; ++step) {
 
-    velocity.correct_velocity(
-      step,
-      group,
-      atom.cpu_mass,
-      atom.position_per_atom,
-      atom.cpu_position_per_atom,
-      atom.cpu_velocity_per_atom,
-      atom.velocity_per_atom);
+    velocity.correct_velocity(step, group, atom);
 
     calculate_time_step(
       max_distance_per_step, atom.velocity_per_atom, initial_time_step, time_step);
@@ -603,10 +593,7 @@ void Run::parse_velocity(const char** param, int num_param)
   velocity.initialize(
     has_velocity_in_xyz,
     initial_temperature,
-    atom.cpu_mass,
-    atom.cpu_position_per_atom,
-    atom.cpu_velocity_per_atom,
-    atom.velocity_per_atom,
+    atom,
     use_seed,
     seed);
   if (!has_velocity_in_xyz) {

--- a/src/main_gpumd/velocity.cu
+++ b/src/main_gpumd/velocity.cu
@@ -21,6 +21,7 @@ If DEBUG is on in the makefile, the velocities are the same from run to run.
 If DEBUG is off, the velocities are different in different runs.
 ------------------------------------------------------------------------------*/
 
+#include "model/atom.cuh"
 #include "model/group.cuh"
 #include "utilities/common.cuh"
 #include "utilities/gpu_vector.cuh"
@@ -207,12 +208,11 @@ static void zero_angular_momentum(
 }
 
 void Velocity::correct_velocity(
+  const int N,
   const std::vector<double>& cpu_mass,
   const std::vector<double>& cpu_position_per_atom,
   std::vector<double>& cpu_velocity_per_atom)
 {
-  const int N = cpu_mass.size();
-
   zero_linear_momentum(
     N,
     cpu_mass.data(),
@@ -270,21 +270,16 @@ void Velocity::correct_velocity(
     cpu_velocity_per_atom.data() + N * 2);
 }
 
-void Velocity::correct_velocity(
-  const int step,
-  const std::vector<Group>& group,
-  const std::vector<double>& cpu_mass,
-  GPU_Vector<double>& position_per_atom,
-  std::vector<double>& cpu_position_per_atom,
-  std::vector<double>& cpu_velocity_per_atom,
-  GPU_Vector<double>& velocity_per_atom)
+void Velocity::correct_velocity(const int step, const std::vector<Group>& group, Atom& atom)
 {
+  const int N = atom.number_of_atoms;
+
   if (do_velocity_correction) {
     if (step % velocity_correction_interval == 0) {
-      position_per_atom.copy_to_host(cpu_position_per_atom.data());
-      velocity_per_atom.copy_to_host(cpu_velocity_per_atom.data());
+      atom.position_per_atom.copy_to_host(atom.position_per_atom.data());
+      atom.velocity_per_atom.copy_to_host(atom.velocity_per_atom.data());
       if (velocity_correction_group_method < 0) {
-        correct_velocity(cpu_mass, cpu_position_per_atom, cpu_velocity_per_atom);
+        correct_velocity(N, atom.cpu_mass, atom.cpu_position_per_atom, atom.cpu_velocity_per_atom);
       } else {
         for (int g = 0; g < group[velocity_correction_group_method].number; ++g) {
           int cpu_size = group[velocity_correction_group_method].cpu_size[g];
@@ -294,22 +289,22 @@ void Velocity::correct_velocity(
           std::vector<double> velocity(cpu_size * 3);
           for (int m = 0; m < cpu_size; ++m) {
             int n = group[velocity_correction_group_method].cpu_contents[cpu_size_sum + m];
-            mass[m] = cpu_mass[n];
+            mass[m] = atom.cpu_mass[n];
             for (int d = 0; d < 3; ++d) {
-              position[m + d * cpu_size] = cpu_position_per_atom[n + d * cpu_mass.size()];
-              velocity[m + d * cpu_size] = cpu_velocity_per_atom[n + d * cpu_mass.size()];
+              position[m + d * cpu_size] = atom.cpu_position_per_atom[n + d * N];
+              velocity[m + d * cpu_size] = atom.cpu_velocity_per_atom[n + d * N];
             }
           }
-          correct_velocity(mass, position, velocity);
+          correct_velocity(N, mass, position, velocity);
           for (int m = 0; m < cpu_size; ++m) {
             int n = group[velocity_correction_group_method].cpu_contents[cpu_size_sum + m];
             for (int d = 0; d < 3; ++d) {
-              cpu_velocity_per_atom[n + d * cpu_mass.size()] = velocity[m + d * cpu_size];
+              atom.cpu_velocity_per_atom[n + d * N] = velocity[m + d * cpu_size];
             }
           }
         }
       }
-      velocity_per_atom.copy_from_host(cpu_velocity_per_atom.data());
+      atom.velocity_per_atom.copy_from_host(atom.cpu_velocity_per_atom.data());
     }
   }
 }
@@ -317,40 +312,38 @@ void Velocity::correct_velocity(
 void Velocity::initialize(
   const bool has_velocity_in_xyz,
   const double initial_temperature,
-  const std::vector<double>& cpu_mass,
-  const std::vector<double>& cpu_position_per_atom,
-  std::vector<double>& cpu_velocity_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
+  Atom& atom,
   bool use_seed,
   int seed)
 {
+  const int N = atom.number_of_atoms;
+
   do_velocity_correction = false;
   if (!has_velocity_in_xyz) {
-    const int N = cpu_mass.size();
     if (use_seed) {
       get_random_velocities_by_seed(
         N,
-        cpu_velocity_per_atom.data(),
-        cpu_velocity_per_atom.data() + N,
-        cpu_velocity_per_atom.data() + N * 2,
+        atom.cpu_velocity_per_atom.data(),
+        atom.cpu_velocity_per_atom.data() + N,
+        atom.cpu_velocity_per_atom.data() + N * 2,
         seed);
     } else {
       get_random_velocities(
         N,
-        cpu_velocity_per_atom.data(),
-        cpu_velocity_per_atom.data() + N,
-        cpu_velocity_per_atom.data() + N * 2);
+        atom.cpu_velocity_per_atom.data(),
+        atom.cpu_velocity_per_atom.data() + N,
+        atom.cpu_velocity_per_atom.data() + N * 2);
     }
-    correct_velocity(cpu_mass, cpu_position_per_atom, cpu_velocity_per_atom);
+    correct_velocity(N, atom.cpu_mass, atom.cpu_position_per_atom, atom.cpu_velocity_per_atom);
     scale(
       initial_temperature,
-      cpu_mass,
-      cpu_velocity_per_atom.data(),
-      cpu_velocity_per_atom.data() + N,
-      cpu_velocity_per_atom.data() + N * 2);
+      atom.cpu_mass,
+      atom.cpu_velocity_per_atom.data(),
+      atom.cpu_velocity_per_atom.data() + N,
+      atom.cpu_velocity_per_atom.data() + N * 2);
   }
 
-  velocity_per_atom.copy_from_host(cpu_velocity_per_atom.data());
+  atom.velocity_per_atom.copy_from_host(atom.cpu_velocity_per_atom.data());
 }
 
 void Velocity::finalize()

--- a/src/main_gpumd/velocity.cu
+++ b/src/main_gpumd/velocity.cu
@@ -295,7 +295,7 @@ void Velocity::correct_velocity(const int step, const std::vector<Group>& group,
               velocity[m + d * cpu_size] = atom.cpu_velocity_per_atom[n + d * N];
             }
           }
-          correct_velocity(N, mass, position, velocity);
+          correct_velocity(mass.size(), mass, position, velocity);
           for (int m = 0; m < cpu_size; ++m) {
             int n = group[velocity_correction_group_method].cpu_contents[cpu_size_sum + m];
             for (int d = 0; d < 3; ++d) {

--- a/src/main_gpumd/velocity.cu
+++ b/src/main_gpumd/velocity.cu
@@ -276,8 +276,8 @@ void Velocity::correct_velocity(const int step, const std::vector<Group>& group,
 
   if (do_velocity_correction) {
     if (step % velocity_correction_interval == 0) {
-      atom.position_per_atom.copy_to_host(atom.position_per_atom.data());
-      atom.velocity_per_atom.copy_to_host(atom.velocity_per_atom.data());
+      atom.position_per_atom.copy_to_host(atom.cpu_position_per_atom.data());
+      atom.velocity_per_atom.copy_to_host(atom.cpu_velocity_per_atom.data());
       if (velocity_correction_group_method < 0) {
         correct_velocity(N, atom.cpu_mass, atom.cpu_position_per_atom, atom.cpu_velocity_per_atom);
       } else {

--- a/src/main_gpumd/velocity.cuh
+++ b/src/main_gpumd/velocity.cuh
@@ -30,26 +30,17 @@ public:
   void initialize(
     const bool has_velocity_in_xyz,
     const double initial_temperature,
-    const std::vector<double>& cpu_mass,
-    const std::vector<double>& cpu_position_per_atom,
-    std::vector<double>& cpu_velocity_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
+    Atom& atom,
     bool use_seed,
     int seed);
 
-  void correct_velocity(
-    const int step,
-    const std::vector<Group>& group,
-    const std::vector<double>& cpu_mass,
-    GPU_Vector<double>& position_per_atom,
-    std::vector<double>& cpu_position_per_atom,
-    std::vector<double>& cpu_velocity_per_atom,
-    GPU_Vector<double>& velocity_per_atom);
+  void correct_velocity(const int step, const std::vector<Group>& group, Atom& atom);
 
   void finalize();
 
 private:
   void correct_velocity(
+    const int N,
     const std::vector<double>& cpu_mass,
     const std::vector<double>& cpu_position_per_atom,
     std::vector<double>& cpu_velocity_per_atom);


### PR DESCRIPTION
run.in:

potential     nep.txt
velocity      300 seed 987654
correct_velocity 50 1 
time_step     1

ensemble      npt_scr 300 300 100 0 0 0 500 500 500 2000
dump_thermo   100
dump_exyz   1000 1
dump_xyz  -1 0 1000 1.xyz velocity
run           10000
ensemble      npt_ber 300 300 100 0 0 0 500 500 500 2000
dump_thermo   100
dump_exyz   1000 1
dump_xyz  -1 0 1000 1.xyz velocity
run           10000

ensemble      nvt_bdp 300 300 100
dump_thermo   100
dump_exyz   1000 1
dump_xyz  -1 0 1000 1.xyz velocity
run           10000

ensemble      nvt_nhc 300 300 100
dump_thermo   100
dump_exyz   1000 1
dump_xyz  -1 0 1000 1.xyz velocity
run           10000

ensemble      nvt_lan 300 300 100
dump_thermo   100
dump_exyz   1000 1
dump_xyz  -1 0 1000 1.xyz velocity
run           10000

ensemble      nvt_bao 300 300 100
dump_thermo   100
dump_exyz   1000 1
dump_xyz  -1 0 1000 1.xyz velocity
run           10000

ensemble     npt_mttk temp 300 300 iso 0 0
dump_thermo   100
dump_exyz   1000 1
dump_xyz  -1 0 1000 1.xyz velocity
run           10000

ensemble nph_mttk iso 10 10
dump_thermo   100
dump_exyz   1000 1
dump_xyz  -1 0 1000 1.xyz velocity
run           10000

An “s” at the end of an xyz file indicates that a seed has been used.
An “c” at the end of an xyz file indicates that correct_velocity has been used.
The results of the code comparison before and after the modification are as follows

<img width="771" height="158" alt="image" src="https://github.com/user-attachments/assets/953d34f1-aad5-4dfc-8de2-d1fc8263b50e" />

<img width="1201" height="235" alt="image" src="https://github.com/user-attachments/assets/f90109d1-801f-4bad-9c8c-4634e1f58a8c" />

