### PR TITLE
Update FIRE minimizer box constraint handling

### DIFF
--- a/src/minimize/minimize.cu
+++ b/src/minimize/minimize.cu
@@ -67,8 +67,8 @@ void Minimize::parse_minimize(
   } else if (strcmp(param[1], "fire") == 0) {
     minimizer_type = 1;
 
-    if (!((num_param >= 4) && (num_param <= 6))) {
-      PRINT_INPUT_ERROR("minimize fire should have 2 to 4 parameters.");
+    if (!((num_param >= 4) && (num_param <= 7))) {
+      PRINT_INPUT_ERROR("minimize fire should have 2 to 5 parameters.");
     }
 
     if (!is_valid_real(param[2], &force_tolerance)) {
@@ -103,6 +103,16 @@ void Minimize::parse_minimize(
         PRINT_INPUT_ERROR("Hydrostatic_strain should be 1 or 0.");
       }
     }
+
+    if (num_param >= 7) {
+      int freeze_diagonal_input = 0;
+      if (!is_valid_int(param[6], &freeze_diagonal_input)) {
+        PRINT_INPUT_ERROR("Freeze_diagonal should be an integer.");
+      }
+      if (!(freeze_diagonal_input >= 0 && freeze_diagonal_input <= 3)) {
+        PRINT_INPUT_ERROR("Freeze_diagonal should be 0, 1, 2, or 3.");
+      }
+    }
   } else {
     PRINT_INPUT_ERROR("Invalid minimizer.");
   }
@@ -133,22 +143,34 @@ void Minimize::parse_minimize(
       minimizer->compute(force, box, atom, atom.position_per_atom, group);
 
       break;
-    case 2:
+    case 2: {
+      int freeze_diagonal_input = 0;
+      if (num_param >= 7) {
+        freeze_diagonal_input = atoi(param[6]);
+      }
+      // convert: 0=none(-1), 1=xx(0), 2=yy(1), 3=zz(2)
+      int freeze_diagonal = freeze_diagonal_input - 1;
+
       printf("\nStart to do an energy minimization.\n");
       printf("    using the fast inertial relaxation engine (FIRE) method.\n");
       printf("    with variable box.\n");
       if (hydrostatic_strain == 1) {
         printf("    with hydrostatic pressure.\n");
       }
+      if (freeze_diagonal >= 0) {
+        const char* names[] = {"xx", "yy", "zz"};
+        printf("    with frozen diagonal %s.\n", names[freeze_diagonal]);
+      }
       printf("    with a force tolerance of %g eV/A.\n", force_tolerance);
       printf("    for maximally %d steps.\n", number_of_steps);
 
       minimizer.reset(new Minimizer_FIRE_Box_Change(
-        atom.number_of_atoms, number_of_steps, force_tolerance, hydrostatic_strain));
+        atom.number_of_atoms, number_of_steps, force_tolerance, hydrostatic_strain, freeze_diagonal));
 
       minimizer->compute(force, box, atom, atom.position_per_atom, group);
 
       break;
+    }
     default:
       PRINT_INPUT_ERROR("Invalid minimizer.");
       break;

