### PR TITLE
reduce max basis_size based on tests

### DIFF
--- a/doc/nep/input_parameters/basis_size.rst
+++ b/doc/nep/input_parameters/basis_size.rst
@@ -11,7 +11,7 @@ The syntax is::
   basis_size <N_bas_R> <N_bas_A>
 
 where :attr:`<N_bas_R>` and :attr:`<N_bas_A>` set :math:`N_\mathrm{bas}^\mathrm{R}` and :math:`N_\mathrm{bas}^\mathrm{A}`, respectively.
-The parameters must satisfy :math:`0 \leq N_\mathrm{bas}^\mathrm{R} \leq 16` and :math:`0 \leq N_\mathrm{bas}^\mathrm{A} \leq 12`.
+The parameters must satisfy :math:`0 \leq N_\mathrm{bas}^\mathrm{R} \leq 8` and :math:`0 \leq N_\mathrm{bas}^\mathrm{A} \leq 8`.
 
 The default values of :math:`N_\mathrm{bas}^\mathrm{R}=6` and :math:`N_\mathrm{bas}^\mathrm{A}=6` are usually sufficient.
 

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -926,13 +926,13 @@ void Parameters::parse_basis_size(const char** param, int num_param)
   }
   if (basis_size_radial < 0) {
     PRINT_INPUT_ERROR("basis_size_radial should >= 0.");
-  } else if (basis_size_radial > 16) {
-    PRINT_INPUT_ERROR("basis_size_radial should <= 16.");
+  } else if (basis_size_radial > 8) {
+    PRINT_INPUT_ERROR("basis_size_radial should <= 8.");
   }
   if (basis_size_angular < 0) {
     PRINT_INPUT_ERROR("basis_size_angular should >= 0.");
-  } else if (basis_size_angular > 12) {
-    PRINT_INPUT_ERROR("basis_size_angular should <= 12.");
+  } else if (basis_size_angular > 8) {
+    PRINT_INPUT_ERROR("basis_size_angular should <= 8.");
   }
 }
 


### PR DESCRIPTION
`basis_size=8 8` is sufficient in any case. It is `n_max` that affects the accuracy. To get higher acccuracy, just increase `n_max`!