### PR TITLE
Reorder BEC reference values to match predicted BECs during training

### DIFF
--- a/src/main_nep/structure.cu
+++ b/src/main_nep/structure.cu
@@ -598,6 +598,7 @@ static void reorder(const int num_batches, std::vector<Structure>& structures)
     structures_copy[nc].num_atom = structures[nc].num_atom;
     structures_copy[nc].weight = structures[nc].weight;
     structures_copy[nc].has_virial = structures[nc].has_virial;
+    structures_copy[nc].has_bec = structures[nc].has_bec;
     structures_copy[nc].energy = structures[nc].energy;
     structures_copy[nc].energy_weight = structures[nc].energy_weight;
     structures_copy[nc].has_temperature = structures[nc].has_temperature;
@@ -622,6 +623,7 @@ static void reorder(const int num_batches, std::vector<Structure>& structures)
     structures_copy[nc].fx.resize(structures[nc].num_atom);
     structures_copy[nc].fy.resize(structures[nc].num_atom);
     structures_copy[nc].fz.resize(structures[nc].num_atom);
+    structures_copy[nc].bec.resize(structures[nc].num_atom * 9);
     for (int na = 0; na < structures[nc].num_atom; ++na) {
       structures_copy[nc].type[na] = structures[nc].type[na];
       structures_copy[nc].x[na] = structures[nc].x[na];
@@ -630,6 +632,9 @@ static void reorder(const int num_batches, std::vector<Structure>& structures)
       structures_copy[nc].fx[na] = structures[nc].fx[na];
       structures_copy[nc].fy[na] = structures[nc].fy[na];
       structures_copy[nc].fz[na] = structures[nc].fz[na];
+      for (int d = 0; d < 9; ++d) {
+        structures_copy[nc].bec[na * 9 + d] = structures[nc].bec[na * 9 + d];
+      }
     }
   }
 
@@ -637,6 +642,7 @@ static void reorder(const int num_batches, std::vector<Structure>& structures)
     structures[nc].num_atom = structures_copy[configuration_id[nc]].num_atom;
     structures[nc].weight = structures_copy[configuration_id[nc]].weight;
     structures[nc].has_virial = structures_copy[configuration_id[nc]].has_virial;
+    structures[nc].has_bec = structures_copy[configuration_id[nc]].has_bec;
     structures[nc].energy = structures_copy[configuration_id[nc]].energy;
     structures[nc].energy_weight = structures_copy[configuration_id[nc]].energy_weight;
     structures[nc].has_temperature = structures_copy[configuration_id[nc]].has_temperature;
@@ -661,6 +667,7 @@ static void reorder(const int num_batches, std::vector<Structure>& structures)
     structures[nc].fx.resize(structures[nc].num_atom);
     structures[nc].fy.resize(structures[nc].num_atom);
     structures[nc].fz.resize(structures[nc].num_atom);
+    structures[nc].bec.resize(structures[nc].num_atom * 9);
     for (int na = 0; na < structures[nc].num_atom; ++na) {
       structures[nc].type[na] = structures_copy[configuration_id[nc]].type[na];
       structures[nc].x[na] = structures_copy[configuration_id[nc]].x[na];
@@ -669,6 +676,9 @@ static void reorder(const int num_batches, std::vector<Structure>& structures)
       structures[nc].fx[na] = structures_copy[configuration_id[nc]].fx[na];
       structures[nc].fy[na] = structures_copy[configuration_id[nc]].fy[na];
       structures[nc].fz[na] = structures_copy[configuration_id[nc]].fz[na];
+      for (int d = 0; d < 9; ++d) {
+        structures[nc].bec[na * 9 + d] = structures_copy[configuration_id[nc]].bec[na * 9 + d];
+      }
     }
   }
 }


### PR DESCRIPTION
**Summary**
Fix #1468 
Specifically, in the qNEP, the BEC-related reference values were not reordered together with the structures. As a result, during non-full-batch training, the reference BEC values could become mismatched with the predicted BEC values in `bec_train.out`. This issue could also affect the BEC-related part of the training process itself.

**Modification**
Updated the `reorder()` logic in `src/main_nep/structure.cu`
Added reordering for the BEC-related reference data so that it remains consistent with the reordered structures

**Validation**
After the fix, the BEC fitting accuracy is improved. The potential energy surface fitting accuracy shows no obvious change.

<img width="2702" height="1318" alt="image" src="https://github.com/user-attachments/assets/a8645f56-df65-464d-9a38-0cf4e0837b3d" />

<img width="2196" height="1496" alt="image" src="https://github.com/user-attachments/assets/54cb3f49-ccec-49d0-82de-6ca57b49e0e0" />