--- a/src/minimize/minimizer_fire_box_change.cu
+++ b/src/minimize/minimizer_fire_box_change.cu
@@ -256,6 +256,14 @@ void Minimizer_FIRE_Box_Change::compute(
   double L_scale = std::cbrt(box.get_volume());
   const double stress_tolerance_GPa = 1e-4;
 
+  // freeze_diagonal: -1=none, 0=xx, 1=yy, 2=zz
+  int frozen_idx = -1;
+  double saved_h = 0.0;
+  if (freeze_diagonal >= 0) {
+    frozen_idx = (freeze_diagonal == 0) ? 0 : (freeze_diagonal == 1) ? 4 : 8;
+    saved_h = box.cpu_h[frozen_idx];
+  }
+
   printf("\nEnergy minimization with changed box started.\n");
 
   for (int step = 0; step < number_of_steps_; ++step) {
@@ -280,6 +288,11 @@ void Minimizer_FIRE_Box_Change::compute(
     double virial_cpu[9];
     virialtot.copy_to_host(virial_cpu);
 
+    // freeze: zero the virial driving force for the frozen diagonal
+    if (freeze_diagonal >= 0) {
+      virial_cpu[frozen_idx] = 0.0;
+    }
+
     double current_volume = box.get_volume();
     double stress_GPa[9];
     double max_stress_component = 0.0;
@@ -300,6 +313,9 @@ void Minimizer_FIRE_Box_Change::compute(
       virial_cpu[8] = trace_virial / 3.0;
     } else {
       for (int i = 0; i < 9; i++) {
+        // skip frozen diagonal in max stress check
+        if (freeze_diagonal >= 0 && i == frozen_idx)
+          continue;
         max_stress_component = std::max(max_stress_component, std::abs(stress_GPa[i]));
       }
     }
@@ -374,6 +390,12 @@ void Minimizer_FIRE_Box_Change::compute(
     }
     vector_sum(temp1, temp2, v);
 
+    // freeze: zero the box velocity for the frozen diagonal on device
+    if (freeze_diagonal >= 0) {
+      double zero = 0.0;
+      gpuMemcpy(v.data() + size + frozen_idx, &zero, sizeof(double), gpuMemcpyHostToDevice);
+    }
+
     double v_box_cpu[9];
     gpuMemcpy(v_box_cpu, v.data() + size, 9 * sizeof(double), gpuMemcpyDeviceToHost);
 
@@ -387,6 +409,12 @@ void Minimizer_FIRE_Box_Change::compute(
     matrix_multiply(dEps, box.cpu_h, dH);
     for (int i = 0; i < 9; i++)
       box.cpu_h[i] += dH[i];
+
+    // freeze: restore the frozen diagonal to its original value
+    if (freeze_diagonal >= 0) {
+      box.cpu_h[frozen_idx] = saved_h;
+    }
+
     box.get_inverse();
 
     // 2. dr = v*dt + dEps*r

--- a/src/minimize/minimizer_fire_box_change.cuh
+++ b/src/minimize/minimizer_fire_box_change.cuh
@@ -35,22 +35,19 @@ private:
   int N_pos = 0;
   double P;
   int hydrostatic_strain = 0;
+  int freeze_diagonal = -1;  // -1: no freeze, 0: xx, 1: yy, 2: zz
 
 public:
-  Minimizer_FIRE_Box_Change(
-    const int number_of_atoms, const int number_of_steps, const double force_tolerance)
-    : Minimizer(-1, 0, number_of_atoms, number_of_steps, force_tolerance)
-  {
-  }
-
   Minimizer_FIRE_Box_Change(
     const int number_of_atoms,
     const int number_of_steps,
     const double force_tolerance,
-    const int _hydrostatic_strain)
+    const int _hydrostatic_strain = 0,
+    const int _freeze_diagonal = -1)
     : Minimizer(-1, 0, number_of_atoms, number_of_steps, force_tolerance)
   {
     hydrostatic_strain = _hydrostatic_strain;
+    freeze_diagonal = _freeze_diagonal;
   }
 
   void compute(


### PR DESCRIPTION
**Summary**

Adds a `freeze_diagonal` parameter to the `minimize fire` command with box relaxation, allowing the user to keep one diagonal component of the box (xx, yy, or zz) fixed during minimization. This mimics LAMMPS' `fix box/relax` with a frozen coupled coefficient.

**Modification**
1. "src/minimize/minimizer_fire_box_change.cuh"
   - Merged two constructors into one with default parameters
   - Added `int freeze_diagonal` member (default -1 = no freeze)

2. "src/minimize/minimizer_fire_box_change.cu"
   - 5 freeze logic insertion points in `compute()`:
     1. Zero the virial component for the frozen diagonal 
     2. Exclude frozen diagonal from `max_stress_component` convergence check
     3. Zero the box velocity degree of freedom on GPU for frozen diagonal
     4. Restore frozen diagonal to original value after box update
   - Behavior unchanged when `freeze_diagonal < 0`

3. "src/minimize/minimize.cu"
   - Increased parameter count upper bound from 6 to 7
   - Added parsing for 7th parameter (valid: 0/1/2/3 for none/xx/yy/zz)
   - User-facing values 1/2/3 map internally to diagonal indices 0/4/8
   - Added print message for frozen diagonal case
 
**usage**
minimize fire <force_tolerance> <max_steps> <box_change> <hydrostatic_strain> <freeze_diagonal>
