### PR TITLE
compute ion conductivity when compute msd

### DIFF
--- a/src/measure/msd.cu
+++ b/src/measure/msd.cu
@@ -200,6 +200,24 @@ __global__ void gpu_find_msd(
       }
     }
   }
+
+double linear_fit(const std::vector<double>& x, const std::vector<double>& y)
+{
+  const int n = x.size();
+  double sum_x = 0.0, sum_y = 0.0;
+  double sum_xy = 0.0, sum_x2 = 0.0;
+
+  for (int i = 0; i < n; ++i) {
+      sum_x  += x[i];
+      sum_y  += y[i];
+      sum_xy += x[i] * y[i];
+      sum_x2 += x[i] * x[i];
+  }
+
+  const double denom = n * sum_x2 - sum_x * sum_x;
+  const double slope = (n * sum_xy - sum_x * sum_y) / denom;
+  return slope;
+}
 } //namespace
 
 void MSD::preprocess(
@@ -417,7 +435,35 @@ void MSD::write(const char* filename)
   fclose(fid);
 }
 
+void MSD::calc_ion_conductivity(
+  const int z, 
+  const double temp, 
+  const double vol, 
+  const int n)
+{
+  double e   = 1.602176634e-19;    // Elementary charge, C
+  double kB   = 1.380649e-23;     // Boltzmann constant, J/K
+  float factor = 5e22 * n * z * z * e * e  / (vol * kB * temp);
 
+  const int start = 0.1 * num_correlation_steps_;
+  const int end   = 0.4 * num_correlation_steps_;
+  const int len   = end - start;
+  std::vector<double> t(len), mx(len), my(len), mz(len), mt(len);
+
+  for (int i = 0; i < len; ++i) {
+    int j = start + i;
+    t[i]  = j * dt_in_ps_;
+    mx[i] = msdx_out_[j];
+    my[i] = msdy_out_[j];
+    mz[i] = msdz_out_[j];
+    mt[i] = msdx_out_[j] + msdy_out_[j] + msdz_out_[j];
+  }
+
+  cx = linear_fit(t, mx) * factor; // convert from A^2/ps to cm^2/s
+  cy = linear_fit(t, my) * factor;
+  cz = linear_fit(t, mz) * factor;
+  ct = linear_fit(t, mt) * factor / 3.0;
+}
 
 void MSD::postprocess(
   Atom& atom,
@@ -432,6 +478,17 @@ void MSD::postprocess(
   write("msd.out");
   compute_ = false;
   grouping_method_ = -1;
+  
+  if (calc_ion_conductivity_) {
+    const double volume = box.get_volume();
+    calc_ion_conductivity(species_charge_, temperature, volume, num_atoms_);
+
+    printf("   Ionic conductivity of Group %d in Grouping Method %d:\n", group_id_, grouping_method_);
+    printf("   Sigma_x: %g mS/cm\n", cx);
+    printf("   Sigma_y: %g mS/cm\n", cy);
+    printf("   Sigma_z: %g mS/cm\n", cz);
+    printf("   Sigma_total: %g mS/cm\n", ct);
+  }
 }
 
 MSD::MSD(const char** param, const int num_param, const std::vector<Group>& groups, Atom& atom)
@@ -481,10 +538,18 @@ void MSD::parse(const char** param, const int num_param, const std::vector<Group
     if (strcmp(param[k], "group") == 0) {
       parse_group(param, num_param, false, groups, k, grouping_method_, group_id_);
 
+      if (strcmp(param[6], "charge") == 0) {
+        calc_ion_conductivity_ = true;
+        if (!is_valid_real(param[7], &species_charge_)) {
+          PRINT_INPUT_ERROR("species charge should be a real number.\n");
+        }
+        printf("    will compute ion conductivity for atoms in group %d with charge %g.\n", group_id_, species_charge_);
+        k += 2; // update index for next command
+      }
     } else if (strcmp(param[k], "all_groups") == 0) {
       msd_over_all_groups_ = true;
       // Compute MSD individually for all groups
-     if (!is_valid_int(param[4], &grouping_method_)) {
+     if (!is_valid_int(param[k+1], &grouping_method_)) {
         PRINT_INPUT_ERROR("Grouping method should be an integer.\n");
       }
       if (grouping_method_ < 0) {

--- a/src/measure/msd.cu
+++ b/src/measure/msd.cu
@@ -476,8 +476,6 @@ void MSD::postprocess(
   if (!compute_)
     return;
   write("msd.out");
-  compute_ = false;
-  grouping_method_ = -1;
   
   if (calc_ion_conductivity_) {
     const double volume = box.get_volume();
@@ -489,6 +487,9 @@ void MSD::postprocess(
     printf("   Sigma_z: %g mS/cm\n", cz);
     printf("   Sigma_total: %g mS/cm\n", ct);
   }
+
+  compute_ = false;
+  grouping_method_ = -1;
 }
 
 MSD::MSD(const char** param, const int num_param, const std::vector<Group>& groups, Atom& atom)

--- a/src/measure/msd.cuh
+++ b/src/measure/msd.cuh
@@ -29,6 +29,7 @@ public:
   int grouping_method_ = -1;
   int group_id_ = -1;
   bool msd_over_all_groups_ = false;
+  bool calc_ion_conductivity_ = false;
 
   virtual void preprocess(
     const int number_of_steps,
@@ -62,6 +63,11 @@ public:
     const double temperature);
 
   virtual void write(const char* filename);
+  virtual void calc_ion_conductivity(
+    const int z, 
+    const double temp, 
+    const double vol, 
+    const int n);
 
   MSD(const char** param, const int num_param, const std::vector<Group>& groups, Atom& atom);
   void parse(const char** param, const int num_param, const std::vector<Group>& groups);
@@ -79,4 +85,6 @@ private:
   GPU_Vector<double> msdx_, msdy_, msdz_;
   GPU_Vector<double> msdx_out_, msdy_out_, msdz_out_;  // holds output for writing
   GPU_Vector<int> group_per_atom_gpu_;
+  double species_charge_ = 0.0; // for computing ion conductivity
+  double cx, cy, cz, ct; // ionic conductivity in each direction
 };


### PR DESCRIPTION
First, in `model.xyz`, group atoms of the same element together; for example, in LLZO, Li atoms are grouped together.
After calculating the MSD, the ionic conductivity is determined.

Need to specify the group and charge information in `run.in`, the charge refers to the charge assigned to the element being calculated.
`compute_msd 10 5000 all_groups 0 charge 1`

The final calculation will output the conductivity of the atoms in the corresponding group: 
<img width="484" height="310" alt="image" src="https://github.com/user-attachments/assets/459c3eee-91d5-4b79-80dc-33437ca945b3" />

At the same time, the following results were obtained using a Python script, which match the results directly output by the program:
<img width="361" height="332" alt="image" src="https://github.com/user-attachments/assets/09c0fbcb-b189-43e6-b988-7d255da552cf" />

[test_LLZO_1000K.zip](https://github.com/user-attachments/files/27513673/test_LLZO_1000K.zip)
