### PR TITLE
Fix missing D_real mean correction in qNEP charge model

### DIFF
--- a/src/force/nep_charge.cu
+++ b/src/force/nep_charge.cu
@@ -620,6 +620,41 @@ static __global__ void zero_total_charge(const int N, float* g_charge)
   }
 }
 
+
+// Chain rule correction: zero_total_charge shifted q by -mean(q),
+// so D_real must be shifted by -mean(D_real) for consistent forces.
+// Uses double accumulator for numerical precision.
+static __global__ void zero_mean_D_real(const int N, float* g_D_real)
+{
+  int tid = threadIdx.x;
+  int number_of_batches = (N - 1) / 1024 + 1;
+  __shared__ double s_sum[1024];
+  double sum = 0.0;
+  for (int batch = 0; batch < number_of_batches; ++batch) {
+    int n = tid + batch * 1024;
+    if (n < N) {
+      sum += (double)g_D_real[n];
+    }
+  }
+  s_sum[tid] = sum;
+  __syncthreads();
+
+  for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+    if (tid < offset) {
+      s_sum[tid] += s_sum[tid + offset];
+    }
+    __syncthreads();
+  }
+
+  float mean_D = (float)(s_sum[0] / N);
+  for (int batch = 0; batch < number_of_batches; ++batch) {
+    int n = tid + batch * 1024;
+    if (n < N) {
+      g_D_real[n] -= mean_D;
+    }
+  }
+}
+
 static __global__ void find_bec_diagonal(const int N, const float* g_q, float* g_bec)
 {
   int n1 = threadIdx.x + blockIdx.x * blockDim.x;
@@ -1558,6 +1593,10 @@ void NEP_Charge::compute_large_box(
     GPU_CHECK_KERNEL
   }
 
+  // Chain rule correction: D_real -= mean(D_real)
+  zero_mean_D_real<<<1, 1024>>>(N, nep_data.D_real.data());
+  GPU_CHECK_KERNEL
+
   find_force_radial<<<grid_size, BLOCK_SIZE>>>(
     paramb,
     annmb,
@@ -1857,6 +1896,10 @@ void NEP_Charge::compute_small_box(
       nep_data.D_C6.data());
     GPU_CHECK_KERNEL
   }
+
+  // Chain rule correction: D_real -= mean(D_real)
+  zero_mean_D_real<<<1, 1024>>>(N, nep_data.D_real.data());
+  GPU_CHECK_KERNEL
 
   find_force_radial_small_box<<<grid_size, BLOCK_SIZE>>>(
     paramb,

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -1320,6 +1320,46 @@ static __global__ void zero_total_charge(
   }
 }
 
+
+// Per-structure mean subtraction of D_real for training.
+// Chain rule correction for zero_total_charge (see MD-side comment for derivation).
+// Launch: <<<Nc, 1024>>>
+static __global__ void zero_mean_D_real_train(
+  const int* Na,
+  const int* Na_sum,
+  float* g_D_real)
+{
+  int tid = threadIdx.x;
+  int N1 = Na_sum[blockIdx.x];
+  int N2 = N1 + Na[blockIdx.x];
+  int number_of_batches = (N2 - N1 - 1) / 1024 + 1;
+  __shared__ double s_sum[1024];
+  double sum = 0.0;
+  for (int batch = 0; batch < number_of_batches; ++batch) {
+    int n = tid + batch * 1024 + N1;
+    if (n < N2) {
+      sum += (double)g_D_real[n];
+    }
+  }
+  s_sum[tid] = sum;
+  __syncthreads();
+
+  for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+    if (tid < offset) {
+      s_sum[tid] += s_sum[tid + offset];
+    }
+    __syncthreads();
+  }
+
+  float mean_D = (float)(s_sum[0] / (N2 - N1));
+  for (int batch = 0; batch < number_of_batches; ++batch) {
+    int n = tid + batch * 1024 + N1;
+    if (n < N2) {
+      g_D_real[n] -= mean_D;
+    }
+  }
+}
+
 void NEP_Charge::find_force(
   Parameters& para,
   const float* parameters,
@@ -1620,6 +1660,13 @@ void NEP_Charge::find_force(
         nep_data[device_id].D_C6.data());
       GPU_CHECK_KERNEL
     }
+
+    // Chain rule correction: D_real -= mean(D_real) per structure
+    zero_mean_D_real_train<<<dataset[device_id].Nc, 1024>>>(
+      dataset[device_id].Na.data(),
+      dataset[device_id].Na_sum.data(),
+      nep_data[device_id].D_real.data());
+    GPU_CHECK_KERNEL
 
     find_force_radial<<<grid_size, block_size>>>(
       dataset[device_id].N,


### PR DESCRIPTION
### Problem

The `zero_total_charge` kernel enforces charge neutrality by shifting predicted charges: `q_shift = q_pred - mean(q_pred)`. However, the corresponding chain-rule correction was missing in the force backpropagation pathway.

The electrostatic derivative `D_real = dU_ES/dq_shift` is consumed by `find_force_radial` and `find_force_angular` to compute forces via:

```
F = (Fp + charge_derivative * D_real) * d(descriptor)/dr
```

Since `q_shift` depends on all `q_pred` through the mean subtraction, the correct backpropagation requires:

```
D_real_corrected[i] = D_real[i] - mean(D_real)
```

Without this, the Jacobian of the charge neutralization projection (`δ_ij - 1/N`) is ignored, producing forces that are not the exact gradient of the energy.

### Impact

- **Non-conservative forces**: `F ≠ -∇U`, violating energy conservation
- **NVE energy drift**: systematic energy accumulation over time
- **Affects all qNEP systems**: especially slab, surface, cluster — geometry where D_real is not fully cancelled 

### Fix

Two new CUDA kernels, mirroring the structure of `zero_total_charge`:

| Kernel | File | Launch | Scope |
|--------|------|--------|-------|
| `zero_mean_D_real` | `src/force/nep_charge.cu` | `<<<1, 1024>>>` | Whole system (MD) |
| `zero_mean_D_real_train` | `src/main_nep/nep_charge.cu` | `<<<Nc, 1024>>>` | Per structure (training) |

Both use `double` shared-memory accumulators for numerical precision and are inserted after D_real is fully computed (Ewald/PPPM + real-space contributions) and before any force kernel reads it.

### Test Results

PbTe 2×2×2 supercell, `charge_mode=2`, 500,000 NVE steps (1 ns):

| Configuration | σ(E_total) / eV | vs Fixed |
|---------------|-----------------|----------|
| **Fixed (Ewald)** | 0.0002 | 1.0× |
| No charge (nep4) | 0.0002 | 1.0× |
| Original (Ewald, no fix) | 0.0009 | 3.8× |
| Original (PPPM, no fix) | 0.0015 | 6.6× |

