### PR TITLE
Integration of atomic class for minimize.cu/cuh file

### DIFF
--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -363,12 +363,8 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
       integrate.fixed_grouping_method,
       force,
       box,
-      atom.position_per_atom,
-      atom.type,
-      group,
-      atom.potential_per_atom,
-      atom.force_per_atom,
-      atom.virial_per_atom);
+      atom,
+      group);
   } else if (strcmp(param[0], "compute_phonon") == 0) {
     Hessian hessian;
     hessian.parse(param, num_param);

--- a/src/minimize/minimize.cu
+++ b/src/minimize/minimize.cu
@@ -18,6 +18,7 @@ The driver class for minimizers.
 ------------------------------------------------------------------------------*/
 
 #include "force/force.cuh"
+#include "model/atom.cuh"
 #include "minimize.cuh"
 #include "minimizer_fire.cuh"
 #include "minimizer_fire_box_change.cuh"
@@ -35,12 +36,8 @@ void Minimize::parse_minimize(
   int fixed_grouping_method,
   Force& force,
   Box& box,
-  GPU_Vector<double>& position_per_atom,
-  GPU_Vector<int>& type,
-  std::vector<Group>& group,
-  GPU_Vector<double>& potential_per_atom,
-  GPU_Vector<double>& force_per_atom,
-  GPU_Vector<double>& virial_per_atom)
+  Atom& atom,
+  std::vector<Group>& group)
 {
 
   int minimizer_type = 0;
@@ -49,7 +46,6 @@ void Minimize::parse_minimize(
   int box_change = 0;
   int hydrostatic_strain = 0;
   std::unique_ptr<Minimizer> minimizer;
-  const int number_of_atoms = type.size();
 
   if (strcmp(param[1], "sd") == 0) {
     minimizer_type = 0;
@@ -120,17 +116,17 @@ void Minimize::parse_minimize(
       printf("    for maximally %d steps.\n", number_of_steps);
 
       minimizer.reset(
-        new Minimizer_SD(fixed_group, fixed_grouping_method, number_of_atoms, number_of_steps, force_tolerance));
+        new Minimizer_SD(fixed_group, fixed_grouping_method, atom.number_of_atoms, number_of_steps, force_tolerance));
 
       minimizer->compute(
         force,
         box,
-        position_per_atom,
-        type,
+        atom.position_per_atom,
+        atom.type,
         group,
-        potential_per_atom,
-        force_per_atom,
-        virial_per_atom);
+        atom.potential_per_atom,
+        atom.force_per_atom,
+        atom.virial_per_atom);
 
       break;
     case 1:
@@ -140,17 +136,17 @@ void Minimize::parse_minimize(
       printf("    with a force tolerance of %g eV/A.\n", force_tolerance);
       printf("    for maximally %d steps.\n", number_of_steps);
 
-      minimizer.reset(new Minimizer_FIRE(number_of_atoms, number_of_steps, force_tolerance));
+      minimizer.reset(new Minimizer_FIRE(atom.number_of_atoms, number_of_steps, force_tolerance));
 
       minimizer->compute(
         force,
         box,
-        position_per_atom,
-        type,
+        atom.position_per_atom,
+        atom.type,
         group,
-        potential_per_atom,
-        force_per_atom,
-        virial_per_atom);
+        atom.potential_per_atom,
+        atom.force_per_atom,
+        atom.virial_per_atom);
 
       break;
     case 2:
@@ -164,17 +160,17 @@ void Minimize::parse_minimize(
       printf("    for maximally %d steps.\n", number_of_steps);
 
       minimizer.reset(new Minimizer_FIRE_Box_Change(
-        number_of_atoms, number_of_steps, force_tolerance, hydrostatic_strain));
+        atom.number_of_atoms, number_of_steps, force_tolerance, hydrostatic_strain));
 
       minimizer->compute(
         force,
         box,
-        position_per_atom,
-        type,
+        atom.position_per_atom,
+        atom.type,
         group,
-        potential_per_atom,
-        force_per_atom,
-        virial_per_atom);
+        atom.potential_per_atom,
+        atom.force_per_atom,
+        atom.virial_per_atom);
 
       break;
     default:

--- a/src/minimize/minimize.cuh
+++ b/src/minimize/minimize.cuh
@@ -19,6 +19,7 @@
 class Force;
 class Box;
 class Group;
+class Atom;
 
 class Minimize
 {
@@ -30,10 +31,6 @@ public:
     int fixed_grouping_method,
     Force& force,
     Box& box,
-    GPU_Vector<double>& position_per_atom,
-    GPU_Vector<int>& type,
-    std::vector<Group>& group,
-    GPU_Vector<double>& potential_per_atom,
-    GPU_Vector<double>& force_per_atom,
-    GPU_Vector<double>& virial_per_atom);
+    Atom& atom,
+    std::vector<Group>& group);
 };


### PR DESCRIPTION
run.in:
potential  ./C_2024_NEP4.txt
ensemble    nve
time_step 0 
dump_exyz 1 0 1
run 1
minimize sd 1e-5 1000 
minimize fire 1e-5 1000 
minimize fire 1e-5 1000 1 1
ensemble    nve
time_step 0 
dump_exyz 1 0 1
run 1


An “s” at the end of an xyz file indicates that sd method has been used.
Only “f” at the end of an xyz file indicates that fire method has been used. And “fc” at the end of an xyz file indicates that fire method with change box has been used.

<img width="992" height="136" alt="image" src="https://github.com/user-attachments/assets/38617092-7cf6-4393-9519-0c0291605840" />

