### PR TITLE
add an option to use q for efield in qNEP

### DIFF
--- a/doc/gpumd/input_parameters/add_efield.rst
+++ b/doc/gpumd/input_parameters/add_efield.rst
@@ -15,14 +15,22 @@ For other models, the force equals to the product of the electric field and the 
 Syntax
 ------
 
-This keyword is used in one of the following two ways::
+This keyword is used in one of the following ways::
 
   add_efield <group_method> <group_id> <Ex> <Ey> <Ez> # usage 1
   add_efield <group_method> <group_id> <add_efield_file> # usage 2
+  add_efield <group_method> <group_id> <Ex> <Ey> <Ez> <mode> # usage 3
+  add_efield <group_method> <group_id> <add_efield_file> <mode> # usage 4
 
 * Electric field is applied to atoms in group :attr:`group_id` of group method :attr:`group_method`.
-* In the first usage, the constant electric field with components :attr:`Ex`, :attr:`Ey`, and :attr:`Ez` is applied to each selected atom.
-* In the second usage, a series of electric fields specified in the file :attr:`add_efield_file` will be periodically applied to each selected atom.
+* In usage 1, the constant electric field with components :attr:`Ex`, :attr:`Ey`, and :attr:`Ez` is applied to each selected atom.
+* In usage 2, a series of electric fields specified in the file :attr:`add_efield_file` will be periodically applied to each selected atom.
+* In usages 1 and 2, if the potential model is qNEP, the added electric force equals to the dot product of the electric field and the :term:`BEC`; otherwise it equals to the product of the electric field and the charge of the atom as specified in :attr:`model.xyz` via :attr:`charge:R:1`.
+* In usages 3 and 4, :attr:`mode` can be charge or bec.
+  * When :attr:`mode` is charge, the electric force will be calculated via 
+    * the qNEP predicted charges for qNEP potential models
+    * the user-specified charges for other potential models
+  * When :attr:`mode` is bec, the potential model must be qNEP, and the :term:`BEC` will be used to calculate the electric force.
 * Electric field is in units of V/Å.
 
 Example 1

