### PR TITLE
Add TTM method

### DIFF
--- a/doc/gpumd/input_parameters/ensemble_heat.rst
+++ b/doc/gpumd/input_parameters/ensemble_heat.rst
@@ -30,3 +30,29 @@ If the first parameter is :attr:`heat_bdp`, it is similar to the case of :attr:`
 :attr:`heat_lan`
 ^^^^^^^^^^^^^^^^
 If the first parameter is :attr:`heat_lan`, it is similar to the case of :attr:`heat_nhc`, but using the :ref:`Langevin method <langevin_thermostat>`.
+
+:attr:`ttm`
+^^^^^^^^^^^
+If the first parameter is :attr:`ttm`, the run uses a two-temperature-model (TTM) integrator.
+The selected atom group is coupled to an electron temperature grid.
+
+The full command is::
+
+  ensemble ttm <ttm_gm> <ttm_gid> <Ce> <rho_e> <kappa_e> <gamma_p> <gamma_s> <v_0> <nx> <ny> <nz> <T_e_init> [{optional_args}]
+
+The meanings of the parameters and optional arguments are described in
+:ref:`TTM integrators <kw_ensemble_ttm>`.
+
+:attr:`heat_ttm`
+^^^^^^^^^^^^^^^^
+If the first parameter is :attr:`heat_ttm`, the run uses local source/sink Langevin thermostats together with the TTM electron grid.
+
+The full command is::
+
+  ensemble heat_ttm <T> <T_coup> <delta_T> <label_source> <label_sink> <ttm_gm> <ttm_gid> <Ce> <rho_e> <kappa_e> <gamma_p> <gamma_s> <v_0> <nx> <ny> <nz> <T_e_init> [{optional_args}]
+
+The first five parameters,
+:attr:`<T>`, :attr:`<T_coup>`, :attr:`<delta_T>`, :attr:`<label_source>`, and :attr:`<label_sink>`,
+have the same meanings as in :attr:`heat_lan`.
+The remaining parameters and optional arguments are described in
+:ref:`TTM integrators <kw_ensemble_ttm>`.

--- a/doc/gpumd/input_parameters/ensemble_ttm.rst
+++ b/doc/gpumd/input_parameters/ensemble_ttm.rst
@@ -1,0 +1,135 @@
+.. _kw_ensemble_ttm:
+
+:attr:`ensemble` (TTM)
+======================
+
+This page describes the two-temperature-model (TTM) integrators
+:attr:`ttm` and :attr:`heat_ttm`.
+
+Syntax
+------
+
+:attr:`ttm`
+^^^^^^^^^^^
+The full command is::
+
+  ensemble ttm <ttm_gm> <ttm_gid> <Ce> <rho_e> <kappa_e> <gamma_p> <gamma_s> <v_0> <nx> <ny> <nz> <T_e_init> [{optional_args}]
+
+:attr:`heat_ttm`
+^^^^^^^^^^^^^^^^
+The full command is::
+
+  ensemble heat_ttm <T> <T_coup> <delta_T> <label_source> <label_sink> <ttm_gm> <ttm_gid> <Ce> <rho_e> <kappa_e> <gamma_p> <gamma_s> <v_0> <nx> <ny> <nz> <T_e_init> [{optional_args}]
+
+For :attr:`heat_ttm`, the first five parameters,
+:attr:`<T>`, :attr:`<T_coup>`, :attr:`<delta_T>`, :attr:`<label_source>`, and
+:attr:`<label_sink>`, have the same meanings as in :attr:`heat_lan`.
+
+Required parameters
+-------------------
+
+For both :attr:`ttm` and :attr:`heat_ttm`:
+
+* :attr:`<ttm_gm>` and :attr:`<ttm_gid>` specify the atom group coupled to the electron grid.
+* :attr:`<Ce>` is the electron specific heat per electron.
+* :attr:`<rho_e>` is the electron number density.
+* :attr:`<kappa_e>` is the electron thermal conductivity in eV/(ps K Å).
+* :attr:`<gamma_p>` and :attr:`<gamma_s>` are friction coefficients in amu/ps.
+* :attr:`<v_0>` is the threshold velocity in Å/ps.
+* :attr:`<nx>`, :attr:`<ny>`, and :attr:`<nz>` are the numbers of electron grid cells in the three directions.
+* :attr:`<T_e_init>` is the initial electron temperature in K.
+
+The product :attr:`<Ce> \times <rho_e>` is the volumetric electron heat capacity.
+
+Optional arguments
+------------------
+
+:attr:`ttm_out_interval`
+^^^^^^^^^^^^^^^^^^^^^^^^
+Syntax::
+
+  ttm_out_interval <interval>
+
+Set the output interval for :ref:`ttm_electron_temperature.out <ttm_electron_temperature_out>`.
+The default value is 1.
+
+:attr:`ttm_infile`
+^^^^^^^^^^^^^^^^^^
+Syntax::
+
+  ttm_infile <filename>
+
+Read the initial electron temperature from a file.
+The file must contain one line for each cell in the form::
+
+  ix iy iz T_e
+
+The grid indices are 1-based.
+
+:attr:`ttm_properties_file`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Syntax::
+
+  ttm_properties_file <filename>
+
+Read per-cell electron properties from a file.
+The file must contain one line for each cell in the form::
+
+  ix iy iz C_vol kappa_e gamma_p eta
+
+Here, :attr:`C_vol` is the volumetric electron heat capacity,
+:attr:`kappa_e` is in eV/(ps K Å), :attr:`gamma_p` is in amu/ps,
+and :attr:`eta` is the source absorption efficiency.
+This file must define all grid cells and overrides the uniform
+:attr:`<Ce>`, :attr:`<rho_e>`, :attr:`<kappa_e>`, and :attr:`<gamma_p>` values.
+
+:attr:`ttm_source`
+^^^^^^^^^^^^^^^^^^
+Syntax::
+
+  ttm_source <source>
+
+Add a volumetric heat source to the electron grid.
+The source strength is in eV/(ps Å\ :math:`^3`).
+When :attr:`ttm_properties_file` is used, the source in each cell is multiplied by :attr:`eta`.
+
+:attr:`ttm_active_x`, :attr:`ttm_active_y`, :attr:`ttm_active_z`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Syntax::
+
+  ttm_active_x <range>
+  ttm_active_y <range>
+  ttm_active_z <range>
+
+Set the active range of the electron grid in each direction.
+The range can be :attr:`all`, a single 1-based cell index, or an inclusive interval
+such as :attr:`3:10` or :attr:`3-10`.
+Cells outside the active region have zero electron temperature and do not exchange
+energy with neighboring cells or atoms.
+
+Notes
+-----
+
+* The simulation box for the electron grid is the full MD box.
+* The electron grid is always uniform in real space.
+* Electron-temperature snapshots are written to :ref:`ttm_electron_temperature.out <ttm_electron_temperature_out>`.
+* In :attr:`heat_ttm`, the source and sink labels always refer to grouping method 0.
+
+Examples
+--------
+
+Uniform pure TTM::
+
+  ensemble ttm 0 0 1.0 1.0 0.005 0.01 0.0 100.0 1 1 12 300
+
+Pure TTM with an input electron-temperature profile and periodic snapshots::
+
+  ensemble ttm 0 0 1.0 1.0 0.005 0.01 0.0 100.0 1 1 12 300 ttm_infile te_init.dat ttm_out_interval 50
+
+Pure TTM with per-cell properties::
+
+  ensemble ttm 0 0 1.0 1.0 0.005 0.01 0.0 100.0 1 1 40 300 ttm_properties_file properties.dat ttm_active_z 6:35 ttm_out_interval 100
+
+Heat source/sink plus TTM::
+
+  ensemble heat_ttm 300 100 30 0 1 1 0 1.0 1.0 0.005 0.02 0.0 100.0 1 1 40 300 ttm_out_interval 100

--- a/doc/gpumd/input_parameters/index.rst
+++ b/doc/gpumd/input_parameters/index.rst
@@ -25,6 +25,7 @@ Below you can find a listing of keywords for the ``run.in`` input file.
    ensemble_mttk
    ensemble_qtb
    ensemble_heat
+   ensemble_ttm
    ensemble_pimd
    ensemble_ti_liquid
    ensemble_ti_spring

--- a/doc/gpumd/output_files/compute_out.rst
+++ b/doc/gpumd/output_files/compute_out.rst
@@ -26,3 +26,5 @@ Assuming that the system is divided into :math:`M` groups according to the group
   * if temperature is computed, the last second column is the total energy of the thermostat coupling to the heat source region (in units of eV) and the last column is the total energy of the thermostat coupling to the heat sink region (in units of eV)
 
 Note that regardless of the order of properties in the :ref:`compute keyword <kw_compute>`, the order of the output data is fixed as given above.
+
+For runs that do not use explicit source and sink thermostats, such as a pure :attr:`ttm` run, the last two columns are present but remain zero.

--- a/doc/gpumd/output_files/index.rst
+++ b/doc/gpumd/output_files/index.rst
@@ -65,6 +65,10 @@ Output files
      - :ref:`compute <kw_compute>`
      - Time and space (group) averaged quantities
      - Append
+   * - :ref:`ttm_electron_temperature.out <ttm_electron_temperature_out>`
+     - :ref:`ensemble <kw_ensemble>` with :attr:`ttm` or :attr:`heat_ttm`
+     - Electron temperature snapshots on the TTM grid
+     - Overwrite
    * - :ref:`hac.out <hac_out>`
      - :ref:`compute_hac <kw_compute_hac>`
      - Thermal conductivity data from the :term:`EMD` method
@@ -160,6 +164,7 @@ Output files
    
    cohesive_out
    compute_out
+   ttm_electron_temperature_out
    D_out
    dos_out
    dpdt_out

--- a/doc/gpumd/output_files/ttm_electron_temperature_out.rst
+++ b/doc/gpumd/output_files/ttm_electron_temperature_out.rst
@@ -1,0 +1,42 @@
+.. _ttm_electron_temperature_out:
+.. index::
+   single: ttm_electron_temperature.out (output file)
+
+``ttm_electron_temperature.out``
+================================
+
+This file contains electron temperature snapshots from :attr:`ttm` and
+:attr:`heat_ttm` runs.
+It is written every :attr:`ttm_out_interval` steps and the output mode is overwrite.
+
+File format
+-----------
+
+The file starts with a header such as::
+
+  # electron temperature snapshots for TTM
+  # nx 1 ny 1 nz 12
+  # active_x 1 1 active_y 1 1 active_z 3 10
+  # properties_file yes
+  # electron_source 0.0000000000e+00
+  # output_interval 50 step(s)
+  # columns: ix iy iz T_e[K]
+
+Each snapshot starts with::
+
+  # step 2000
+
+followed by one line for each electron grid cell::
+
+  ix iy iz T_e
+
+where:
+
+* :attr:`ix`, :attr:`iy`, :attr:`iz` are the 1-based electron-grid indices
+* :attr:`T_e` is the electron temperature in K
+
+Notes
+-----
+
+* The grid order is x-fastest, then y, then z.
+* Cells outside the active TTM region are written with zero electron temperature.

--- a/src/integrate/ensemble_ttm.cu
+++ b/src/integrate/ensemble_ttm.cu
@@ -27,8 +27,8 @@ diffusion. Metal atoms exchange energy with the local electron temperature
 via a Langevin-like coupling (friction + stochastic force).
 
 References:
-[1] P.B. Crozier, R.E. Jones, et al., LAMMPS fix_ttm implementation.
-[2] G. Bussi and M. Parrinello, Phys. Rev. E 75, 056707 (2007).
+[1] D.M. Duffy and A.M. Rutherford, J. Phys.: Condens. Matter 19, 016207 (2007).
+[2] A.M. Rutherford and D.M. Duffy, J. Phys.: Condens. Matter 19, 496201 (2007).
 ------------------------------------------------------------------------------*/
 
 #include "ensemble_ttm.cuh"
@@ -422,7 +422,7 @@ static __global__ void gpu_update_ttm_force(
     double gamma = gamma_p;
     if (vsq > v_0_sq) gamma = gamma_p + gamma_s;
 
-    // LAMMPS fix_ttm uses a uniform random number in [-0.5, 0.5].
+    // Use zero-mean uniform random numbers for the stochastic force.
     double gfactor = sqrt(Te * 24.0 * K_B * gamma_p / time_step);
 
     gpurandState state = g_state[m];
@@ -778,8 +778,7 @@ void Ensemble_TTM::initialize_ttm_common(
   energy_transferred[1] = 0.0;
 
   // TTM physics parameters.
-  // Inputs follow the LAMMPS fix_ttm convention so the same numeric
-  // parameters can be reused here:
+  // Input units are converted to internal GPUMD units:
   //   kappa_e : eV / (ps * K * A)
   //   gamma_* : mass / ps
   //   v_0     : A / ps

--- a/src/integrate/ensemble_ttm.cu
+++ b/src/integrate/ensemble_ttm.cu
@@ -36,6 +36,7 @@ References:
 #include "utilities/common.cuh"
 #include "utilities/error.cuh"
 #include "utilities/gpu_macro.cuh"
+#include "utilities/read_file.cuh"
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -48,6 +49,272 @@ References:
 #else
   #define TTM_RAND_UNIFORM(a) curand_uniform(a)
 #endif
+
+static void parse_ttm_active_range(
+  const char* text,
+  const char* axis_name,
+  const int upper_bound,
+  int& lower,
+  int& upper)
+{
+  if (strcmp(text, "all") == 0) {
+    lower = 1;
+    upper = upper_bound;
+    return;
+  }
+
+  int value = 0;
+  if (is_valid_int(text, &value)) {
+    lower = value;
+    upper = value;
+  } else {
+    const char* separator = strchr(text, ':');
+    if (separator == nullptr) {
+      separator = strchr(text, '-');
+    }
+    if (separator == nullptr) {
+      PRINT_INPUT_ERROR("TTM active range should be an integer, all, or min:max.");
+    }
+
+    const std::string lower_text(text, separator - text);
+    const std::string upper_text(separator + 1);
+    if (!is_valid_int(lower_text.c_str(), &lower) || !is_valid_int(upper_text.c_str(), &upper)) {
+      PRINT_INPUT_ERROR("TTM active range bounds should be integers.");
+    }
+  }
+
+  if (lower < 1 || upper < 1 || lower > upper_bound || upper > upper_bound || lower > upper) {
+    if (strcmp(axis_name, "x") == 0) {
+      PRINT_INPUT_ERROR("ttm_active_x is out of range.");
+    } else if (strcmp(axis_name, "y") == 0) {
+      PRINT_INPUT_ERROR("ttm_active_y is out of range.");
+    } else {
+      PRINT_INPUT_ERROR("ttm_active_z is out of range.");
+    }
+  }
+}
+
+void parse_ttm_parameters(
+  const int type,
+  const char** param,
+  const int num_param,
+  const Atom& atom,
+  const Box& box,
+  const std::vector<Group>& group,
+  const int source,
+  const int sink,
+  TTM_Parameters& ttm_parameters)
+{
+  ttm_parameters = TTM_Parameters();
+
+  if (box.pbc_x == 0 || box.pbc_y == 0 || box.pbc_z == 0) {
+    PRINT_INPUT_ERROR("ensemble ttm/heat_ttm requires periodic boundary conditions in all directions.");
+  }
+  if (
+    box.cpu_h[1] != 0 || box.cpu_h[2] != 0 || box.cpu_h[3] != 0 || box.cpu_h[5] != 0 ||
+    box.cpu_h[6] != 0 || box.cpu_h[7] != 0) {
+    PRINT_INPUT_ERROR("ensemble ttm/heat_ttm only supports orthogonal boxes.");
+  }
+  if (group.empty()) {
+    PRINT_INPUT_ERROR("ensemble ttm/heat_ttm requires at least one grouping method.");
+  }
+
+  const int ttm_offset = (type == 24) ? 7 : 2;
+
+  if (!is_valid_int(param[ttm_offset], &ttm_parameters.grouping_method)) {
+    PRINT_INPUT_ERROR("TTM grouping method should be an integer.");
+  }
+  if (ttm_parameters.grouping_method < 0 || ttm_parameters.grouping_method >= group.size()) {
+    PRINT_INPUT_ERROR("TTM grouping method out of range.");
+  }
+
+  if (!is_valid_int(param[ttm_offset + 1], &ttm_parameters.group_id)) {
+    PRINT_INPUT_ERROR("TTM group ID should be an integer.");
+  }
+  if (
+    ttm_parameters.group_id < 0 ||
+    ttm_parameters.group_id >= group[ttm_parameters.grouping_method].number) {
+    PRINT_INPUT_ERROR("TTM group ID out of range.");
+  }
+  if (group[ttm_parameters.grouping_method].cpu_size[ttm_parameters.group_id] <= 0) {
+    PRINT_INPUT_ERROR("TTM metal group cannot be empty.");
+  }
+
+  if (type == 24) {
+    if (group[0].cpu_size[source] <= 0) {
+      PRINT_INPUT_ERROR("Heat source group for ensemble heat_ttm cannot be empty.");
+    }
+    if (group[0].cpu_size[sink] <= 0) {
+      PRINT_INPUT_ERROR("Heat sink group for ensemble heat_ttm cannot be empty.");
+    }
+    for (int n = 0; n < atom.number_of_atoms; ++n) {
+      if (
+        group[ttm_parameters.grouping_method].cpu_label[n] == ttm_parameters.group_id &&
+        (group[0].cpu_label[n] == source || group[0].cpu_label[n] == sink)) {
+        PRINT_INPUT_ERROR("TTM metal group cannot overlap with the heat source or sink group.");
+      }
+    }
+  }
+
+  if (!is_valid_real(param[ttm_offset + 2], &ttm_parameters.Ce)) {
+    PRINT_INPUT_ERROR("Ce (electronic specific heat) should be a number.");
+  }
+  if (ttm_parameters.Ce <= 0.0) {
+    PRINT_INPUT_ERROR("Ce should > 0.");
+  }
+
+  if (!is_valid_real(param[ttm_offset + 3], &ttm_parameters.rho_e)) {
+    PRINT_INPUT_ERROR("rho_e (electronic density) should be a number.");
+  }
+  if (ttm_parameters.rho_e <= 0.0) {
+    PRINT_INPUT_ERROR("rho_e should > 0.");
+  }
+
+  if (!is_valid_real(param[ttm_offset + 4], &ttm_parameters.kappa_e)) {
+    PRINT_INPUT_ERROR("kappa_e (electronic thermal conductivity) should be a number.");
+  }
+  if (ttm_parameters.kappa_e < 0.0) {
+    PRINT_INPUT_ERROR("kappa_e should >= 0.");
+  }
+
+  if (!is_valid_real(param[ttm_offset + 5], &ttm_parameters.gamma_p)) {
+    PRINT_INPUT_ERROR("gamma_p (e-ph coupling friction) should be a number.");
+  }
+  if (ttm_parameters.gamma_p <= 0.0) {
+    PRINT_INPUT_ERROR("gamma_p should > 0.");
+  }
+
+  if (!is_valid_real(param[ttm_offset + 6], &ttm_parameters.gamma_s)) {
+    PRINT_INPUT_ERROR("gamma_s (stopping power friction) should be a number.");
+  }
+  if (ttm_parameters.gamma_s < 0.0) {
+    PRINT_INPUT_ERROR("gamma_s should >= 0.");
+  }
+
+  if (!is_valid_real(param[ttm_offset + 7], &ttm_parameters.v_0)) {
+    PRINT_INPUT_ERROR("v_0 (velocity threshold) should be a number.");
+  }
+  if (ttm_parameters.v_0 < 0.0) {
+    PRINT_INPUT_ERROR("v_0 should >= 0.");
+  }
+
+  if (!is_valid_int(param[ttm_offset + 8], &ttm_parameters.nx)) {
+    PRINT_INPUT_ERROR("nx (electron grid x) should be an integer.");
+  }
+  if (!is_valid_int(param[ttm_offset + 9], &ttm_parameters.ny)) {
+    PRINT_INPUT_ERROR("ny (electron grid y) should be an integer.");
+  }
+  if (!is_valid_int(param[ttm_offset + 10], &ttm_parameters.nz)) {
+    PRINT_INPUT_ERROR("nz (electron grid z) should be an integer.");
+  }
+  if (ttm_parameters.nx <= 0 || ttm_parameters.ny <= 0 || ttm_parameters.nz <= 0) {
+    PRINT_INPUT_ERROR("Electron grid sizes must all be > 0.");
+  }
+
+  ttm_parameters.active_x_max = ttm_parameters.nx;
+  ttm_parameters.active_y_max = ttm_parameters.ny;
+  ttm_parameters.active_z_max = ttm_parameters.nz;
+
+  const long long ttm_ngrid_total =
+    1LL * ttm_parameters.nx * ttm_parameters.ny * ttm_parameters.nz;
+  if (ttm_ngrid_total > 2147483647LL) {
+    PRINT_INPUT_ERROR("Too many electron grid points for ensemble ttm/heat_ttm.");
+  }
+
+  if (!is_valid_real(param[ttm_offset + 11], &ttm_parameters.T_e_init)) {
+    PRINT_INPUT_ERROR("T_e_init (initial electron temperature) should be a number.");
+  }
+  if (ttm_parameters.T_e_init <= 0.0) {
+    PRINT_INPUT_ERROR("T_e_init should > 0.");
+  }
+
+  int i = ttm_offset + 12;
+  while (i < num_param) {
+    if (strcmp(param[i], "ttm_out_interval") == 0) {
+      if (!is_valid_int(param[i + 1], &ttm_parameters.out_interval)) {
+        PRINT_INPUT_ERROR("ttm_out_interval should be an integer.");
+      }
+      if (ttm_parameters.out_interval <= 0) {
+        PRINT_INPUT_ERROR("ttm_out_interval should > 0.");
+      }
+    } else if (strcmp(param[i], "ttm_infile") == 0) {
+      ttm_parameters.infile = param[i + 1];
+      if (ttm_parameters.infile.empty()) {
+        PRINT_INPUT_ERROR("ttm_infile should be a valid file path.");
+      }
+    } else if (strcmp(param[i], "ttm_properties_file") == 0) {
+      ttm_parameters.properties_file = param[i + 1];
+      if (ttm_parameters.properties_file.empty()) {
+        PRINT_INPUT_ERROR("ttm_properties_file should be a valid file path.");
+      }
+    } else if (strcmp(param[i], "ttm_source") == 0) {
+      if (!is_valid_real(param[i + 1], &ttm_parameters.source)) {
+        PRINT_INPUT_ERROR("ttm_source should be a number.");
+      }
+    } else if (strcmp(param[i], "ttm_active_x") == 0) {
+      parse_ttm_active_range(
+        param[i + 1], "x", ttm_parameters.nx, ttm_parameters.active_x_min, ttm_parameters.active_x_max);
+    } else if (strcmp(param[i], "ttm_active_y") == 0) {
+      parse_ttm_active_range(
+        param[i + 1], "y", ttm_parameters.ny, ttm_parameters.active_y_min, ttm_parameters.active_y_max);
+    } else if (strcmp(param[i], "ttm_active_z") == 0) {
+      parse_ttm_active_range(
+        param[i + 1], "z", ttm_parameters.nz, ttm_parameters.active_z_min, ttm_parameters.active_z_max);
+    } else {
+      PRINT_INPUT_ERROR("Unknown ensemble ttm/heat_ttm optional keyword.");
+    }
+    i += 2;
+  }
+}
+
+void print_ttm_settings(const TTM_Parameters& ttm_parameters)
+{
+  printf(
+    "    TTM metal group is group %d in grouping method %d.\n",
+    ttm_parameters.group_id,
+    ttm_parameters.grouping_method);
+  printf(
+    "    Ce = %g, rho_e = %g, kappa_e = %g.\n",
+    ttm_parameters.Ce,
+    ttm_parameters.rho_e,
+    ttm_parameters.kappa_e);
+  printf(
+    "    gamma_p = %g, gamma_s = %g, v_0 = %g.\n",
+    ttm_parameters.gamma_p,
+    ttm_parameters.gamma_s,
+    ttm_parameters.v_0);
+  printf(
+    "    electron grid: %d x %d x %d.\n",
+    ttm_parameters.nx,
+    ttm_parameters.ny,
+    ttm_parameters.nz);
+  printf(
+    "    active electron cells: x %d:%d, y %d:%d, z %d:%d.\n",
+    ttm_parameters.active_x_min,
+    ttm_parameters.active_x_max,
+    ttm_parameters.active_y_min,
+    ttm_parameters.active_y_max,
+    ttm_parameters.active_z_min,
+    ttm_parameters.active_z_max);
+  if (ttm_parameters.infile.empty()) {
+    printf("    uniform initial electron temperature is %g K.\n", ttm_parameters.T_e_init);
+  } else {
+    printf("    initial electron temperature is read from %s.\n", ttm_parameters.infile.c_str());
+  }
+  if (ttm_parameters.properties_file.empty()) {
+    printf("    electron properties are spatially uniform.\n");
+  } else {
+    printf(
+      "    electron cell properties are read from %s.\n", ttm_parameters.properties_file.c_str());
+  }
+  if (ttm_parameters.source != 0.0) {
+    printf("    electron volumetric source is %g.\n", ttm_parameters.source);
+  }
+  printf(
+    "    electron temperature snapshots are written every %d step(s) to "
+    "ttm_electron_temperature.out.\n",
+    ttm_parameters.out_interval);
+}
 
 // Map a metal atom to its electron grid cell index.
 // For orthogonal GPUMD boxes, positions are wrapped into [0, L).
@@ -494,36 +761,15 @@ void Ensemble_TTM::initialize_ttm_gpu_data()
 
 void Ensemble_TTM::initialize_ttm_common(
   int type_input,
-  int ttm_grouping_method_input,
-  int ttm_group_input,
   int ttm_group_size,
   int ttm_group_offset,
-  double Ce_input,
-  double rho_e_input,
-  double kappa_e_input,
-  double gamma_p_input,
-  double gamma_s_input,
-  double v_0_input,
-  int nx_input,
-  int ny_input,
-  int nz_input,
-  int active_x_min_input,
-  int active_x_max_input,
-  int active_y_min_input,
-  int active_y_max_input,
-  int active_z_min_input,
-  int active_z_max_input,
-  double T_e_init,
-  int electron_temperature_output_interval_input,
-  const std::string& electron_temperature_init_file_input,
-  const std::string& electron_property_file_input,
-  double electron_source_input,
+  const TTM_Parameters& ttm_parameters,
   const Box& box)
 {
   type = type_input;
 
-  ttm_grouping_method = ttm_grouping_method_input;
-  ttm_group_id = ttm_group_input;
+  ttm_grouping_method = ttm_parameters.grouping_method;
+  ttm_group_id = ttm_parameters.group_id;
   N_metal = ttm_group_size;
   offset_metal = ttm_group_offset;
   initialize_ttm_random_states();
@@ -537,31 +783,35 @@ void Ensemble_TTM::initialize_ttm_common(
   //   kappa_e : eV / (ps * K * A)
   //   gamma_* : mass / ps
   //   v_0     : A / ps
-  Ce = Ce_input;
-  rho_e = rho_e_input;
-  kappa_e = kappa_e_input / 1000.0;
-  gamma_p = gamma_p_input;
-  gamma_s = gamma_s_input;
+  Ce = ttm_parameters.Ce;
+  rho_e = ttm_parameters.rho_e;
+  kappa_e = ttm_parameters.kappa_e / 1000.0;
+  gamma_p = ttm_parameters.gamma_p;
+  gamma_s = ttm_parameters.gamma_s;
   gamma_p_nat = gamma_p * TIME_UNIT_CONVERSION / 1000.0;
   gamma_s_nat = gamma_s * TIME_UNIT_CONVERSION / 1000.0;
-  double v_0_nat = v_0_input * TIME_UNIT_CONVERSION / 1000.0;
+  double v_0_nat = ttm_parameters.v_0 * TIME_UNIT_CONVERSION / 1000.0;
   v_0_sq = v_0_nat * v_0_nat;
-  electron_source = electron_source_input / 1000.0;
-  use_electron_properties = !electron_property_file_input.empty();
+  electron_source = ttm_parameters.source / 1000.0;
+  use_electron_properties = !ttm_parameters.properties_file.empty();
 
-  nx = nx_input;
-  ny = ny_input;
-  nz = nz_input;
+  nx = ttm_parameters.nx;
+  ny = ttm_parameters.ny;
+  nz = ttm_parameters.nz;
   ngrid_total = nx * ny * nz;
-  active_x_min = active_x_min_input;
-  active_x_max = active_x_max_input;
-  active_y_min = active_y_min_input;
-  active_y_max = active_y_max_input;
-  active_z_min = active_z_min_input;
-  active_z_max = active_z_max_input;
-  electron_temperature_output_interval = electron_temperature_output_interval_input;
+  active_x_min = ttm_parameters.active_x_min;
+  active_x_max = ttm_parameters.active_x_max;
+  active_y_min = ttm_parameters.active_y_min;
+  active_y_max = ttm_parameters.active_y_max;
+  active_z_min = ttm_parameters.active_z_min;
+  active_z_max = ttm_parameters.active_z_max;
+  electron_temperature_output_interval = ttm_parameters.out_interval;
 
-  initialize_electron_grid(T_e_init, electron_temperature_init_file_input, electron_property_file_input, box);
+  initialize_electron_grid(
+    ttm_parameters.T_e_init,
+    ttm_parameters.infile,
+    ttm_parameters.properties_file,
+    box);
   initialize_ttm_gpu_data();
 }
 
@@ -573,33 +823,12 @@ Ensemble_TTM::Ensemble_TTM(
   int sink_size,
   int source_offset,
   int sink_offset,
-  int ttm_grouping_method_input,
-  int ttm_group_input,
   int ttm_group_size,
   int ttm_group_offset,
   double T,
   double Tc,
   double dT,
-  double Ce_input,
-  double rho_e_input,
-  double kappa_e_input,
-  double gamma_p_input,
-  double gamma_s_input,
-  double v_0_input,
-  int nx_input,
-  int ny_input,
-  int nz_input,
-  int active_x_min_input,
-  int active_x_max_input,
-  int active_y_min_input,
-  int active_y_max_input,
-  int active_z_min_input,
-  int active_z_max_input,
-  double T_e_init,
-  int electron_temperature_output_interval_input,
-  const std::string& electron_temperature_init_file_input,
-  const std::string& electron_property_file_input,
-  double electron_source_input,
+  const TTM_Parameters& ttm_parameters,
   const Box& box)
 {
   use_heat_lan = true;
@@ -631,59 +860,17 @@ Ensemble_TTM::Ensemble_TTM(
   GPU_CHECK_KERNEL
   initialize_ttm_common(
     type_input,
-    ttm_grouping_method_input,
-    ttm_group_input,
     ttm_group_size,
     ttm_group_offset,
-    Ce_input,
-    rho_e_input,
-    kappa_e_input,
-    gamma_p_input,
-    gamma_s_input,
-    v_0_input,
-    nx_input,
-    ny_input,
-    nz_input,
-    active_x_min_input,
-    active_x_max_input,
-    active_y_min_input,
-    active_y_max_input,
-    active_z_min_input,
-    active_z_max_input,
-    T_e_init,
-    electron_temperature_output_interval_input,
-    electron_temperature_init_file_input,
-    electron_property_file_input,
-    electron_source_input,
+    ttm_parameters,
     box);
 }
 
 Ensemble_TTM::Ensemble_TTM(
   int type_input,
-  int ttm_grouping_method_input,
-  int ttm_group_input,
   int ttm_group_size,
   int ttm_group_offset,
-  double Ce_input,
-  double rho_e_input,
-  double kappa_e_input,
-  double gamma_p_input,
-  double gamma_s_input,
-  double v_0_input,
-  int nx_input,
-  int ny_input,
-  int nz_input,
-  int active_x_min_input,
-  int active_x_max_input,
-  int active_y_min_input,
-  int active_y_max_input,
-  int active_z_min_input,
-  int active_z_max_input,
-  double T_e_init,
-  int electron_temperature_output_interval_input,
-  const std::string& electron_temperature_init_file_input,
-  const std::string& electron_property_file_input,
-  double electron_source_input,
+  const TTM_Parameters& ttm_parameters,
   const Box& box)
 {
   use_heat_lan = false;
@@ -701,30 +888,9 @@ Ensemble_TTM::Ensemble_TTM(
   curand_states_sink.resize(0);
   initialize_ttm_common(
     type_input,
-    ttm_grouping_method_input,
-    ttm_group_input,
     ttm_group_size,
     ttm_group_offset,
-    Ce_input,
-    rho_e_input,
-    kappa_e_input,
-    gamma_p_input,
-    gamma_s_input,
-    v_0_input,
-    nx_input,
-    ny_input,
-    nz_input,
-    active_x_min_input,
-    active_x_max_input,
-    active_y_min_input,
-    active_y_max_input,
-    active_z_min_input,
-    active_z_max_input,
-    T_e_init,
-    electron_temperature_output_interval_input,
-    electron_temperature_init_file_input,
-    electron_property_file_input,
-    electron_source_input,
+    ttm_parameters,
     box);
 }
 

--- a/src/integrate/ensemble_ttm.cu
+++ b/src/integrate/ensemble_ttm.cu
@@ -182,6 +182,7 @@ static __global__ void gpu_accumulate_ttm_power(
   const double* __restrict__ g_vx,
   const double* __restrict__ g_vy,
   const double* __restrict__ g_vz,
+  const double time_unit_conversion,
   double* __restrict__ g_net_energy)
 {
   int m = blockIdx.x * blockDim.x + threadIdx.x;
@@ -197,7 +198,7 @@ static __global__ void gpu_accumulate_ttm_power(
     double fx = g_ttm_force[m];
     double fy = g_ttm_force[m + N_metal];
     double fz = g_ttm_force[m + 2 * N_metal];
-    const double power_fs = (fx * vx + fy * vy + fz * vz) / TIME_UNIT_CONVERSION;
+    const double power_fs = (fx * vx + fy * vy + fz * vz) / time_unit_conversion;
     atomicAdd(&g_net_energy[grid_idx], power_fs);
   }
 }
@@ -886,6 +887,7 @@ void Ensemble_TTM::accumulate_ttm_power(
     velocity_per_atom.data(),
     velocity_per_atom.data() + number_of_atoms,
     velocity_per_atom.data() + 2 * number_of_atoms,
+    TIME_UNIT_CONVERSION,
     gpu_net_energy.data());
   GPU_CHECK_KERNEL
 }

--- a/src/integrate/ensemble_ttm.cu
+++ b/src/integrate/ensemble_ttm.cu
@@ -1,0 +1,1085 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*----------------------------------------------------------------------------80
+Two-Temperature Model (TTM) for metals, with an optional heat_lan source/sink
+channel for heat transport across metal-nonmetal heterointerfaces.
+
+Three atom categories:
+  1. Source/sink atoms (grouping method 0): Langevin thermostat at T+dT / T-dT
+  2. Metal atoms (ttm_grouping_method): TTM Langevin coupled to electron grid
+  3. All other atoms: NVE (no thermostat)
+
+The electron subsystem is modeled as a 3D grid with finite-difference heat
+diffusion. Metal atoms exchange energy with the local electron temperature
+via a Langevin-like coupling (friction + stochastic force).
+
+References:
+[1] P.B. Crozier, R.E. Jones, et al., LAMMPS fix_ttm implementation.
+[2] G. Bussi and M. Parrinello, Phys. Rev. E 75, 056707 (2007).
+------------------------------------------------------------------------------*/
+
+#include "ensemble_ttm.cuh"
+#include "langevin_utilities.cuh"
+#include "utilities/common.cuh"
+#include "utilities/error.cuh"
+#include "utilities/gpu_macro.cuh"
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#ifdef USE_HIP
+  #define TTM_RAND_UNIFORM(a) hiprand_uniform(a)
+#else
+  #define TTM_RAND_UNIFORM(a) curand_uniform(a)
+#endif
+
+// Map a metal atom to its electron grid cell index.
+// For orthogonal GPUMD boxes, positions are wrapped into [0, L).
+static __global__ void gpu_map_atoms_to_grid(
+  const int N_metal,
+  const int offset,
+  const int* __restrict__ g_group_contents,
+  const double* __restrict__ g_x,
+  const double* __restrict__ g_y,
+  const double* __restrict__ g_z,
+  const double dxinv,
+  const double dyinv,
+  const double dzinv,
+  const int nx,
+  const int ny,
+  const int nz,
+  int* __restrict__ g_atom_grid)
+{
+  int m = blockIdx.x * blockDim.x + threadIdx.x;
+  if (m < N_metal) {
+    int n = g_group_contents[offset + m];
+    double x = g_x[n];
+    double y = g_y[n];
+    double z = g_z[n];
+    int ix = static_cast<int>(floor(x * dxinv));
+    int iy = static_cast<int>(floor(y * dyinv));
+    int iz = static_cast<int>(floor(z * dzinv));
+
+    ix %= nx;
+    iy %= ny;
+    iz %= nz;
+    if (ix < 0) ix += nx;
+    if (iy < 0) iy += ny;
+    if (iz < 0) iz += nz;
+
+    g_atom_grid[m] = iz * ny * nx + iy * nx + ix;
+  }
+}
+
+// Apply a stored TTM force for half a timestep.
+static __global__ void gpu_apply_ttm_force_half(
+  const int N_metal,
+  const int offset,
+  const int* __restrict__ g_group_contents,
+  const double* __restrict__ g_mass,
+  const double* __restrict__ g_ttm_force,
+  const double half_dt,
+  double* __restrict__ g_vx,
+  double* __restrict__ g_vy,
+  double* __restrict__ g_vz)
+{
+  int m = blockIdx.x * blockDim.x + threadIdx.x;
+  if (m < N_metal) {
+    int n = g_group_contents[offset + m];
+    double inv_mass = 1.0 / g_mass[n];
+    g_vx[n] += g_ttm_force[m] * half_dt * inv_mass;
+    g_vy[n] += g_ttm_force[m + N_metal] * half_dt * inv_mass;
+    g_vz[n] += g_ttm_force[m + 2 * N_metal] * half_dt * inv_mass;
+  }
+}
+
+// Compute the current TTM Langevin force from the electron grid.
+static __global__ void gpu_update_ttm_force(
+  gpurandState* __restrict__ g_state,
+  const int N_metal,
+  const int offset,
+  const int* __restrict__ g_group_contents,
+  const double* __restrict__ g_Te,
+  const int* __restrict__ g_active,
+  const double* __restrict__ g_gamma_p,
+  const int* __restrict__ g_atom_grid,
+  const double gamma_s,
+  const double time_step,
+  const double v_0_sq,
+  double* __restrict__ g_ttm_force,
+  double* __restrict__ g_vx,
+  double* __restrict__ g_vy,
+  double* __restrict__ g_vz)
+{
+  int m = blockIdx.x * blockDim.x + threadIdx.x;
+  if (m < N_metal) {
+    int n = g_group_contents[offset + m];
+    int grid_idx = g_atom_grid[m];
+    double Te = g_Te[grid_idx];
+    if (g_active[grid_idx] == 0 || Te <= 0.0) {
+      g_ttm_force[m] = 0.0;
+      g_ttm_force[m + N_metal] = 0.0;
+      g_ttm_force[m + 2 * N_metal] = 0.0;
+      return;
+    }
+    if (Te < 0.0) Te = 0.0;
+    const double gamma_p = g_gamma_p[grid_idx];
+    if (gamma_p <= 0.0) {
+      g_ttm_force[m] = 0.0;
+      g_ttm_force[m + N_metal] = 0.0;
+      g_ttm_force[m + 2 * N_metal] = 0.0;
+      return;
+    }
+
+    double vx = g_vx[n];
+    double vy = g_vy[n];
+    double vz = g_vz[n];
+
+    double vsq = vx * vx + vy * vy + vz * vz;
+    double gamma = gamma_p;
+    if (vsq > v_0_sq) gamma = gamma_p + gamma_s;
+
+    // LAMMPS fix_ttm uses a uniform random number in [-0.5, 0.5].
+    double gfactor = sqrt(Te * 24.0 * K_B * gamma_p / time_step);
+
+    gpurandState state = g_state[m];
+    double fx = -gamma * vx + gfactor * (TTM_RAND_UNIFORM(&state) - 0.5);
+    double fy = -gamma * vy + gfactor * (TTM_RAND_UNIFORM(&state) - 0.5);
+    double fz = -gamma * vz + gfactor * (TTM_RAND_UNIFORM(&state) - 0.5);
+    g_state[m] = state;
+
+    g_ttm_force[m] = fx;
+    g_ttm_force[m + N_metal] = fy;
+    g_ttm_force[m + 2 * N_metal] = fz;
+  }
+}
+
+// Accumulate the instantaneous electron-to-atom power using the stored
+// Langevin force and the final velocity of the MD step.
+static __global__ void gpu_accumulate_ttm_power(
+  const int N_metal,
+  const int offset,
+  const int* __restrict__ g_group_contents,
+  const int* __restrict__ g_active,
+  const int* __restrict__ g_atom_grid,
+  const double* __restrict__ g_ttm_force,
+  const double* __restrict__ g_vx,
+  const double* __restrict__ g_vy,
+  const double* __restrict__ g_vz,
+  double* __restrict__ g_net_energy)
+{
+  int m = blockIdx.x * blockDim.x + threadIdx.x;
+  if (m < N_metal) {
+    int n = g_group_contents[offset + m];
+    int grid_idx = g_atom_grid[m];
+    if (g_active[grid_idx] == 0) {
+      return;
+    }
+    double vx = g_vx[n];
+    double vy = g_vy[n];
+    double vz = g_vz[n];
+    double fx = g_ttm_force[m];
+    double fy = g_ttm_force[m + N_metal];
+    double fz = g_ttm_force[m + 2 * N_metal];
+    const double power_fs = (fx * vx + fy * vy + fz * vz) / TIME_UNIT_CONVERSION;
+    atomicAdd(&g_net_energy[grid_idx], power_fs);
+  }
+}
+
+void Ensemble_TTM::update_box_geometry(const Box& box)
+{
+  box_length[0] = box.cpu_h[0];
+  box_length[1] = box.cpu_h[4];
+  box_length[2] = box.cpu_h[8];
+  dx = box_length[0] / nx;
+  dy = box_length[1] / ny;
+  dz = box_length[2] / nz;
+}
+
+void Ensemble_TTM::open_electron_temperature_file()
+{
+  electron_temperature_file = my_fopen("ttm_electron_temperature.out", "w");
+  fprintf(
+    electron_temperature_file,
+    "# electron temperature snapshots for TTM\n"
+    "# nx %d ny %d nz %d\n"
+    "# active_x %d %d active_y %d %d active_z %d %d\n"
+    "# properties_file %s\n"
+    "# electron_source %.10e\n"
+    "# output_interval %d step(s)\n"
+    "# columns: ix iy iz T_e[K]\n",
+    nx,
+    ny,
+    nz,
+    active_x_min,
+    active_x_max,
+    active_y_min,
+    active_y_max,
+    active_z_min,
+    active_z_max,
+    use_electron_properties ? "yes" : "no",
+    electron_source,
+    electron_temperature_output_interval);
+}
+
+void Ensemble_TTM::initialize_active_cells()
+{
+  electron_cell_active.resize(ngrid_total, 0);
+  for (int iz = 0; iz < nz; ++iz) {
+    for (int iy = 0; iy < ny; ++iy) {
+      for (int ix = 0; ix < nx; ++ix) {
+        const bool active_x = ix + 1 >= active_x_min && ix + 1 <= active_x_max;
+        const bool active_y = iy + 1 >= active_y_min && iy + 1 <= active_y_max;
+        const bool active_z = iz + 1 >= active_z_min && iz + 1 <= active_z_max;
+        if (active_x && active_y && active_z) {
+          electron_cell_active[iz * ny * nx + iy * nx + ix] = 1;
+        }
+      }
+    }
+  }
+}
+
+void Ensemble_TTM::apply_active_cell_mask()
+{
+  for (int i = 0; i < ngrid_total; ++i) {
+    if (electron_cell_active[i] == 0) {
+      T_electron[i] = 0.0;
+      T_electron_old[i] = 0.0;
+      if (i < static_cast<int>(electron_heat_capacity.size())) {
+        electron_heat_capacity[i] = 0.0;
+        electron_thermal_conductivity[i] = 0.0;
+        electron_gamma_p_nat[i] = 0.0;
+        electron_eta[i] = 0.0;
+      }
+    }
+  }
+}
+
+void Ensemble_TTM::load_initial_electron_temperatures(const std::string& filename)
+{
+  if (filename.empty()) {
+    apply_active_cell_mask();
+    return;
+  }
+
+  std::ifstream input(filename);
+  if (!input) {
+    std::string error = "Could not open ttm_infile.";
+    PRINT_INPUT_ERROR(error.c_str());
+  }
+
+  std::vector<int> is_set(ngrid_total, 0);
+  int num_set = 0;
+  std::string line;
+  while (std::getline(input, line)) {
+    const size_t first_nonblank = line.find_first_not_of(" \t\r\n");
+    if (first_nonblank == std::string::npos) {
+      continue;
+    }
+    if (line[first_nonblank] == '#') {
+      continue;
+    }
+
+    std::istringstream iss(line.substr(first_nonblank));
+    int ix = 0;
+    int iy = 0;
+    int iz = 0;
+    double Te = 0.0;
+    if (!(iss >> ix >> iy >> iz >> Te)) {
+      std::string error = "Invalid line in ttm_infile.";
+      PRINT_INPUT_ERROR(error.c_str());
+    }
+    if (ix < 1 || ix > nx || iy < 1 || iy > ny || iz < 1 || iz > nz) {
+      std::string error = "Grid index in ttm_infile is out of range.";
+      PRINT_INPUT_ERROR(error.c_str());
+    }
+    const int idx = (iz - 1) * ny * nx + (iy - 1) * nx + (ix - 1);
+    if (is_set[idx]) {
+      std::string error = "Duplicate grid point found in ttm_infile.";
+      PRINT_INPUT_ERROR(error.c_str());
+    }
+    if (Te < 0.0) {
+      std::string error = "Electron temperatures in ttm_infile should >= 0.";
+      PRINT_INPUT_ERROR(error.c_str());
+    }
+    if (electron_cell_active[idx] == 0 && Te != 0.0) {
+      std::string error = "Electron temperatures in inactive ttm cells should be 0.";
+      PRINT_INPUT_ERROR(error.c_str());
+    }
+    T_electron[idx] = Te;
+    T_electron_old[idx] = Te;
+    is_set[idx] = 1;
+    ++num_set;
+  }
+
+  if (num_set != ngrid_total) {
+    std::string error = "ttm_infile did not set all electron grid temperatures.";
+    PRINT_INPUT_ERROR(error.c_str());
+  }
+
+  apply_active_cell_mask();
+}
+
+void Ensemble_TTM::load_electron_properties(const std::string& filename)
+{
+  if (filename.empty()) {
+    return;
+  }
+
+  std::ifstream input(filename);
+  if (!input) {
+    std::string error = "Could not open ttm_properties_file.";
+    PRINT_INPUT_ERROR(error.c_str());
+  }
+
+  std::vector<int> is_set(ngrid_total, 0);
+  int num_set = 0;
+  std::string line;
+  while (std::getline(input, line)) {
+    const size_t first_nonblank = line.find_first_not_of(" \t\r\n");
+    if (first_nonblank == std::string::npos) {
+      continue;
+    }
+    if (line[first_nonblank] == '#') {
+      continue;
+    }
+
+    std::istringstream iss(line.substr(first_nonblank));
+    int ix = 0;
+    int iy = 0;
+    int iz = 0;
+    double c_vol = 0.0;
+    double kappa = 0.0;
+    double gamma_p_local = 0.0;
+    double eta = 0.0;
+    if (!(iss >> ix >> iy >> iz >> c_vol >> kappa >> gamma_p_local >> eta)) {
+      std::string error = "Invalid line in ttm_properties_file.";
+      PRINT_INPUT_ERROR(error.c_str());
+    }
+    if (ix < 1 || ix > nx || iy < 1 || iy > ny || iz < 1 || iz > nz) {
+      std::string error = "Grid index in ttm_properties_file is out of range.";
+      PRINT_INPUT_ERROR(error.c_str());
+    }
+    if (c_vol < 0.0 || kappa < 0.0 || gamma_p_local < 0.0) {
+      std::string error = "Cell properties in ttm_properties_file should be >= 0.";
+      PRINT_INPUT_ERROR(error.c_str());
+    }
+    if (eta < 0.0 || eta > 1.0) {
+      std::string error = "eta in ttm_properties_file should be between 0 and 1.";
+      PRINT_INPUT_ERROR(error.c_str());
+    }
+
+    const int idx = (iz - 1) * ny * nx + (iy - 1) * nx + (ix - 1);
+    if (is_set[idx]) {
+      std::string error = "Duplicate grid point found in ttm_properties_file.";
+      PRINT_INPUT_ERROR(error.c_str());
+    }
+    electron_heat_capacity[idx] = c_vol;
+    electron_thermal_conductivity[idx] = kappa / 1000.0;
+    electron_gamma_p_nat[idx] = gamma_p_local * TIME_UNIT_CONVERSION / 1000.0;
+    electron_eta[idx] = eta;
+    is_set[idx] = 1;
+    ++num_set;
+  }
+
+  if (num_set != ngrid_total) {
+    std::string error = "ttm_properties_file did not set all electron grid properties.";
+    PRINT_INPUT_ERROR(error.c_str());
+  }
+}
+
+static inline double safe_effective_kappa(const double a, const double b)
+{
+  if (a <= 0.0 || b <= 0.0) {
+    return 0.0;
+  }
+  return 2.0 * a * b / (a + b);
+}
+
+void Ensemble_TTM::write_electron_temperature_snapshot(const int step)
+{
+  fprintf(electron_temperature_file, "# step %d\n", step);
+  for (int iz = 0; iz < nz; ++iz) {
+    for (int iy = 0; iy < ny; ++iy) {
+      for (int ix = 0; ix < nx; ++ix) {
+        const int idx = iz * ny * nx + iy * nx + ix;
+        fprintf(
+          electron_temperature_file, "%d %d %d %.10e\n", ix + 1, iy + 1, iz + 1, T_electron[idx]);
+      }
+    }
+  }
+  fflush(electron_temperature_file);
+}
+
+void Ensemble_TTM::close_electron_temperature_file()
+{
+  if (electron_temperature_file != nullptr) {
+    fclose(electron_temperature_file);
+    electron_temperature_file = nullptr;
+  }
+}
+
+void Ensemble_TTM::initialize_ttm_random_states()
+{
+  curand_states_metal.resize(N_metal);
+  int grid_size_metal = (N_metal - 1) / 128 + 1;
+  initialize_curand_states<<<grid_size_metal, 128>>>(curand_states_metal.data(), N_metal, rand());
+  GPU_CHECK_KERNEL
+}
+
+void Ensemble_TTM::initialize_electron_grid(
+  double T_e_init,
+  const std::string& electron_temperature_init_file_input,
+  const std::string& electron_property_file_input,
+  const Box& box)
+{
+  update_box_geometry(box);
+  initialize_active_cells();
+
+  T_electron.resize(ngrid_total, T_e_init);
+  T_electron_old.resize(ngrid_total, T_e_init);
+  electron_heat_capacity.resize(ngrid_total, Ce * rho_e);
+  electron_thermal_conductivity.resize(ngrid_total, kappa_e);
+  electron_gamma_p_nat.resize(ngrid_total, gamma_p_nat);
+  electron_eta.resize(ngrid_total, 0.0);
+  if (!use_electron_properties) {
+    for (int i = 0; i < ngrid_total; ++i) {
+      if (electron_cell_active[i]) {
+        electron_eta[i] = 1.0;
+      }
+    }
+  }
+  load_electron_properties(electron_property_file_input);
+  load_initial_electron_temperatures(electron_temperature_init_file_input);
+}
+
+void Ensemble_TTM::initialize_ttm_gpu_data()
+{
+  gpu_T_electron.resize(ngrid_total);
+  gpu_T_electron.fill(0);
+  gpu_electron_cell_active.resize(ngrid_total);
+  gpu_electron_cell_active.fill(0);
+  gpu_electron_gamma_p_nat.resize(ngrid_total);
+  gpu_electron_gamma_p_nat.fill(0);
+  gpu_net_energy.resize(ngrid_total);
+  gpu_net_energy.fill(0);
+  gpu_atom_grid_index.resize(N_metal);
+  gpu_atom_grid_index.fill(0);
+  gpu_ttm_force.resize(N_metal * 3);
+  gpu_ttm_force.fill(0);
+
+  gpu_T_electron.copy_from_host(T_electron.data());
+  gpu_electron_cell_active.copy_from_host(electron_cell_active.data());
+  gpu_electron_gamma_p_nat.copy_from_host(electron_gamma_p_nat.data());
+  open_electron_temperature_file();
+  write_electron_temperature_snapshot(0);
+}
+
+void Ensemble_TTM::initialize_ttm_common(
+  int type_input,
+  int ttm_grouping_method_input,
+  int ttm_group_input,
+  int ttm_group_size,
+  int ttm_group_offset,
+  double Ce_input,
+  double rho_e_input,
+  double kappa_e_input,
+  double gamma_p_input,
+  double gamma_s_input,
+  double v_0_input,
+  int nx_input,
+  int ny_input,
+  int nz_input,
+  int active_x_min_input,
+  int active_x_max_input,
+  int active_y_min_input,
+  int active_y_max_input,
+  int active_z_min_input,
+  int active_z_max_input,
+  double T_e_init,
+  int electron_temperature_output_interval_input,
+  const std::string& electron_temperature_init_file_input,
+  const std::string& electron_property_file_input,
+  double electron_source_input,
+  const Box& box)
+{
+  type = type_input;
+
+  ttm_grouping_method = ttm_grouping_method_input;
+  ttm_group_id = ttm_group_input;
+  N_metal = ttm_group_size;
+  offset_metal = ttm_group_offset;
+  initialize_ttm_random_states();
+
+  energy_transferred[0] = 0.0;
+  energy_transferred[1] = 0.0;
+
+  // TTM physics parameters.
+  // Inputs follow the LAMMPS fix_ttm convention so the same numeric
+  // parameters can be reused here:
+  //   kappa_e : eV / (ps * K * A)
+  //   gamma_* : mass / ps
+  //   v_0     : A / ps
+  Ce = Ce_input;
+  rho_e = rho_e_input;
+  kappa_e = kappa_e_input / 1000.0;
+  gamma_p = gamma_p_input;
+  gamma_s = gamma_s_input;
+  gamma_p_nat = gamma_p * TIME_UNIT_CONVERSION / 1000.0;
+  gamma_s_nat = gamma_s * TIME_UNIT_CONVERSION / 1000.0;
+  double v_0_nat = v_0_input * TIME_UNIT_CONVERSION / 1000.0;
+  v_0_sq = v_0_nat * v_0_nat;
+  electron_source = electron_source_input / 1000.0;
+  use_electron_properties = !electron_property_file_input.empty();
+
+  nx = nx_input;
+  ny = ny_input;
+  nz = nz_input;
+  ngrid_total = nx * ny * nz;
+  active_x_min = active_x_min_input;
+  active_x_max = active_x_max_input;
+  active_y_min = active_y_min_input;
+  active_y_max = active_y_max_input;
+  active_z_min = active_z_min_input;
+  active_z_max = active_z_max_input;
+  electron_temperature_output_interval = electron_temperature_output_interval_input;
+
+  initialize_electron_grid(T_e_init, electron_temperature_init_file_input, electron_property_file_input, box);
+  initialize_ttm_gpu_data();
+}
+
+Ensemble_TTM::Ensemble_TTM(
+  int type_input,
+  int source_input,
+  int sink_input,
+  int source_size,
+  int sink_size,
+  int source_offset,
+  int sink_offset,
+  int ttm_grouping_method_input,
+  int ttm_group_input,
+  int ttm_group_size,
+  int ttm_group_offset,
+  double T,
+  double Tc,
+  double dT,
+  double Ce_input,
+  double rho_e_input,
+  double kappa_e_input,
+  double gamma_p_input,
+  double gamma_s_input,
+  double v_0_input,
+  int nx_input,
+  int ny_input,
+  int nz_input,
+  int active_x_min_input,
+  int active_x_max_input,
+  int active_y_min_input,
+  int active_y_max_input,
+  int active_z_min_input,
+  int active_z_max_input,
+  double T_e_init,
+  int electron_temperature_output_interval_input,
+  const std::string& electron_temperature_init_file_input,
+  const std::string& electron_property_file_input,
+  double electron_source_input,
+  const Box& box)
+{
+  use_heat_lan = true;
+  temperature = T;
+  temperature_coupling = Tc;
+  delta_temperature = dT;
+  source = source_input;
+  sink = sink_input;
+  N_source = source_size;
+  N_sink = sink_size;
+  offset_source = source_offset;
+  offset_sink = sink_offset;
+
+  // source/sink Langevin coefficients (same as heat_lan)
+  c1 = exp(-0.5 / temperature_coupling);
+  c2_source = sqrt((1 - c1 * c1) * K_B * (T + dT));
+  c2_sink = sqrt((1 - c1 * c1) * K_B * (T - dT));
+
+  // initialize curand states for source, sink, and metal
+  curand_states_source.resize(N_source);
+  curand_states_sink.resize(N_sink);
+  int grid_size_source = (N_source - 1) / 128 + 1;
+  int grid_size_sink = (N_sink - 1) / 128 + 1;
+  initialize_curand_states<<<grid_size_source, 128>>>(
+    curand_states_source.data(), N_source, rand());
+  GPU_CHECK_KERNEL
+  initialize_curand_states<<<grid_size_sink, 128>>>(
+    curand_states_sink.data(), N_sink, rand());
+  GPU_CHECK_KERNEL
+  initialize_ttm_common(
+    type_input,
+    ttm_grouping_method_input,
+    ttm_group_input,
+    ttm_group_size,
+    ttm_group_offset,
+    Ce_input,
+    rho_e_input,
+    kappa_e_input,
+    gamma_p_input,
+    gamma_s_input,
+    v_0_input,
+    nx_input,
+    ny_input,
+    nz_input,
+    active_x_min_input,
+    active_x_max_input,
+    active_y_min_input,
+    active_y_max_input,
+    active_z_min_input,
+    active_z_max_input,
+    T_e_init,
+    electron_temperature_output_interval_input,
+    electron_temperature_init_file_input,
+    electron_property_file_input,
+    electron_source_input,
+    box);
+}
+
+Ensemble_TTM::Ensemble_TTM(
+  int type_input,
+  int ttm_grouping_method_input,
+  int ttm_group_input,
+  int ttm_group_size,
+  int ttm_group_offset,
+  double Ce_input,
+  double rho_e_input,
+  double kappa_e_input,
+  double gamma_p_input,
+  double gamma_s_input,
+  double v_0_input,
+  int nx_input,
+  int ny_input,
+  int nz_input,
+  int active_x_min_input,
+  int active_x_max_input,
+  int active_y_min_input,
+  int active_y_max_input,
+  int active_z_min_input,
+  int active_z_max_input,
+  double T_e_init,
+  int electron_temperature_output_interval_input,
+  const std::string& electron_temperature_init_file_input,
+  const std::string& electron_property_file_input,
+  double electron_source_input,
+  const Box& box)
+{
+  use_heat_lan = false;
+  temperature = 0.0;
+  temperature_coupling = 0.0;
+  delta_temperature = 0.0;
+  source = -1;
+  sink = -1;
+  N_source = 0;
+  N_sink = 0;
+  offset_source = 0;
+  offset_sink = 0;
+
+  curand_states_source.resize(0);
+  curand_states_sink.resize(0);
+  initialize_ttm_common(
+    type_input,
+    ttm_grouping_method_input,
+    ttm_group_input,
+    ttm_group_size,
+    ttm_group_offset,
+    Ce_input,
+    rho_e_input,
+    kappa_e_input,
+    gamma_p_input,
+    gamma_s_input,
+    v_0_input,
+    nx_input,
+    ny_input,
+    nz_input,
+    active_x_min_input,
+    active_x_max_input,
+    active_y_min_input,
+    active_y_max_input,
+    active_z_min_input,
+    active_z_max_input,
+    T_e_init,
+    electron_temperature_output_interval_input,
+    electron_temperature_init_file_input,
+    electron_property_file_input,
+    electron_source_input,
+    box);
+}
+
+Ensemble_TTM::~Ensemble_TTM(void)
+{
+  close_electron_temperature_file();
+}
+
+// Source/sink Langevin thermostat (identical to heat_lan)
+void Ensemble_TTM::integrate_heat_lan_half(
+  const std::vector<Group>& group,
+  const GPU_Vector<double>& mass,
+  GPU_Vector<double>& velocity_per_atom)
+{
+  const int number_of_atoms = mass.size();
+  int Ng = group[0].number;
+
+  std::vector<double> ek2(Ng);
+  GPU_Vector<double> ke(Ng);
+
+  find_ke<<<Ng, 512>>>(
+    group[0].size.data(),
+    group[0].size_sum.data(),
+    group[0].contents.data(),
+    mass.data(),
+    velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms,
+    velocity_per_atom.data() + 2 * number_of_atoms,
+    ke.data());
+  GPU_CHECK_KERNEL
+
+  ke.copy_to_host(ek2.data());
+  energy_transferred[0] += ek2[source] * 0.5;
+  energy_transferred[1] += ek2[sink] * 0.5;
+
+  gpu_langevin<<<(N_source - 1) / 128 + 1, 128>>>(
+    curand_states_source.data(),
+    N_source,
+    offset_source,
+    group[0].contents.data(),
+    c1,
+    c2_source,
+    mass.data(),
+    velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms,
+    velocity_per_atom.data() + 2 * number_of_atoms);
+  GPU_CHECK_KERNEL
+
+  gpu_langevin<<<(N_sink - 1) / 128 + 1, 128>>>(
+    curand_states_sink.data(),
+    N_sink,
+    offset_sink,
+    group[0].contents.data(),
+    c1,
+    c2_sink,
+    mass.data(),
+    velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms,
+    velocity_per_atom.data() + 2 * number_of_atoms);
+  GPU_CHECK_KERNEL
+
+  find_ke<<<Ng, 512>>>(
+    group[0].size.data(),
+    group[0].size_sum.data(),
+    group[0].contents.data(),
+    mass.data(),
+    velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms,
+    velocity_per_atom.data() + 2 * number_of_atoms,
+    ke.data());
+  GPU_CHECK_KERNEL
+
+  ke.copy_to_host(ek2.data());
+  energy_transferred[0] -= ek2[source] * 0.5;
+  energy_transferred[1] -= ek2[sink] * 0.5;
+}
+
+// Apply the stored TTM force to metal atoms for half a timestep.
+void Ensemble_TTM::apply_ttm_force_half(
+  const double half_time_step,
+  const std::vector<Group>& group,
+  const GPU_Vector<double>& mass,
+  GPU_Vector<double>& velocity_per_atom)
+{
+  const int number_of_atoms = mass.size();
+  const int gm = ttm_grouping_method;
+  gpu_apply_ttm_force_half<<<(N_metal - 1) / 128 + 1, 128>>>(
+    N_metal,
+    offset_metal,
+    group[gm].contents.data(),
+    mass.data(),
+    gpu_ttm_force.data(),
+    half_time_step,
+    velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms,
+    velocity_per_atom.data() + 2 * number_of_atoms);
+  GPU_CHECK_KERNEL
+}
+
+// Compute the current TTM Langevin force from the electron grid.
+void Ensemble_TTM::update_ttm_force(
+  const double time_step,
+  const std::vector<Group>& group,
+  const GPU_Vector<double>& position_per_atom,
+  GPU_Vector<double>& velocity_per_atom)
+{
+  const int number_of_atoms = position_per_atom.size() / 3;
+  const int gm = ttm_grouping_method;
+
+  gpu_map_atoms_to_grid<<<(N_metal - 1) / 128 + 1, 128>>>(
+    N_metal,
+    offset_metal,
+    group[gm].contents.data(),
+    position_per_atom.data(),
+    position_per_atom.data() + number_of_atoms,
+    position_per_atom.data() + 2 * number_of_atoms,
+    nx / box_length[0],
+    ny / box_length[1],
+    nz / box_length[2],
+    nx,
+    ny,
+    nz,
+    gpu_atom_grid_index.data());
+  GPU_CHECK_KERNEL
+
+  gpu_net_energy.fill(0);
+
+  gpu_update_ttm_force<<<(N_metal - 1) / 128 + 1, 128>>>(
+    curand_states_metal.data(),
+    N_metal,
+    offset_metal,
+    group[gm].contents.data(),
+    gpu_T_electron.data(),
+    gpu_electron_cell_active.data(),
+    gpu_electron_gamma_p_nat.data(),
+    gpu_atom_grid_index.data(),
+    gamma_s_nat,
+    time_step,
+    v_0_sq,
+    gpu_ttm_force.data(),
+    velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms,
+    velocity_per_atom.data() + 2 * number_of_atoms);
+  GPU_CHECK_KERNEL
+}
+
+void Ensemble_TTM::accumulate_ttm_power(
+  const std::vector<Group>& group,
+  GPU_Vector<double>& velocity_per_atom)
+{
+  const int number_of_atoms = velocity_per_atom.size() / 3;
+  const int gm = ttm_grouping_method;
+  gpu_accumulate_ttm_power<<<(N_metal - 1) / 128 + 1, 128>>>(
+    N_metal,
+    offset_metal,
+    group[gm].contents.data(),
+    gpu_electron_cell_active.data(),
+    gpu_atom_grid_index.data(),
+    gpu_ttm_force.data(),
+    velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms,
+    velocity_per_atom.data() + 2 * number_of_atoms,
+    gpu_net_energy.data());
+  GPU_CHECK_KERNEL
+}
+
+// Solve the electron heat diffusion equation with explicit finite differences
+void Ensemble_TTM::update_electron_temperature(const double time_step)
+{
+  double dt_fs = time_step * TIME_UNIT_CONVERSION;
+  double del_vol = dx * dy * dz;
+
+  // copy net electron-to-atom power from GPU to CPU
+  std::vector<double> net_energy_cpu(ngrid_total);
+  gpu_net_energy.copy_to_host(net_energy_cpu.data());
+
+  // stability criterion for explicit FD
+  int num_inner_steps = 1;
+  double inner_dt = dt_fs;
+
+  const double voxel_coeff = 1.0 / (dx * dx) + 1.0 / (dy * dy) + 1.0 / (dz * dz);
+  double fourier_max = 0.0;
+  for (int i = 0; i < ngrid_total; ++i) {
+    if (electron_heat_capacity[i] > 0.0 && electron_thermal_conductivity[i] > 0.0) {
+      const double fourier =
+        2.0 * electron_thermal_conductivity[i] * voxel_coeff / electron_heat_capacity[i];
+      if (fourier > fourier_max) {
+        fourier_max = fourier;
+      }
+    }
+  }
+
+  if (fourier_max > 0.0) {
+    double stability = 1.0 - fourier_max * inner_dt;
+    if (stability < 0.0) {
+      inner_dt = 1.0 / fourier_max;
+      num_inner_steps = static_cast<int>(dt_fs / inner_dt) + 1;
+      inner_dt = dt_fs / static_cast<double>(num_inner_steps);
+      if (num_inner_steps > 1000000) {
+        printf("Warning: too many inner timesteps (%d) in TTM electron diffusion.\n",
+               num_inner_steps);
+      }
+    }
+  }
+
+  // finite difference iterations
+  for (int istep = 0; istep < num_inner_steps; istep++) {
+    // save old temperatures
+    for (int i = 0; i < ngrid_total; i++) {
+      T_electron_old[i] = T_electron[i];
+    }
+
+    // update electron temperature
+    for (int iz = 0; iz < nz; iz++) {
+      for (int iy = 0; iy < ny; iy++) {
+        for (int ix = 0; ix < nx; ix++) {
+          int idx = iz * ny * nx + iy * nx + ix;
+          const double T_center = T_electron_old[idx];
+          if (electron_cell_active[idx] == 0 || T_center <= 0.0) {
+            T_electron[idx] = 0.0;
+            continue;
+          }
+
+          // periodic neighbors
+          int xr = (ix + 1 < nx) ? ix + 1 : 0;
+          int xl = (ix - 1 >= 0) ? ix - 1 : nx - 1;
+          int yr = (iy + 1 < ny) ? iy + 1 : 0;
+          int yl = (iy - 1 >= 0) ? iy - 1 : ny - 1;
+          int zr = (iz + 1 < nz) ? iz + 1 : 0;
+          int zl = (iz - 1 >= 0) ? iz - 1 : nz - 1;
+
+          const int idx_xr = iz * ny * nx + iy * nx + xr;
+          const int idx_xl = iz * ny * nx + iy * nx + xl;
+          const int idx_yr = iz * ny * nx + yr * nx + ix;
+          const int idx_yl = iz * ny * nx + yl * nx + ix;
+          const int idx_zr = zr * ny * nx + iy * nx + ix;
+          const int idx_zl = zl * ny * nx + iy * nx + ix;
+          int left = 1;
+          int right = 1;
+          int in = 1;
+          int out = 1;
+          int up = 1;
+          int down = 1;
+          if (!(electron_cell_active[idx_xl] && T_electron_old[idx_xl] > 0.0)) left = 0;
+          if (!(electron_cell_active[idx_xr] && T_electron_old[idx_xr] > 0.0)) right = 0;
+          if (!(electron_cell_active[idx_yr] && T_electron_old[idx_yr] > 0.0)) in = 0;
+          if (!(electron_cell_active[idx_yl] && T_electron_old[idx_yl] > 0.0)) out = 0;
+          if (!(electron_cell_active[idx_zr] && T_electron_old[idx_zr] > 0.0)) up = 0;
+          if (!(electron_cell_active[idx_zl] && T_electron_old[idx_zl] > 0.0)) down = 0;
+
+          const double c_vol = electron_heat_capacity[idx];
+          if (c_vol <= 0.0) {
+            T_electron[idx] = 0.0;
+            continue;
+          }
+
+          const double k_center = electron_thermal_conductivity[idx];
+          const double diffusion =
+            safe_effective_kappa(electron_thermal_conductivity[idx_xl], k_center) *
+              (T_electron_old[idx_xl] - T_center) / (dx * dx) * left +
+            safe_effective_kappa(electron_thermal_conductivity[idx_xr], k_center) *
+              (T_electron_old[idx_xr] - T_center) / (dx * dx) * right +
+            safe_effective_kappa(electron_thermal_conductivity[idx_yl], k_center) *
+              (T_electron_old[idx_yl] - T_center) / (dy * dy) * out +
+            safe_effective_kappa(electron_thermal_conductivity[idx_yr], k_center) *
+              (T_electron_old[idx_yr] - T_center) / (dy * dy) * in +
+            safe_effective_kappa(electron_thermal_conductivity[idx_zl], k_center) *
+              (T_electron_old[idx_zl] - T_center) / (dz * dz) * down +
+            safe_effective_kappa(electron_thermal_conductivity[idx_zr], k_center) *
+              (T_electron_old[idx_zr] - T_center) / (dz * dz) * up;
+
+          T_electron[idx] = T_center +
+            inner_dt / c_vol *
+              (diffusion - net_energy_cpu[idx] / del_vol + electron_source * electron_eta[idx]);
+        }
+      }
+    }
+  }
+
+  for (int i = 0; i < ngrid_total; ++i) {
+    if (electron_cell_active[i] == 0) {
+      T_electron[i] = 0.0;
+    } else if (T_electron[i] < 0.0) {
+      PRINT_INPUT_ERROR("Electronic temperature dropped below zero.");
+    }
+  }
+
+  // copy updated electron temperatures back to GPU
+  gpu_T_electron.copy_from_host(T_electron.data());
+  const int step = *current_step + 1;
+  if (step % electron_temperature_output_interval == 0) {
+    write_electron_temperature_snapshot(step);
+  }
+}
+
+void Ensemble_TTM::compute1(
+  const double time_step,
+  const std::vector<Group>& group,
+  Box& box,
+  Atom& atom,
+  GPU_Vector<double>& thermo)
+{
+  update_box_geometry(box);
+
+  if (use_heat_lan) {
+    // 1. Apply source/sink Langevin thermostat (NEMD part)
+    integrate_heat_lan_half(group, atom.mass, atom.velocity_per_atom);
+  }
+
+  // 2. Apply the stored TTM force for the first half-step.
+  apply_ttm_force_half(0.5 * time_step, group, atom.mass, atom.velocity_per_atom);
+
+  // 3. Velocity Verlet first half-step (all atoms)
+  velocity_verlet(
+    true,
+    time_step,
+    group,
+    atom.mass,
+    atom.force_per_atom,
+    atom.position_per_atom,
+    atom.velocity_per_atom);
+}
+
+void Ensemble_TTM::compute2(
+  const double time_step,
+  const std::vector<Group>& group,
+  Box& box,
+  Atom& atom,
+  GPU_Vector<double>& thermo)
+{
+  update_box_geometry(box);
+
+  // 1. Generate the current TTM force using the pre-final-integrate velocity.
+  update_ttm_force(time_step, group, atom.position_per_atom, atom.velocity_per_atom);
+
+  // 2. Velocity Verlet second half-step (all atoms)
+  velocity_verlet(
+    false,
+    time_step,
+    group,
+    atom.mass,
+    atom.force_per_atom,
+    atom.position_per_atom,
+    atom.velocity_per_atom);
+
+  if (use_heat_lan) {
+    // 3. Apply source/sink Langevin thermostat (NEMD part)
+    integrate_heat_lan_half(group, atom.mass, atom.velocity_per_atom);
+  }
+
+  // 4. Apply the current TTM force for the second half-step.
+  apply_ttm_force_half(0.5 * time_step, group, atom.mass, atom.velocity_per_atom);
+
+  // 5. Accumulate the electron-to-atom power with the final velocity.
+  accumulate_ttm_power(group, atom.velocity_per_atom);
+
+  // 6. Update electron temperature grid (FD diffusion)
+  update_electron_temperature(time_step);
+}

--- a/src/integrate/ensemble_ttm.cu
+++ b/src/integrate/ensemble_ttm.cu
@@ -16,19 +16,6 @@
 /*----------------------------------------------------------------------------80
 Two-Temperature Model (TTM) for metals, with an optional heat_lan source/sink
 channel for heat transport across metal-nonmetal heterointerfaces.
-
-Three atom categories:
-  1. Source/sink atoms (grouping method 0): Langevin thermostat at T+dT / T-dT
-  2. Metal atoms (ttm_grouping_method): TTM Langevin coupled to electron grid
-  3. All other atoms: NVE (no thermostat)
-
-The electron subsystem is modeled as a 3D grid with finite-difference heat
-diffusion. Metal atoms exchange energy with the local electron temperature
-via a Langevin-like coupling (friction + stochastic force).
-
-References:
-[1] D.M. Duffy and A.M. Rutherford, J. Phys.: Condens. Matter 19, 016207 (2007).
-[2] A.M. Rutherford and D.M. Duffy, J. Phys.: Condens. Matter 19, 496201 (2007).
 ------------------------------------------------------------------------------*/
 
 #include "ensemble_ttm.cuh"
@@ -316,8 +303,6 @@ void print_ttm_settings(const TTM_Parameters& ttm_parameters)
     ttm_parameters.out_interval);
 }
 
-// Map a metal atom to its electron grid cell index.
-// For orthogonal GPUMD boxes, positions are wrapped into [0, L).
 static __global__ void gpu_map_atoms_to_grid(
   const int N_metal,
   const int offset,
@@ -354,7 +339,6 @@ static __global__ void gpu_map_atoms_to_grid(
   }
 }
 
-// Apply a stored TTM force for half a timestep.
 static __global__ void gpu_apply_ttm_force_half(
   const int N_metal,
   const int offset,
@@ -376,7 +360,6 @@ static __global__ void gpu_apply_ttm_force_half(
   }
 }
 
-// Compute the current TTM Langevin force from the electron grid.
 static __global__ void gpu_update_ttm_force(
   gpurandState* __restrict__ g_state,
   const int N_metal,
@@ -422,7 +405,6 @@ static __global__ void gpu_update_ttm_force(
     double gamma = gamma_p;
     if (vsq > v_0_sq) gamma = gamma_p + gamma_s;
 
-    // Use zero-mean uniform random numbers for the stochastic force.
     double gfactor = sqrt(Te * 24.0 * K_B * gamma_p / time_step);
 
     gpurandState state = g_state[m];
@@ -437,8 +419,6 @@ static __global__ void gpu_update_ttm_force(
   }
 }
 
-// Accumulate the instantaneous electron-to-atom power using the stored
-// Langevin force and the final velocity of the MD step.
 static __global__ void gpu_accumulate_ttm_power(
   const int N_metal,
   const int offset,
@@ -777,7 +757,6 @@ void Ensemble_TTM::initialize_ttm_common(
   energy_transferred[0] = 0.0;
   energy_transferred[1] = 0.0;
 
-  // TTM physics parameters.
   // Input units are converted to internal GPUMD units:
   //   kappa_e : eV / (ps * K * A)
   //   gamma_* : mass / ps
@@ -841,12 +820,10 @@ Ensemble_TTM::Ensemble_TTM(
   offset_source = source_offset;
   offset_sink = sink_offset;
 
-  // source/sink Langevin coefficients (same as heat_lan)
   c1 = exp(-0.5 / temperature_coupling);
   c2_source = sqrt((1 - c1 * c1) * K_B * (T + dT));
   c2_sink = sqrt((1 - c1 * c1) * K_B * (T - dT));
 
-  // initialize curand states for source, sink, and metal
   curand_states_source.resize(N_source);
   curand_states_sink.resize(N_sink);
   int grid_size_source = (N_source - 1) / 128 + 1;
@@ -898,7 +875,6 @@ Ensemble_TTM::~Ensemble_TTM(void)
   close_electron_temperature_file();
 }
 
-// Source/sink Langevin thermostat (identical to heat_lan)
 void Ensemble_TTM::integrate_heat_lan_half(
   const std::vector<Group>& group,
   const GPU_Vector<double>& mass,
@@ -967,7 +943,6 @@ void Ensemble_TTM::integrate_heat_lan_half(
   energy_transferred[1] -= ek2[sink] * 0.5;
 }
 
-// Apply the stored TTM force to metal atoms for half a timestep.
 void Ensemble_TTM::apply_ttm_force_half(
   const double half_time_step,
   const std::vector<Group>& group,
@@ -989,7 +964,6 @@ void Ensemble_TTM::apply_ttm_force_half(
   GPU_CHECK_KERNEL
 }
 
-// Compute the current TTM Langevin force from the electron grid.
 void Ensemble_TTM::update_ttm_force(
   const double time_step,
   const std::vector<Group>& group,
@@ -1057,17 +1031,14 @@ void Ensemble_TTM::accumulate_ttm_power(
   GPU_CHECK_KERNEL
 }
 
-// Solve the electron heat diffusion equation with explicit finite differences
 void Ensemble_TTM::update_electron_temperature(const double time_step)
 {
   double dt_fs = time_step * TIME_UNIT_CONVERSION;
   double del_vol = dx * dy * dz;
 
-  // copy net electron-to-atom power from GPU to CPU
   std::vector<double> net_energy_cpu(ngrid_total);
   gpu_net_energy.copy_to_host(net_energy_cpu.data());
 
-  // stability criterion for explicit FD
   int num_inner_steps = 1;
   double inner_dt = dt_fs;
 
@@ -1096,14 +1067,11 @@ void Ensemble_TTM::update_electron_temperature(const double time_step)
     }
   }
 
-  // finite difference iterations
   for (int istep = 0; istep < num_inner_steps; istep++) {
-    // save old temperatures
     for (int i = 0; i < ngrid_total; i++) {
       T_electron_old[i] = T_electron[i];
     }
 
-    // update electron temperature
     for (int iz = 0; iz < nz; iz++) {
       for (int iy = 0; iy < ny; iy++) {
         for (int ix = 0; ix < nx; ix++) {
@@ -1114,7 +1082,6 @@ void Ensemble_TTM::update_electron_temperature(const double time_step)
             continue;
           }
 
-          // periodic neighbors
           int xr = (ix + 1 < nx) ? ix + 1 : 0;
           int xl = (ix - 1 >= 0) ? ix - 1 : nx - 1;
           int yr = (iy + 1 < ny) ? iy + 1 : 0;
@@ -1178,7 +1145,6 @@ void Ensemble_TTM::update_electron_temperature(const double time_step)
     }
   }
 
-  // copy updated electron temperatures back to GPU
   gpu_T_electron.copy_from_host(T_electron.data());
   const int step = *current_step + 1;
   if (step % electron_temperature_output_interval == 0) {
@@ -1196,14 +1162,11 @@ void Ensemble_TTM::compute1(
   update_box_geometry(box);
 
   if (use_heat_lan) {
-    // 1. Apply source/sink Langevin thermostat (NEMD part)
     integrate_heat_lan_half(group, atom.mass, atom.velocity_per_atom);
   }
 
-  // 2. Apply the stored TTM force for the first half-step.
   apply_ttm_force_half(0.5 * time_step, group, atom.mass, atom.velocity_per_atom);
 
-  // 3. Velocity Verlet first half-step (all atoms)
   velocity_verlet(
     true,
     time_step,
@@ -1223,10 +1186,8 @@ void Ensemble_TTM::compute2(
 {
   update_box_geometry(box);
 
-  // 1. Generate the current TTM force using the pre-final-integrate velocity.
   update_ttm_force(time_step, group, atom.position_per_atom, atom.velocity_per_atom);
 
-  // 2. Velocity Verlet second half-step (all atoms)
   velocity_verlet(
     false,
     time_step,
@@ -1237,16 +1198,12 @@ void Ensemble_TTM::compute2(
     atom.velocity_per_atom);
 
   if (use_heat_lan) {
-    // 3. Apply source/sink Langevin thermostat (NEMD part)
     integrate_heat_lan_half(group, atom.mass, atom.velocity_per_atom);
   }
 
-  // 4. Apply the current TTM force for the second half-step.
   apply_ttm_force_half(0.5 * time_step, group, atom.mass, atom.velocity_per_atom);
 
-  // 5. Accumulate the electron-to-atom power with the final velocity.
   accumulate_ttm_power(group, atom.velocity_per_atom);
 
-  // 6. Update electron temperature grid (FD diffusion)
   update_electron_temperature(time_step);
 }

--- a/src/integrate/ensemble_ttm.cuh
+++ b/src/integrate/ensemble_ttm.cuh
@@ -24,6 +24,8 @@ References:
 
 #pragma once
 #include "ensemble.cuh"
+#include "model/box.cuh"
+#include "model/group.cuh"
 #include "utilities/gpu_macro.cuh"
 #ifdef USE_HIP
   #include <hiprand/hiprand_kernel.h>
@@ -33,6 +35,47 @@ References:
 #include <cstdio>
 #include <string>
 #include <vector>
+
+class Atom;
+
+struct TTM_Parameters
+{
+  int grouping_method = 0;
+  int group_id = 0;
+  double Ce = 0.0;
+  double rho_e = 0.0;
+  double kappa_e = 0.0;
+  double gamma_p = 0.0;
+  double gamma_s = 0.0;
+  double v_0 = 0.0;
+  int nx = 0;
+  int ny = 0;
+  int nz = 0;
+  int active_x_min = 1;
+  int active_x_max = 0;
+  int active_y_min = 1;
+  int active_y_max = 0;
+  int active_z_min = 1;
+  int active_z_max = 0;
+  double T_e_init = 0.0;
+  int out_interval = 1;
+  std::string infile;
+  std::string properties_file;
+  double source = 0.0;
+};
+
+void parse_ttm_parameters(
+  const int type,
+  const char** param,
+  const int num_param,
+  const Atom& atom,
+  const Box& box,
+  const std::vector<Group>& group,
+  const int source,
+  const int sink,
+  TTM_Parameters& ttm_parameters);
+
+void print_ttm_settings(const TTM_Parameters& ttm_parameters);
 
 class Ensemble_TTM : public Ensemble
 {
@@ -45,61 +88,19 @@ public:
     int sink_size,
     int source_offset,
     int sink_offset,
-    int ttm_grouping_method_input,
-    int ttm_group_input,
     int ttm_group_size,
     int ttm_group_offset,
     double T,
     double Tc,
     double dT,
-    double Ce_input,
-    double rho_e_input,
-    double kappa_e_input,
-    double gamma_p_input,
-    double gamma_s_input,
-    double v_0_input,
-    int nx_input,
-    int ny_input,
-    int nz_input,
-    int active_x_min_input,
-    int active_x_max_input,
-    int active_y_min_input,
-    int active_y_max_input,
-    int active_z_min_input,
-    int active_z_max_input,
-    double T_e_init,
-    int electron_temperature_output_interval_input,
-    const std::string& electron_temperature_init_file_input,
-    const std::string& electron_property_file_input,
-    double electron_source_input,
+    const TTM_Parameters& ttm_parameters,
     const Box& box);
 
   Ensemble_TTM(
     int type_input,
-    int ttm_grouping_method_input,
-    int ttm_group_input,
     int ttm_group_size,
     int ttm_group_offset,
-    double Ce_input,
-    double rho_e_input,
-    double kappa_e_input,
-    double gamma_p_input,
-    double gamma_s_input,
-    double v_0_input,
-    int nx_input,
-    int ny_input,
-    int nz_input,
-    int active_x_min_input,
-    int active_x_max_input,
-    int active_y_min_input,
-    int active_y_max_input,
-    int active_z_min_input,
-    int active_z_max_input,
-    double T_e_init,
-    int electron_temperature_output_interval_input,
-    const std::string& electron_temperature_init_file_input,
-    const std::string& electron_property_file_input,
-    double electron_source_input,
+    const TTM_Parameters& ttm_parameters,
     const Box& box);
 
   virtual ~Ensemble_TTM(void);
@@ -177,30 +178,9 @@ private:
   // methods
   void initialize_ttm_common(
     int type_input,
-    int ttm_grouping_method_input,
-    int ttm_group_input,
     int ttm_group_size,
     int ttm_group_offset,
-    double Ce_input,
-    double rho_e_input,
-    double kappa_e_input,
-    double gamma_p_input,
-    double gamma_s_input,
-    double v_0_input,
-    int nx_input,
-    int ny_input,
-    int nz_input,
-    int active_x_min_input,
-    int active_x_max_input,
-    int active_y_min_input,
-    int active_y_max_input,
-    int active_z_min_input,
-    int active_z_max_input,
-    double T_e_init,
-    int electron_temperature_output_interval_input,
-    const std::string& electron_temperature_init_file_input,
-    const std::string& electron_property_file_input,
-    double electron_source_input,
+    const TTM_Parameters& ttm_parameters,
     const Box& box);
   void initialize_ttm_random_states();
   void initialize_electron_grid(

--- a/src/integrate/ensemble_ttm.cuh
+++ b/src/integrate/ensemble_ttm.cuh
@@ -122,38 +122,34 @@ public:
 private:
   bool use_heat_lan;
 
-  // source/sink Langevin parameters (same as heat_lan)
   int N_source, N_sink, offset_source, offset_sink;
   double c1, c2_source, c2_sink;
   GPU_Vector<gpurandState> curand_states_source;
   GPU_Vector<gpurandState> curand_states_sink;
 
-  // TTM metal group
   int ttm_grouping_method;
   int ttm_group_id;
   int N_metal;
   int offset_metal;
   GPU_Vector<gpurandState> curand_states_metal;
 
-  // electron-phonon coupling parameters
-  double Ce;           // electronic specific heat
-  double rho_e;        // electronic density [1/A^3] (Ce*rho_e = volumetric heat capacity)
+  double Ce;
+  double rho_e;
   double kappa_e;      // internal conductivity [eV/(fs*K*A)]
-  double gamma_p;      // input electron-phonon friction [mass/ps]
-  double gamma_s;      // input electronic stopping friction [mass/ps]
-  double gamma_p_nat;  // internal friction coefficient [mass/natural_time]
-  double gamma_s_nat;  // internal stopping coefficient [mass/natural_time]
-  double v_0_sq;       // velocity threshold squared in internal velocity units
+  double gamma_p;
+  double gamma_s;
+  double gamma_p_nat;
+  double gamma_s_nat;
+  double v_0_sq;
   double electron_source;
   bool use_electron_properties;
 
-  // electron temperature grid
   int nx, ny, nz;
   int ngrid_total;
   int active_x_min, active_x_max;
   int active_y_min, active_y_max;
   int active_z_min, active_z_max;
-  double dx, dy, dz; // grid spacing in Angstrom
+  double dx, dy, dz;
   std::vector<double> T_electron;
   std::vector<double> T_electron_old;
   std::vector<int> electron_cell_active;
@@ -164,18 +160,15 @@ private:
   FILE* electron_temperature_file = nullptr;
   int electron_temperature_output_interval;
 
-  // GPU arrays for TTM coupling
-  GPU_Vector<double> gpu_T_electron;       // electron temperature at each grid point
+  GPU_Vector<double> gpu_T_electron;
   GPU_Vector<int> gpu_electron_cell_active;
   GPU_Vector<double> gpu_electron_gamma_p_nat;
-  GPU_Vector<double> gpu_net_energy;       // net electron-to-atom power per grid cell
-  GPU_Vector<int> gpu_atom_grid_index;     // grid cell index for each metal atom
-  GPU_Vector<double> gpu_ttm_force;        // stored Langevin force for each metal atom
+  GPU_Vector<double> gpu_net_energy;
+  GPU_Vector<int> gpu_atom_grid_index;
+  GPU_Vector<double> gpu_ttm_force;
 
-  // box dimensions (orthogonal periodic box)
   double box_length[3];
 
-  // methods
   void initialize_ttm_common(
     int type_input,
     int ttm_group_size,

--- a/src/integrate/ensemble_ttm.cuh
+++ b/src/integrate/ensemble_ttm.cuh
@@ -18,8 +18,8 @@ Two-Temperature Model (TTM) for metals, with an optional heat_lan source/sink
 channel for heat transport across metal-nonmetal heterointerfaces.
 
 References:
-[1] P.B. Crozier, R.E. Jones, et al., LAMMPS fix_ttm implementation.
-[2] G. Bussi and M. Parrinello, Phys. Rev. E 75, 056707 (2007).
+[1] D.M. Duffy and A.M. Rutherford, J. Phys.: Condens. Matter 19, 016207 (2007).
+[2] A.M. Rutherford and D.M. Duffy, J. Phys.: Condens. Matter 19, 496201 (2007).
 ------------------------------------------------------------------------------*/
 
 #pragma once
@@ -136,11 +136,11 @@ private:
   GPU_Vector<gpurandState> curand_states_metal;
 
   // electron-phonon coupling parameters
-  double Ce;           // electronic specific heat, matching LAMMPS fix_ttm input
+  double Ce;           // electronic specific heat
   double rho_e;        // electronic density [1/A^3] (Ce*rho_e = volumetric heat capacity)
   double kappa_e;      // internal conductivity [eV/(fs*K*A)]
-  double gamma_p;      // raw LAMMPS-style input [mass/ps]
-  double gamma_s;      // raw LAMMPS-style input [mass/ps]
+  double gamma_p;      // input electron-phonon friction [mass/ps]
+  double gamma_s;      // input electronic stopping friction [mass/ps]
   double gamma_p_nat;  // internal friction coefficient [mass/natural_time]
   double gamma_s_nat;  // internal stopping coefficient [mass/natural_time]
   double v_0_sq;       // velocity threshold squared in internal velocity units

--- a/src/integrate/ensemble_ttm.cuh
+++ b/src/integrate/ensemble_ttm.cuh
@@ -1,0 +1,243 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*----------------------------------------------------------------------------80
+Two-Temperature Model (TTM) for metals, with an optional heat_lan source/sink
+channel for heat transport across metal-nonmetal heterointerfaces.
+
+References:
+[1] P.B. Crozier, R.E. Jones, et al., LAMMPS fix_ttm implementation.
+[2] G. Bussi and M. Parrinello, Phys. Rev. E 75, 056707 (2007).
+------------------------------------------------------------------------------*/
+
+#pragma once
+#include "ensemble.cuh"
+#include "utilities/gpu_macro.cuh"
+#ifdef USE_HIP
+  #include <hiprand/hiprand_kernel.h>
+#else
+  #include <curand_kernel.h>
+#endif
+#include <cstdio>
+#include <string>
+#include <vector>
+
+class Ensemble_TTM : public Ensemble
+{
+public:
+  Ensemble_TTM(
+    int type_input,
+    int source_input,
+    int sink_input,
+    int source_size,
+    int sink_size,
+    int source_offset,
+    int sink_offset,
+    int ttm_grouping_method_input,
+    int ttm_group_input,
+    int ttm_group_size,
+    int ttm_group_offset,
+    double T,
+    double Tc,
+    double dT,
+    double Ce_input,
+    double rho_e_input,
+    double kappa_e_input,
+    double gamma_p_input,
+    double gamma_s_input,
+    double v_0_input,
+    int nx_input,
+    int ny_input,
+    int nz_input,
+    int active_x_min_input,
+    int active_x_max_input,
+    int active_y_min_input,
+    int active_y_max_input,
+    int active_z_min_input,
+    int active_z_max_input,
+    double T_e_init,
+    int electron_temperature_output_interval_input,
+    const std::string& electron_temperature_init_file_input,
+    const std::string& electron_property_file_input,
+    double electron_source_input,
+    const Box& box);
+
+  Ensemble_TTM(
+    int type_input,
+    int ttm_grouping_method_input,
+    int ttm_group_input,
+    int ttm_group_size,
+    int ttm_group_offset,
+    double Ce_input,
+    double rho_e_input,
+    double kappa_e_input,
+    double gamma_p_input,
+    double gamma_s_input,
+    double v_0_input,
+    int nx_input,
+    int ny_input,
+    int nz_input,
+    int active_x_min_input,
+    int active_x_max_input,
+    int active_y_min_input,
+    int active_y_max_input,
+    int active_z_min_input,
+    int active_z_max_input,
+    double T_e_init,
+    int electron_temperature_output_interval_input,
+    const std::string& electron_temperature_init_file_input,
+    const std::string& electron_property_file_input,
+    double electron_source_input,
+    const Box& box);
+
+  virtual ~Ensemble_TTM(void);
+
+  virtual void compute1(
+    const double time_step,
+    const std::vector<Group>& group,
+    Box& box,
+    Atom& atom,
+    GPU_Vector<double>& thermo);
+
+  virtual void compute2(
+    const double time_step,
+    const std::vector<Group>& group,
+    Box& box,
+    Atom& atom,
+    GPU_Vector<double>& thermo);
+
+private:
+  bool use_heat_lan;
+
+  // source/sink Langevin parameters (same as heat_lan)
+  int N_source, N_sink, offset_source, offset_sink;
+  double c1, c2_source, c2_sink;
+  GPU_Vector<gpurandState> curand_states_source;
+  GPU_Vector<gpurandState> curand_states_sink;
+
+  // TTM metal group
+  int ttm_grouping_method;
+  int ttm_group_id;
+  int N_metal;
+  int offset_metal;
+  GPU_Vector<gpurandState> curand_states_metal;
+
+  // electron-phonon coupling parameters
+  double Ce;           // electronic specific heat, matching LAMMPS fix_ttm input
+  double rho_e;        // electronic density [1/A^3] (Ce*rho_e = volumetric heat capacity)
+  double kappa_e;      // internal conductivity [eV/(fs*K*A)]
+  double gamma_p;      // raw LAMMPS-style input [mass/ps]
+  double gamma_s;      // raw LAMMPS-style input [mass/ps]
+  double gamma_p_nat;  // internal friction coefficient [mass/natural_time]
+  double gamma_s_nat;  // internal stopping coefficient [mass/natural_time]
+  double v_0_sq;       // velocity threshold squared in internal velocity units
+  double electron_source;
+  bool use_electron_properties;
+
+  // electron temperature grid
+  int nx, ny, nz;
+  int ngrid_total;
+  int active_x_min, active_x_max;
+  int active_y_min, active_y_max;
+  int active_z_min, active_z_max;
+  double dx, dy, dz; // grid spacing in Angstrom
+  std::vector<double> T_electron;
+  std::vector<double> T_electron_old;
+  std::vector<int> electron_cell_active;
+  std::vector<double> electron_heat_capacity;
+  std::vector<double> electron_thermal_conductivity;
+  std::vector<double> electron_gamma_p_nat;
+  std::vector<double> electron_eta;
+  FILE* electron_temperature_file = nullptr;
+  int electron_temperature_output_interval;
+
+  // GPU arrays for TTM coupling
+  GPU_Vector<double> gpu_T_electron;       // electron temperature at each grid point
+  GPU_Vector<int> gpu_electron_cell_active;
+  GPU_Vector<double> gpu_electron_gamma_p_nat;
+  GPU_Vector<double> gpu_net_energy;       // net electron-to-atom power per grid cell
+  GPU_Vector<int> gpu_atom_grid_index;     // grid cell index for each metal atom
+  GPU_Vector<double> gpu_ttm_force;        // stored Langevin force for each metal atom
+
+  // box dimensions (orthogonal periodic box)
+  double box_length[3];
+
+  // methods
+  void initialize_ttm_common(
+    int type_input,
+    int ttm_grouping_method_input,
+    int ttm_group_input,
+    int ttm_group_size,
+    int ttm_group_offset,
+    double Ce_input,
+    double rho_e_input,
+    double kappa_e_input,
+    double gamma_p_input,
+    double gamma_s_input,
+    double v_0_input,
+    int nx_input,
+    int ny_input,
+    int nz_input,
+    int active_x_min_input,
+    int active_x_max_input,
+    int active_y_min_input,
+    int active_y_max_input,
+    int active_z_min_input,
+    int active_z_max_input,
+    double T_e_init,
+    int electron_temperature_output_interval_input,
+    const std::string& electron_temperature_init_file_input,
+    const std::string& electron_property_file_input,
+    double electron_source_input,
+    const Box& box);
+  void initialize_ttm_random_states();
+  void initialize_electron_grid(
+    double T_e_init,
+    const std::string& electron_temperature_init_file_input,
+    const std::string& electron_property_file_input,
+    const Box& box);
+  void initialize_ttm_gpu_data();
+  void update_box_geometry(const Box& box);
+  void open_electron_temperature_file();
+  void load_initial_electron_temperatures(const std::string& filename);
+  void load_electron_properties(const std::string& filename);
+  void write_electron_temperature_snapshot(const int step);
+  void close_electron_temperature_file();
+  void initialize_active_cells();
+  void apply_active_cell_mask();
+
+  void integrate_heat_lan_half(
+    const std::vector<Group>& group,
+    const GPU_Vector<double>& mass,
+    GPU_Vector<double>& velocity_per_atom);
+
+  void apply_ttm_force_half(
+    const double half_time_step,
+    const std::vector<Group>& group,
+    const GPU_Vector<double>& mass,
+    GPU_Vector<double>& velocity_per_atom);
+
+  void update_ttm_force(
+    const double time_step,
+    const std::vector<Group>& group,
+    const GPU_Vector<double>& position_per_atom,
+    GPU_Vector<double>& velocity_per_atom);
+
+  void accumulate_ttm_power(
+    const std::vector<Group>& group,
+    GPU_Vector<double>& velocity_per_atom);
+
+  void update_electron_temperature(const double time_step);
+};

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -373,7 +373,8 @@ void Integrate::compute2(
 // 0:     NVE
 // 1-10:  NVT
 // 11-20: NPT
-// 21-30: heat and TTM related methods
+// 21-30: heat (NEMD method for heat conductivity)
+// 24-25: TTM related methods
 // 31-40: PIMD related
 void Integrate::parse_ensemble(
   const char** param,

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -38,103 +38,12 @@ The driver class for the various integrators.
 #include "ensemble_wall_harmonic.cuh"
 #include "ensemble_wall_mirror.cuh"
 #include "ensemble_wall_piston.cuh"
-#include "ensemble_ttm.cuh"
 #include "integrate.cuh"
 #include "model/atom.cuh"
 #include "utilities/common.cuh"
 #include "utilities/gpu_macro.cuh"
 #include "utilities/read_file.cuh"
 #include <cstring>
-
-static void parse_ttm_active_range(
-  const char* text,
-  const char* axis_name,
-  int upper_bound,
-  int& lower,
-  int& upper)
-{
-  if (strcmp(text, "all") == 0) {
-    lower = 1;
-    upper = upper_bound;
-    return;
-  }
-
-  int value = 0;
-  if (is_valid_int(text, &value)) {
-    lower = value;
-    upper = value;
-  } else {
-    const char* separator = strchr(text, ':');
-    if (separator == nullptr) {
-      separator = strchr(text, '-');
-    }
-    if (separator == nullptr) {
-      PRINT_INPUT_ERROR("TTM active range should be an integer, all, or min:max.");
-    }
-
-    const std::string lower_text(text, separator - text);
-    const std::string upper_text(separator + 1);
-    if (!is_valid_int(lower_text.c_str(), &lower) || !is_valid_int(upper_text.c_str(), &upper)) {
-      PRINT_INPUT_ERROR("TTM active range bounds should be integers.");
-    }
-  }
-
-  if (lower < 1 || upper < 1 || lower > upper_bound || upper > upper_bound || lower > upper) {
-    if (strcmp(axis_name, "x") == 0) {
-      PRINT_INPUT_ERROR("ttm_active_x is out of range.");
-    } else if (strcmp(axis_name, "y") == 0) {
-      PRINT_INPUT_ERROR("ttm_active_y is out of range.");
-    } else {
-      PRINT_INPUT_ERROR("ttm_active_z is out of range.");
-    }
-  }
-}
-
-static void print_ttm_settings(const Integrate& integrate)
-{
-  printf(
-    "    TTM metal group is group %d in grouping method %d.\n",
-    integrate.ttm_group,
-    integrate.ttm_grouping_method);
-  printf(
-    "    Ce = %g, rho_e = %g, kappa_e = %g.\n",
-    integrate.ttm_Ce,
-    integrate.ttm_rho_e,
-    integrate.ttm_kappa_e);
-  printf(
-    "    gamma_p = %g, gamma_s = %g, v_0 = %g.\n",
-    integrate.ttm_gamma_p,
-    integrate.ttm_gamma_s,
-    integrate.ttm_v_0);
-  printf(
-    "    electron grid: %d x %d x %d.\n", integrate.ttm_nx, integrate.ttm_ny, integrate.ttm_nz);
-  printf(
-    "    active electron cells: x %d:%d, y %d:%d, z %d:%d.\n",
-    integrate.ttm_active_x_min,
-    integrate.ttm_active_x_max,
-    integrate.ttm_active_y_min,
-    integrate.ttm_active_y_max,
-    integrate.ttm_active_z_min,
-    integrate.ttm_active_z_max);
-  if (integrate.ttm_infile.empty()) {
-    printf("    uniform initial electron temperature is %g K.\n", integrate.ttm_T_e_init);
-  } else {
-    printf("    initial electron temperature is read from %s.\n", integrate.ttm_infile.c_str());
-  }
-  if (integrate.ttm_properties_file.empty()) {
-    printf("    electron properties are spatially uniform.\n");
-  } else {
-    printf(
-      "    electron cell properties are read from %s.\n", integrate.ttm_properties_file.c_str());
-  }
-  if (integrate.ttm_source != 0.0) {
-    printf("    electron volumetric source is %g.\n", integrate.ttm_source);
-  }
-  printf(
-    "    electron temperature snapshots are written every %d step(s) to "
-    "ttm_electron_temperature.out.\n",
-    integrate.ttm_out_interval);
-}
 
 void Integrate::initialize(
   double time_step,
@@ -291,62 +200,20 @@ void Integrate::initialize(
         group[0].cpu_size[sink],
         group[0].cpu_size_sum[source],
         group[0].cpu_size_sum[sink],
-        ttm_grouping_method,
-        ttm_group,
-        group[ttm_grouping_method].cpu_size[ttm_group],
-        group[ttm_grouping_method].cpu_size_sum[ttm_group],
+        group[ttm_parameters.grouping_method].cpu_size[ttm_parameters.group_id],
+        group[ttm_parameters.grouping_method].cpu_size_sum[ttm_parameters.group_id],
         temperature,
         temperature_coupling,
         delta_temperature,
-        ttm_Ce,
-        ttm_rho_e,
-        ttm_kappa_e,
-        ttm_gamma_p,
-        ttm_gamma_s,
-        ttm_v_0,
-        ttm_nx,
-        ttm_ny,
-        ttm_nz,
-        ttm_active_x_min,
-        ttm_active_x_max,
-        ttm_active_y_min,
-        ttm_active_y_max,
-        ttm_active_z_min,
-        ttm_active_z_max,
-        ttm_T_e_init,
-        ttm_out_interval,
-        ttm_infile,
-        ttm_properties_file,
-        ttm_source,
+        ttm_parameters,
         box));
       break;
     case 25: // pure TTM
       ensemble.reset(new Ensemble_TTM(
         type,
-        ttm_grouping_method,
-        ttm_group,
-        group[ttm_grouping_method].cpu_size[ttm_group],
-        group[ttm_grouping_method].cpu_size_sum[ttm_group],
-        ttm_Ce,
-        ttm_rho_e,
-        ttm_kappa_e,
-        ttm_gamma_p,
-        ttm_gamma_s,
-        ttm_v_0,
-        ttm_nx,
-        ttm_ny,
-        ttm_nz,
-        ttm_active_x_min,
-        ttm_active_x_max,
-        ttm_active_y_min,
-        ttm_active_y_max,
-        ttm_active_z_min,
-        ttm_active_z_max,
-        ttm_T_e_init,
-        ttm_out_interval,
-        ttm_infile,
-        ttm_properties_file,
-        ttm_source,
+        group[ttm_parameters.grouping_method].cpu_size[ttm_parameters.group_id],
+        group[ttm_parameters.grouping_method].cpu_size_sum[ttm_parameters.group_id],
+        ttm_parameters,
         box));
       break;
     case 31: // RPMD
@@ -866,171 +733,8 @@ void Integrate::parse_ensemble(
     temperature2 = 0.0;
   }
 
-  // 4b. TTM-specific parameters (type 24/25)
   if (type == 24 || type == 25) {
-    ttm_out_interval = 1;
-    ttm_infile.clear();
-    ttm_properties_file.clear();
-    ttm_source = 0.0;
-    ttm_active_x_min = 1;
-    ttm_active_x_max = 0;
-    ttm_active_y_min = 1;
-    ttm_active_y_max = 0;
-    ttm_active_z_min = 1;
-    ttm_active_z_max = 0;
-    if (box.pbc_x == 0 || box.pbc_y == 0 || box.pbc_z == 0) {
-      PRINT_INPUT_ERROR("ensemble ttm/heat_ttm requires periodic boundary conditions in all directions.");
-    }
-    if (
-      box.cpu_h[1] != 0 || box.cpu_h[2] != 0 || box.cpu_h[3] != 0 || box.cpu_h[5] != 0 ||
-      box.cpu_h[6] != 0 || box.cpu_h[7] != 0) {
-      PRINT_INPUT_ERROR("ensemble ttm/heat_ttm only supports orthogonal boxes.");
-    }
-    if (group.size() < 1) {
-      PRINT_INPUT_ERROR("ensemble ttm/heat_ttm requires at least one grouping method.");
-    }
-
-    const int ttm_offset = (type == 24) ? 7 : 2;
-
-    // ttm_grouping_method
-    if (!is_valid_int(param[ttm_offset], &ttm_grouping_method)) {
-      PRINT_INPUT_ERROR("TTM grouping method should be an integer.");
-    }
-    if (ttm_grouping_method < 0 || ttm_grouping_method >= group.size()) {
-      PRINT_INPUT_ERROR("TTM grouping method out of range.");
-    }
-    // ttm_group
-    if (!is_valid_int(param[ttm_offset + 1], &ttm_group)) {
-      PRINT_INPUT_ERROR("TTM group ID should be an integer.");
-    }
-    if (ttm_group < 0 || ttm_group >= group[ttm_grouping_method].number) {
-      PRINT_INPUT_ERROR("TTM group ID out of range.");
-    }
-    if (group[ttm_grouping_method].cpu_size[ttm_group] <= 0) {
-      PRINT_INPUT_ERROR("TTM metal group cannot be empty.");
-    }
-    if (type == 24) {
-      if (group[0].cpu_size[source] <= 0) {
-        PRINT_INPUT_ERROR("Heat source group for ensemble heat_ttm cannot be empty.");
-      }
-      if (group[0].cpu_size[sink] <= 0) {
-        PRINT_INPUT_ERROR("Heat sink group for ensemble heat_ttm cannot be empty.");
-      }
-      for (int n = 0; n < atom.number_of_atoms; ++n) {
-        if (
-          group[ttm_grouping_method].cpu_label[n] == ttm_group &&
-          (group[0].cpu_label[n] == source || group[0].cpu_label[n] == sink)) {
-          PRINT_INPUT_ERROR("TTM metal group cannot overlap with the heat source or sink group.");
-        }
-      }
-    }
-    // Ce
-    if (!is_valid_real(param[ttm_offset + 2], &ttm_Ce)) {
-      PRINT_INPUT_ERROR("Ce (electronic specific heat) should be a number.");
-    }
-    if (ttm_Ce <= 0.0) {
-      PRINT_INPUT_ERROR("Ce should > 0.");
-    }
-    // rho_e
-    if (!is_valid_real(param[ttm_offset + 3], &ttm_rho_e)) {
-      PRINT_INPUT_ERROR("rho_e (electronic density) should be a number.");
-    }
-    if (ttm_rho_e <= 0.0) {
-      PRINT_INPUT_ERROR("rho_e should > 0.");
-    }
-    // kappa_e
-    if (!is_valid_real(param[ttm_offset + 4], &ttm_kappa_e)) {
-      PRINT_INPUT_ERROR("kappa_e (electronic thermal conductivity) should be a number.");
-    }
-    if (ttm_kappa_e < 0.0) {
-      PRINT_INPUT_ERROR("kappa_e should >= 0.");
-    }
-    // gamma_p
-    if (!is_valid_real(param[ttm_offset + 5], &ttm_gamma_p)) {
-      PRINT_INPUT_ERROR("gamma_p (e-ph coupling friction) should be a number.");
-    }
-    if (ttm_gamma_p <= 0.0) {
-      PRINT_INPUT_ERROR("gamma_p should > 0.");
-    }
-    // gamma_s
-    if (!is_valid_real(param[ttm_offset + 6], &ttm_gamma_s)) {
-      PRINT_INPUT_ERROR("gamma_s (stopping power friction) should be a number.");
-    }
-    if (ttm_gamma_s < 0.0) {
-      PRINT_INPUT_ERROR("gamma_s should >= 0.");
-    }
-    // v_0
-    if (!is_valid_real(param[ttm_offset + 7], &ttm_v_0)) {
-      PRINT_INPUT_ERROR("v_0 (velocity threshold) should be a number.");
-    }
-    if (ttm_v_0 < 0.0) {
-      PRINT_INPUT_ERROR("v_0 should >= 0.");
-    }
-    // nx ny nz
-    if (!is_valid_int(param[ttm_offset + 8], &ttm_nx)) {
-      PRINT_INPUT_ERROR("nx (electron grid x) should be an integer.");
-    }
-    if (!is_valid_int(param[ttm_offset + 9], &ttm_ny)) {
-      PRINT_INPUT_ERROR("ny (electron grid y) should be an integer.");
-    }
-    if (!is_valid_int(param[ttm_offset + 10], &ttm_nz)) {
-      PRINT_INPUT_ERROR("nz (electron grid z) should be an integer.");
-    }
-    if (ttm_nx <= 0 || ttm_ny <= 0 || ttm_nz <= 0) {
-      PRINT_INPUT_ERROR("Electron grid sizes must all be > 0.");
-    }
-    ttm_active_x_max = ttm_nx;
-    ttm_active_y_max = ttm_ny;
-    ttm_active_z_max = ttm_nz;
-    const long long ttm_ngrid_total = 1LL * ttm_nx * ttm_ny * ttm_nz;
-    if (ttm_ngrid_total > 2147483647LL) {
-      PRINT_INPUT_ERROR("Too many electron grid points for ensemble ttm/heat_ttm.");
-    }
-    // T_e_init
-    if (!is_valid_real(param[ttm_offset + 11], &ttm_T_e_init)) {
-      PRINT_INPUT_ERROR("T_e_init (initial electron temperature) should be a number.");
-    }
-    if (ttm_T_e_init <= 0.0) {
-      PRINT_INPUT_ERROR("T_e_init should > 0.");
-    }
-
-    int i = ttm_offset + 12;
-    while (i < num_param) {
-      if (strcmp(param[i], "ttm_out_interval") == 0) {
-        if (!is_valid_int(param[i + 1], &ttm_out_interval)) {
-          PRINT_INPUT_ERROR("ttm_out_interval should be an integer.");
-        }
-        if (ttm_out_interval <= 0) {
-          PRINT_INPUT_ERROR("ttm_out_interval should > 0.");
-        }
-      } else if (strcmp(param[i], "ttm_infile") == 0) {
-        ttm_infile = param[i + 1];
-        if (ttm_infile.empty()) {
-          PRINT_INPUT_ERROR("ttm_infile should be a valid file path.");
-        }
-      } else if (strcmp(param[i], "ttm_properties_file") == 0) {
-        ttm_properties_file = param[i + 1];
-        if (ttm_properties_file.empty()) {
-          PRINT_INPUT_ERROR("ttm_properties_file should be a valid file path.");
-        }
-      } else if (strcmp(param[i], "ttm_source") == 0) {
-        if (!is_valid_real(param[i + 1], &ttm_source)) {
-          PRINT_INPUT_ERROR("ttm_source should be a number.");
-        }
-      } else if (strcmp(param[i], "ttm_active_x") == 0) {
-        parse_ttm_active_range(
-          param[i + 1], "x", ttm_nx, ttm_active_x_min, ttm_active_x_max);
-      } else if (strcmp(param[i], "ttm_active_y") == 0) {
-        parse_ttm_active_range(
-          param[i + 1], "y", ttm_ny, ttm_active_y_min, ttm_active_y_max);
-      } else if (strcmp(param[i], "ttm_active_z") == 0) {
-        parse_ttm_active_range(
-          param[i + 1], "z", ttm_nz, ttm_active_z_min, ttm_active_z_max);
-      } else {
-        PRINT_INPUT_ERROR("Unknown ensemble ttm/heat_ttm optional keyword.");
-      }
-      i += 2;
-    }
+    parse_ttm_parameters(type, param, num_param, atom, box, group, source, sink, ttm_parameters);
   }
 
   // 5. PIMD related
@@ -1358,11 +1062,11 @@ void Integrate::parse_ensemble(
       printf("    T_cold is %g K.\n", temperature - delta_temperature);
       printf("    heat source is group %d in grouping method 0.\n", source);
       printf("    heat sink is group %d in grouping method 0.\n", sink);
-      print_ttm_settings(*this);
+      print_ttm_settings(ttm_parameters);
       break;
     case 25:
       printf("Integrate with pure Two-Temperature Model (TTM) for this run.\n");
-      print_ttm_settings(*this);
+      print_ttm_settings(ttm_parameters);
       break;
     case 31:
       printf("Use ring-polymer MD (RPMD) for this run.\n");

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -38,12 +38,103 @@ The driver class for the various integrators.
 #include "ensemble_wall_harmonic.cuh"
 #include "ensemble_wall_mirror.cuh"
 #include "ensemble_wall_piston.cuh"
+#include "ensemble_ttm.cuh"
 #include "integrate.cuh"
 #include "model/atom.cuh"
 #include "utilities/common.cuh"
 #include "utilities/gpu_macro.cuh"
 #include "utilities/read_file.cuh"
 #include <cstring>
+
+static void parse_ttm_active_range(
+  const char* text,
+  const char* axis_name,
+  int upper_bound,
+  int& lower,
+  int& upper)
+{
+  if (strcmp(text, "all") == 0) {
+    lower = 1;
+    upper = upper_bound;
+    return;
+  }
+
+  int value = 0;
+  if (is_valid_int(text, &value)) {
+    lower = value;
+    upper = value;
+  } else {
+    const char* separator = strchr(text, ':');
+    if (separator == nullptr) {
+      separator = strchr(text, '-');
+    }
+    if (separator == nullptr) {
+      PRINT_INPUT_ERROR("TTM active range should be an integer, all, or min:max.");
+    }
+
+    const std::string lower_text(text, separator - text);
+    const std::string upper_text(separator + 1);
+    if (!is_valid_int(lower_text.c_str(), &lower) || !is_valid_int(upper_text.c_str(), &upper)) {
+      PRINT_INPUT_ERROR("TTM active range bounds should be integers.");
+    }
+  }
+
+  if (lower < 1 || upper < 1 || lower > upper_bound || upper > upper_bound || lower > upper) {
+    if (strcmp(axis_name, "x") == 0) {
+      PRINT_INPUT_ERROR("ttm_active_x is out of range.");
+    } else if (strcmp(axis_name, "y") == 0) {
+      PRINT_INPUT_ERROR("ttm_active_y is out of range.");
+    } else {
+      PRINT_INPUT_ERROR("ttm_active_z is out of range.");
+    }
+  }
+}
+
+static void print_ttm_settings(const Integrate& integrate)
+{
+  printf(
+    "    TTM metal group is group %d in grouping method %d.\n",
+    integrate.ttm_group,
+    integrate.ttm_grouping_method);
+  printf(
+    "    Ce = %g, rho_e = %g, kappa_e = %g.\n",
+    integrate.ttm_Ce,
+    integrate.ttm_rho_e,
+    integrate.ttm_kappa_e);
+  printf(
+    "    gamma_p = %g, gamma_s = %g, v_0 = %g.\n",
+    integrate.ttm_gamma_p,
+    integrate.ttm_gamma_s,
+    integrate.ttm_v_0);
+  printf(
+    "    electron grid: %d x %d x %d.\n", integrate.ttm_nx, integrate.ttm_ny, integrate.ttm_nz);
+  printf(
+    "    active electron cells: x %d:%d, y %d:%d, z %d:%d.\n",
+    integrate.ttm_active_x_min,
+    integrate.ttm_active_x_max,
+    integrate.ttm_active_y_min,
+    integrate.ttm_active_y_max,
+    integrate.ttm_active_z_min,
+    integrate.ttm_active_z_max);
+  if (integrate.ttm_infile.empty()) {
+    printf("    uniform initial electron temperature is %g K.\n", integrate.ttm_T_e_init);
+  } else {
+    printf("    initial electron temperature is read from %s.\n", integrate.ttm_infile.c_str());
+  }
+  if (integrate.ttm_properties_file.empty()) {
+    printf("    electron properties are spatially uniform.\n");
+  } else {
+    printf(
+      "    electron cell properties are read from %s.\n", integrate.ttm_properties_file.c_str());
+  }
+  if (integrate.ttm_source != 0.0) {
+    printf("    electron volumetric source is %g.\n", integrate.ttm_source);
+  }
+  printf(
+    "    electron temperature snapshots are written every %d step(s) to "
+    "ttm_electron_temperature.out.\n",
+    integrate.ttm_out_interval);
+}
 
 void Integrate::initialize(
   double time_step,
@@ -190,6 +281,73 @@ void Integrate::initialize(
     case 23: // heat-BDP
       ensemble.reset(
         new Ensemble_BDP(type, source, sink, temperature, temperature_coupling, delta_temperature));
+      break;
+    case 24: // heat-TTM
+      ensemble.reset(new Ensemble_TTM(
+        type,
+        source,
+        sink,
+        group[0].cpu_size[source],
+        group[0].cpu_size[sink],
+        group[0].cpu_size_sum[source],
+        group[0].cpu_size_sum[sink],
+        ttm_grouping_method,
+        ttm_group,
+        group[ttm_grouping_method].cpu_size[ttm_group],
+        group[ttm_grouping_method].cpu_size_sum[ttm_group],
+        temperature,
+        temperature_coupling,
+        delta_temperature,
+        ttm_Ce,
+        ttm_rho_e,
+        ttm_kappa_e,
+        ttm_gamma_p,
+        ttm_gamma_s,
+        ttm_v_0,
+        ttm_nx,
+        ttm_ny,
+        ttm_nz,
+        ttm_active_x_min,
+        ttm_active_x_max,
+        ttm_active_y_min,
+        ttm_active_y_max,
+        ttm_active_z_min,
+        ttm_active_z_max,
+        ttm_T_e_init,
+        ttm_out_interval,
+        ttm_infile,
+        ttm_properties_file,
+        ttm_source,
+        box));
+      break;
+    case 25: // pure TTM
+      ensemble.reset(new Ensemble_TTM(
+        type,
+        ttm_grouping_method,
+        ttm_group,
+        group[ttm_grouping_method].cpu_size[ttm_group],
+        group[ttm_grouping_method].cpu_size_sum[ttm_group],
+        ttm_Ce,
+        ttm_rho_e,
+        ttm_kappa_e,
+        ttm_gamma_p,
+        ttm_gamma_s,
+        ttm_v_0,
+        ttm_nx,
+        ttm_ny,
+        ttm_nz,
+        ttm_active_x_min,
+        ttm_active_x_max,
+        ttm_active_y_min,
+        ttm_active_y_max,
+        ttm_active_z_min,
+        ttm_active_z_max,
+        ttm_T_e_init,
+        ttm_out_interval,
+        ttm_infile,
+        ttm_properties_file,
+        ttm_source,
+        box));
       break;
     case 31: // RPMD
       ensemble.reset(new Ensemble_PIMD(number_of_atoms, number_of_beads, false, atom));
@@ -348,7 +506,7 @@ void Integrate::compute2(
 // 0:     NVE
 // 1-10:  NVT
 // 11-20: NPT
-// 21-30: heat (NEMD method for heat conductivity)
+// 21-30: heat and TTM related methods
 // 31-40: PIMD related
 void Integrate::parse_ensemble(
   const char** param,
@@ -437,6 +595,20 @@ void Integrate::parse_ensemble(
     type = 23;
     if (num_param != 7) {
       PRINT_INPUT_ERROR("ensemble heat_bdp should have 5 parameters.");
+    }
+  } else if (strcmp(param[1], "heat_ttm") == 0) {
+    type = 24;
+    // ensemble heat_ttm ... T_e_init [ttm_out_interval N] [ttm_infile FILE]
+    if (num_param < 19 || (num_param - 19) % 2 != 0) {
+      PRINT_INPUT_ERROR(
+        "ensemble heat_ttm should have 17 required parameters plus optional key-value pairs.");
+    }
+  } else if (strcmp(param[1], "ttm") == 0) {
+    type = 25;
+    // ensemble ttm ... T_e_init [ttm_out_interval N] [ttm_infile FILE]
+    if (num_param < 14 || (num_param - 14) % 2 != 0) {
+      PRINT_INPUT_ERROR(
+        "ensemble ttm should have 12 required parameters plus optional key-value pairs.");
     }
   } else if (strcmp(param[1], "rpmd") == 0) {
     type = 31;
@@ -636,7 +808,7 @@ void Integrate::parse_ensemble(
   }
 
   // 4. heating and cooling wiht fixed temperatures
-  if (type >= 21 && type <= 30) {
+  if (type >= 21 && type <= 24) {
     // temperature
     if (!is_valid_real(param[2], &temperature)) {
       PRINT_INPUT_ERROR("Temperature should be a number.");
@@ -685,6 +857,179 @@ void Integrate::parse_ensemble(
     }
     if (sink >= group[0].number) {
       PRINT_INPUT_ERROR("Group ID for heat sink should < #groups.");
+    }
+  }
+
+  if (type == 25) {
+    temperature = 0.0;
+    temperature1 = 0.0;
+    temperature2 = 0.0;
+  }
+
+  // 4b. TTM-specific parameters (type 24/25)
+  if (type == 24 || type == 25) {
+    ttm_out_interval = 1;
+    ttm_infile.clear();
+    ttm_properties_file.clear();
+    ttm_source = 0.0;
+    ttm_active_x_min = 1;
+    ttm_active_x_max = 0;
+    ttm_active_y_min = 1;
+    ttm_active_y_max = 0;
+    ttm_active_z_min = 1;
+    ttm_active_z_max = 0;
+    if (box.pbc_x == 0 || box.pbc_y == 0 || box.pbc_z == 0) {
+      PRINT_INPUT_ERROR("ensemble ttm/heat_ttm requires periodic boundary conditions in all directions.");
+    }
+    if (
+      box.cpu_h[1] != 0 || box.cpu_h[2] != 0 || box.cpu_h[3] != 0 || box.cpu_h[5] != 0 ||
+      box.cpu_h[6] != 0 || box.cpu_h[7] != 0) {
+      PRINT_INPUT_ERROR("ensemble ttm/heat_ttm only supports orthogonal boxes.");
+    }
+    if (group.size() < 1) {
+      PRINT_INPUT_ERROR("ensemble ttm/heat_ttm requires at least one grouping method.");
+    }
+
+    const int ttm_offset = (type == 24) ? 7 : 2;
+
+    // ttm_grouping_method
+    if (!is_valid_int(param[ttm_offset], &ttm_grouping_method)) {
+      PRINT_INPUT_ERROR("TTM grouping method should be an integer.");
+    }
+    if (ttm_grouping_method < 0 || ttm_grouping_method >= group.size()) {
+      PRINT_INPUT_ERROR("TTM grouping method out of range.");
+    }
+    // ttm_group
+    if (!is_valid_int(param[ttm_offset + 1], &ttm_group)) {
+      PRINT_INPUT_ERROR("TTM group ID should be an integer.");
+    }
+    if (ttm_group < 0 || ttm_group >= group[ttm_grouping_method].number) {
+      PRINT_INPUT_ERROR("TTM group ID out of range.");
+    }
+    if (group[ttm_grouping_method].cpu_size[ttm_group] <= 0) {
+      PRINT_INPUT_ERROR("TTM metal group cannot be empty.");
+    }
+    if (type == 24) {
+      if (group[0].cpu_size[source] <= 0) {
+        PRINT_INPUT_ERROR("Heat source group for ensemble heat_ttm cannot be empty.");
+      }
+      if (group[0].cpu_size[sink] <= 0) {
+        PRINT_INPUT_ERROR("Heat sink group for ensemble heat_ttm cannot be empty.");
+      }
+      for (int n = 0; n < atom.number_of_atoms; ++n) {
+        if (
+          group[ttm_grouping_method].cpu_label[n] == ttm_group &&
+          (group[0].cpu_label[n] == source || group[0].cpu_label[n] == sink)) {
+          PRINT_INPUT_ERROR("TTM metal group cannot overlap with the heat source or sink group.");
+        }
+      }
+    }
+    // Ce
+    if (!is_valid_real(param[ttm_offset + 2], &ttm_Ce)) {
+      PRINT_INPUT_ERROR("Ce (electronic specific heat) should be a number.");
+    }
+    if (ttm_Ce <= 0.0) {
+      PRINT_INPUT_ERROR("Ce should > 0.");
+    }
+    // rho_e
+    if (!is_valid_real(param[ttm_offset + 3], &ttm_rho_e)) {
+      PRINT_INPUT_ERROR("rho_e (electronic density) should be a number.");
+    }
+    if (ttm_rho_e <= 0.0) {
+      PRINT_INPUT_ERROR("rho_e should > 0.");
+    }
+    // kappa_e
+    if (!is_valid_real(param[ttm_offset + 4], &ttm_kappa_e)) {
+      PRINT_INPUT_ERROR("kappa_e (electronic thermal conductivity) should be a number.");
+    }
+    if (ttm_kappa_e < 0.0) {
+      PRINT_INPUT_ERROR("kappa_e should >= 0.");
+    }
+    // gamma_p
+    if (!is_valid_real(param[ttm_offset + 5], &ttm_gamma_p)) {
+      PRINT_INPUT_ERROR("gamma_p (e-ph coupling friction) should be a number.");
+    }
+    if (ttm_gamma_p <= 0.0) {
+      PRINT_INPUT_ERROR("gamma_p should > 0.");
+    }
+    // gamma_s
+    if (!is_valid_real(param[ttm_offset + 6], &ttm_gamma_s)) {
+      PRINT_INPUT_ERROR("gamma_s (stopping power friction) should be a number.");
+    }
+    if (ttm_gamma_s < 0.0) {
+      PRINT_INPUT_ERROR("gamma_s should >= 0.");
+    }
+    // v_0
+    if (!is_valid_real(param[ttm_offset + 7], &ttm_v_0)) {
+      PRINT_INPUT_ERROR("v_0 (velocity threshold) should be a number.");
+    }
+    if (ttm_v_0 < 0.0) {
+      PRINT_INPUT_ERROR("v_0 should >= 0.");
+    }
+    // nx ny nz
+    if (!is_valid_int(param[ttm_offset + 8], &ttm_nx)) {
+      PRINT_INPUT_ERROR("nx (electron grid x) should be an integer.");
+    }
+    if (!is_valid_int(param[ttm_offset + 9], &ttm_ny)) {
+      PRINT_INPUT_ERROR("ny (electron grid y) should be an integer.");
+    }
+    if (!is_valid_int(param[ttm_offset + 10], &ttm_nz)) {
+      PRINT_INPUT_ERROR("nz (electron grid z) should be an integer.");
+    }
+    if (ttm_nx <= 0 || ttm_ny <= 0 || ttm_nz <= 0) {
+      PRINT_INPUT_ERROR("Electron grid sizes must all be > 0.");
+    }
+    ttm_active_x_max = ttm_nx;
+    ttm_active_y_max = ttm_ny;
+    ttm_active_z_max = ttm_nz;
+    const long long ttm_ngrid_total = 1LL * ttm_nx * ttm_ny * ttm_nz;
+    if (ttm_ngrid_total > 2147483647LL) {
+      PRINT_INPUT_ERROR("Too many electron grid points for ensemble ttm/heat_ttm.");
+    }
+    // T_e_init
+    if (!is_valid_real(param[ttm_offset + 11], &ttm_T_e_init)) {
+      PRINT_INPUT_ERROR("T_e_init (initial electron temperature) should be a number.");
+    }
+    if (ttm_T_e_init <= 0.0) {
+      PRINT_INPUT_ERROR("T_e_init should > 0.");
+    }
+
+    int i = ttm_offset + 12;
+    while (i < num_param) {
+      if (strcmp(param[i], "ttm_out_interval") == 0) {
+        if (!is_valid_int(param[i + 1], &ttm_out_interval)) {
+          PRINT_INPUT_ERROR("ttm_out_interval should be an integer.");
+        }
+        if (ttm_out_interval <= 0) {
+          PRINT_INPUT_ERROR("ttm_out_interval should > 0.");
+        }
+      } else if (strcmp(param[i], "ttm_infile") == 0) {
+        ttm_infile = param[i + 1];
+        if (ttm_infile.empty()) {
+          PRINT_INPUT_ERROR("ttm_infile should be a valid file path.");
+        }
+      } else if (strcmp(param[i], "ttm_properties_file") == 0) {
+        ttm_properties_file = param[i + 1];
+        if (ttm_properties_file.empty()) {
+          PRINT_INPUT_ERROR("ttm_properties_file should be a valid file path.");
+        }
+      } else if (strcmp(param[i], "ttm_source") == 0) {
+        if (!is_valid_real(param[i + 1], &ttm_source)) {
+          PRINT_INPUT_ERROR("ttm_source should be a number.");
+        }
+      } else if (strcmp(param[i], "ttm_active_x") == 0) {
+        parse_ttm_active_range(
+          param[i + 1], "x", ttm_nx, ttm_active_x_min, ttm_active_x_max);
+      } else if (strcmp(param[i], "ttm_active_y") == 0) {
+        parse_ttm_active_range(
+          param[i + 1], "y", ttm_ny, ttm_active_y_min, ttm_active_y_max);
+      } else if (strcmp(param[i], "ttm_active_z") == 0) {
+        parse_ttm_active_range(
+          param[i + 1], "z", ttm_nz, ttm_active_z_min, ttm_active_z_max);
+      } else {
+        PRINT_INPUT_ERROR("Unknown ensemble ttm/heat_ttm optional keyword.");
+      }
+      i += 2;
     }
   }
 
@@ -1002,6 +1347,22 @@ void Integrate::parse_ensemble(
       printf("    T_cold is %g K.\n", temperature - delta_temperature);
       printf("    heat source is group %d in grouping method 0.\n", source);
       printf("    heat sink is group %d in grouping method 0.\n", sink);
+      break;
+    case 24:
+      printf("Integrate with heating/cooling and TTM for this run.\n");
+      printf("    choose the Two-Temperature Model (TTM) + Langevin method.\n");
+      printf("    average temperature is %g K.\n", temperature);
+      printf("    tau_T is %g time_step.\n", temperature_coupling);
+      printf("    delta_T is %g K.\n", delta_temperature);
+      printf("    T_hot is %g K.\n", temperature + delta_temperature);
+      printf("    T_cold is %g K.\n", temperature - delta_temperature);
+      printf("    heat source is group %d in grouping method 0.\n", source);
+      printf("    heat sink is group %d in grouping method 0.\n", sink);
+      print_ttm_settings(*this);
+      break;
+    case 25:
+      printf("Integrate with pure Two-Temperature Model (TTM) for this run.\n");
+      print_ttm_settings(*this);
       break;
     case 31:
       printf("Use ring-polymer MD (RPMD) for this run.\n");

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -20,7 +20,6 @@
 #include "model/box.cuh"
 #include "model/group.cuh"
 #include <memory>
-#include <string>
 #include <vector>
 
 class Atom;

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -19,6 +19,7 @@
 #include "model/box.cuh"
 #include "model/group.cuh"
 #include <memory>
+#include <string>
 #include <vector>
 
 class Atom;
@@ -97,6 +98,30 @@ public:
 
   // PIMD
   int number_of_beads;
+
+  // TTM parameters
+  int ttm_grouping_method = 0;
+  int ttm_group = 0;
+  double ttm_Ce = 0.0;
+  double ttm_rho_e = 0.0;
+  double ttm_kappa_e = 0.0;
+  double ttm_gamma_p = 0.0;
+  double ttm_gamma_s = 0.0;
+  double ttm_v_0 = 0.0;
+  int ttm_nx = 0;
+  int ttm_ny = 0;
+  int ttm_nz = 0;
+  int ttm_active_x_min = 1;
+  int ttm_active_x_max = 0;
+  int ttm_active_y_min = 1;
+  int ttm_active_y_max = 0;
+  int ttm_active_z_min = 1;
+  int ttm_active_z_max = 0;
+  double ttm_T_e_init = 0.0;
+  int ttm_out_interval = 1;
+  std::string ttm_infile;
+  std::string ttm_properties_file;
+  double ttm_source = 0.0;
 
   // save some quantities for ensemble to use.
   int current_step = 0;

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "ensemble.cuh"
+#include "ensemble_ttm.cuh"
 #include "model/box.cuh"
 #include "model/group.cuh"
 #include <memory>
@@ -100,28 +101,7 @@ public:
   int number_of_beads;
 
   // TTM parameters
-  int ttm_grouping_method = 0;
-  int ttm_group = 0;
-  double ttm_Ce = 0.0;
-  double ttm_rho_e = 0.0;
-  double ttm_kappa_e = 0.0;
-  double ttm_gamma_p = 0.0;
-  double ttm_gamma_s = 0.0;
-  double ttm_v_0 = 0.0;
-  int ttm_nx = 0;
-  int ttm_ny = 0;
-  int ttm_nz = 0;
-  int ttm_active_x_min = 1;
-  int ttm_active_x_max = 0;
-  int ttm_active_y_min = 1;
-  int ttm_active_y_max = 0;
-  int ttm_active_z_min = 1;
-  int ttm_active_z_max = 0;
-  double ttm_T_e_init = 0.0;
-  int ttm_out_interval = 1;
-  std::string ttm_infile;
-  std::string ttm_properties_file;
-  double ttm_source = 0.0;
+  TTM_Parameters ttm_parameters;
 
   // save some quantities for ensemble to use.
   int current_step = 0;


### PR DESCRIPTION
**Summary**
This PR resolves issue #1427 by adding two-temperature-model (TTM) support to GPUMD for thermal-transport simulations involving metallic systems. It introduces both a pure `ensemble ttm` mode and a `ensemble heat_ttm` mode that combines source/sink Langevin regions with the electron temperature field. The implementation also includes electron temperature output and optional per-cell electron properties.

**Modification**

 - Add a new `Ensemble_TTM` integrator in:
    - `src/integrate/ensemble_ttm.cuh`
    - `src/integrate/ensemble_ttm.cu`
  - Add support for two new ensemble commands:
    - `ensemble ttm`
    - `ensemble heat_ttm`
  - Extend `Integrate` parsing and initialization in:
    - `src/integrate/integrate.cu`
    - `src/integrate/integrate.cuh`
 
**Others**