--- a/src/main_gpumd/add_efield.cu
+++ b/src/main_gpumd/add_efield.cu
@@ -93,7 +93,8 @@ void Add_Efield::compute(const int step, const std::vector<Group>& groups, Atom&
     const int num_atoms_total = atom.force_per_atom.size() / 3;
     const int group_size = groups[grouping_method_[call]].cpu_size[group_id_[call]];
     const int group_size_sum = groups[grouping_method_[call]].cpu_size_sum[group_id_[call]];
-    if (is_nep_charge) {
+
+    if (use_bec_[call]) {
       GPU_Vector<float>& bec = force.potentials[0]->get_bec_reference();
       add_efield_bec<<<(group_size - 1) / 64 + 1, 64>>>(
         num_atoms_total,
@@ -107,8 +108,20 @@ void Add_Efield::compute(const int step, const std::vector<Group>& groups, Atom&
         atom.force_per_atom.data(),
         atom.force_per_atom.data() + num_atoms_total,
         atom.force_per_atom.data() + num_atoms_total * 2);
-    }
-    else {
+    } else if (is_nep_charge) {
+      GPU_Vector<float>& nep_charge = force.potentials[0]->get_charge_reference();
+      add_efield<<<(group_size - 1) / 64 + 1, 64>>>(
+        group_size,
+        group_size_sum,
+        groups[grouping_method_[call]].contents.data(),
+        Ex,
+        Ey,
+        Ez,
+        nep_charge.data(),
+        atom.force_per_atom.data(),
+        atom.force_per_atom.data() + num_atoms_total,
+        atom.force_per_atom.data() + num_atoms_total * 2);
+    } else {
       add_efield<<<(group_size - 1) / 64 + 1, 64>>>(
         group_size,
         group_size_sum,
@@ -129,9 +142,41 @@ void Add_Efield::parse(const char** param, int num_param, const std::vector<Grou
 {
   printf("Add electric field.\n");
 
-  // check the number of parameters
-  if (num_param != 6 && num_param != 4) {
-    PRINT_INPUT_ERROR("add_efield should have 5 or 3 parameters.\n");
+  std::string mode_str;
+  bool use_file_input = false;
+
+  is_nep_charge = check_is_nep_charge();
+
+  if (num_param == 7) {
+    mode_str = param[6];
+    use_file_input = false;
+  } else if (num_param == 5) {
+    mode_str = param[4];
+    use_file_input = true;
+  } else if (num_param == 6) {
+    use_file_input = false;
+  } else if (num_param == 4) {
+    use_file_input = true;
+  } else {
+    PRINT_INPUT_ERROR("add_efield should have 3, 4, 5 or 6 parameters.\n");
+  }
+
+  if (mode_str != "charge" && mode_str != "bec") {
+    PRINT_INPUT_ERROR("Mode can only be charge or bec.\n");
+  }
+
+  if (is_nep_charge) {
+    if (mode_str == "bec") {
+      use_bec_[num_calls_] = true;
+    } else {
+      use_bec_[num_calls_] = false;
+    }
+  } else {
+    if (mode_str == "bec") {
+      PRINT_INPUT_ERROR("Cannot use bec for non-qNEP models.\n");
+    } else {
+      use_bec_[num_calls_] = false;
+    }
   }
 
   // parse grouping method
@@ -161,7 +206,7 @@ void Add_Efield::parse(const char** param, int num_param, const std::vector<Grou
     group_id_[num_calls_],
     grouping_method_[num_calls_]);
 
-  if (num_param == 6) {
+  if (!use_file_input) {
     table_length_[num_calls_] = 1;
     efield_table_[num_calls_].resize(table_length_[num_calls_] * 3);
     if (!is_valid_real(param[3], &efield_table_[num_calls_][0])) {
@@ -211,13 +256,6 @@ void Add_Efield::parse(const char** param, int num_param, const std::vector<Grou
 
   if (num_calls_ > 10) {
     PRINT_INPUT_ERROR("add_efield cannot be used more than 10 times in one run.");
-  }
-
-  is_nep_charge = check_is_nep_charge();
-  if (is_nep_charge) {
-    printf("    using the charge values predicted by the NEP-Charge model.\n");
-  } else {
-    printf("    using the charge values specified in model.xyz.\n");
   }
 
 }

--- a/src/main_gpumd/add_efield.cu
+++ b/src/main_gpumd/add_efield.cu
@@ -142,10 +142,9 @@ void Add_Efield::parse(const char** param, int num_param, const std::vector<Grou
 {
   printf("Add electric field.\n");
 
-  std::string mode_str = "bec";
   bool use_file_input = false;
-
   is_nep_charge = check_is_nep_charge();
+  std::string mode_str = is_nep_charge ? "bec" : "charge";
 
   if (num_param == 7) {
     mode_str = param[6];

--- a/src/main_gpumd/add_efield.cu
+++ b/src/main_gpumd/add_efield.cu
@@ -168,12 +168,15 @@ void Add_Efield::parse(const char** param, int num_param, const std::vector<Grou
   if (is_nep_charge) {
     if (mode_str == "bec") {
       use_bec_[num_calls_] = true;
+      printf("    using the BEC values predicted by the NEP-Charge model.\n");
     } else {
       use_bec_[num_calls_] = false;
+      printf("    using the charge values predicted by the NEP-Charge model.\n");
     }
   } else {
     if (mode_str == "bec") {
       PRINT_INPUT_ERROR("Cannot use bec for non-qNEP models.\n");
+      printf("    using the charge values specified in model.xyz.\n");
     } else {
       use_bec_[num_calls_] = false;
     }

--- a/src/main_gpumd/add_efield.cu
+++ b/src/main_gpumd/add_efield.cu
@@ -142,7 +142,7 @@ void Add_Efield::parse(const char** param, int num_param, const std::vector<Grou
 {
   printf("Add electric field.\n");
 
-  std::string mode_str;
+  std::string mode_str = "bec";
   bool use_file_input = false;
 
   is_nep_charge = check_is_nep_charge();

--- a/src/main_gpumd/add_efield.cuh
+++ b/src/main_gpumd/add_efield.cuh
@@ -35,4 +35,5 @@ private:
   int grouping_method_[10];
   int group_id_[10];
   bool is_nep_charge = false;
+  bool use_bec_[10];
 };


### PR DESCRIPTION
To solve issue #1433 

Extend the `add_efield` method:
Original two usages:
```
add_efield <group_method> <group_id> <Ex> <Ey> <Ez> # usage 1
add_efield <group_method> <group_id> <add_efield_file> # usage 2
```
Extra two usages:
```
add_efield <group_method> <group_id> <Ex> <Ey> <Ez> <mode> # usage 3
add_efield <group_method> <group_id> <add_efield_file> <mode> # usage 4
```

`mode` can be 
* `charge`
  * use qNEP predicted charges for qNEP
  * use user-specified charges for other models
*  `bec` (only valid for qNEP).