### PR TITLE
Use the `compute_ic` command to calculate ionic conductivity

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -56,6 +56,9 @@ Glossary
    HNEMDEC
         :ref:`homogeneous non-equilibrium molecular dynamics Evans-Cummings algorithm <hnemdec>`
 
+   IC
+        iron conductivity
+
    ILP
         interlayer potential for van der Waals materials [Ouyang2018]_ [Ouyang2020]_
 

--- a/doc/gpumd/input_parameters/compute_ic.rst
+++ b/doc/gpumd/input_parameters/compute_ic.rst
@@ -1,0 +1,39 @@
+.. _kw_compute_ic:
+.. index::
+   single: compute_ic (keyword in run.in)
+
+:attr:`compute_ic`
+===================
+
+This keyword computes the iron conductivity (:term:`IC`) from the mean-square displacement (:term:`MSD`) function.
+If this keyword appears in a run, the :term:`IC` function will be calculated as a time derivative of it.
+The results will be written to :ref:`ic.out output file <ic_out>`.
+
+Syntax
+------
+For this keyword, the command looks like::
+  
+  compute_ic <sample_interval> <Nc> <type_iex> <charge>
+
+with parameters defined as
+
+* :attr:`sample_interval`: Sampling interval of the position data
+* :attr:`Nc`: Maximum number of correlation steps
+* :attr:`type_iex`: Type index of the atom to compute. The index using the NEP potential
+* :attr:`charge`: Charge of the ion to compute the conductivity.
+
+
+Examples
+--------
+
+An example of this function is::
+
+  compute_ic 5 200 0 1
+
+This means that you
+
+* want to calculate the iron conductivity from the mean-square displacement function
+* the position data will be recorded every 5 steps
+* the maximum number of correlation steps is 200
+* you would like to compute only for the atom with type 0 in nep.txt and charge 1.
+

--- a/doc/gpumd/input_parameters/compute_ic.rst
+++ b/doc/gpumd/input_parameters/compute_ic.rst
@@ -19,7 +19,7 @@ with parameters defined as
 
 * :attr:`sample_interval`: Sampling interval of the position data
 * :attr:`Nc`: Maximum number of correlation steps
-* :attr:`type_iex`: Type index of the atom to compute. The index using the NEP potential
+* :attr:`type_iex`: Type index of atom to be calculated which in potential
 * :attr:`charge`: Charge of the ion to compute the conductivity.
 
 

--- a/doc/gpumd/input_parameters/index.rst
+++ b/doc/gpumd/input_parameters/index.rst
@@ -63,6 +63,7 @@ Below you can find a listing of keywords for the ``run.in`` input file.
    compute_hnema
    compute_hnemd
    compute_hnemdec
+   compute_ic
    compute_orientorder
    compute_phonon
    compute_sdc

--- a/doc/gpumd/output_files/ic_out.rst
+++ b/doc/gpumd/output_files/ic_out.rst
@@ -1,0 +1,20 @@
+.. _ic_out:
+.. index::
+   single: ic.out (output file)
+
+``ic.out``
+===========
+
+This file contains the iron conductivity (:term:`IC`) based on mean-square displacement (:term:`MSD`).
+It is generated when invoking the :ref:`compute_msd keyword <kw_compute_ic>`.
+
+File format
+-----------
+The data in this file are organized as follows:
+
+* column 1: correlation time (in units of ps)
+* column 2: IC (in units of mS/cm) in the :math:`x` direction
+* column 3: IC (in units of mS/cm) in the :math:`y` direction
+* column 4: IC (in units of mS/cm) in the :math:`z` direction
+
+Only the element selected which in potential via the arguments of the :ref:`compute_msd_keyword <kw_compute_msd>` is included in this output.

--- a/doc/gpumd/output_files/index.rst
+++ b/doc/gpumd/output_files/index.rst
@@ -105,6 +105,10 @@ Output files
      - :ref:`compute_msd <kw_compute_msd>`
      - Mean-square displacement (:term:`MSD`) data
      - Append
+   * - :ref:`ic.out <ic_out>`
+     - :ref:`compute_ic <kw_compute_ic>`
+     - Iron conductivity (:term:`IC`) data
+     - Append
    * - :ref:`cohesive.out <cohesive_out>`
      - :ref:`compute_cohesive <kw_compute_cohesive>`
      - Cohesive energy curve

--- a/doc/gpumd/output_files/shc_out.rst
+++ b/doc/gpumd/output_files/shc_out.rst
@@ -33,4 +33,4 @@ In the next :attr:`num_omega` rows:
 
 Only the potential part of the heat current has been included.
 
-If :attr: 'group_id' is -1, then the file follows the above rules and will contain :math:`K(t)` and :math:`J_q(\omega)` for each group id except for group id 0. And the contents of the :attr: 'group_id' are arranged from smallest to largest.
+If :attr:`group_id` is -1, then the file follows the above rules and will contain :math:`K(t)` and :math:`J_q(\omega)` for each group id except for group id 0. And the contents of the :attr: 'group_id' are arranged from smallest to largest.

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -55,6 +55,7 @@ Run simulation according to the inputs in the run.in file.
 #include "measure/lsqt.cuh"
 #include "measure/measure.cuh"
 #include "measure/modal_analysis.cuh"
+#include "measure/iron_conductivity.cuh"
 #include "measure/msd.cuh"
 #include "measure/orientorder.cuh"
 #include "measure/plumed.cuh"
@@ -475,6 +476,10 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
   } else if (strcmp(param[0], "compute_msd") == 0) {
     std::unique_ptr<Property> property;
     property.reset(new MSD(param, num_param, group, atom));
+    measure.properties.emplace_back(std::move(property));
+  } else if (strcmp(param[0], "compute_ic") == 0) {
+    std::unique_ptr<Property> property;
+    property.reset(new IC(param, num_param, atom));
     measure.properties.emplace_back(std::move(property));
   } else if (strcmp(param[0], "compute_rdf") == 0) {
     std::unique_ptr<Property> property;

--- a/src/measure/iron_conductivity.cu
+++ b/src/measure/iron_conductivity.cu
@@ -1,0 +1,313 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*-----------------------------------------------------------------------------------------------100
+Calculate:
+    Ionic conductivity using the Einstein relation, based on the mean squared displacement.
+--------------------------------------------------------------------------------------------------*/
+
+#include "model/group.cuh"
+#include "iron_conductivity.cuh"
+#include "parse_utilities.cuh"
+#include "utilities/common.cuh"
+#include "utilities/error.cuh"
+#include "utilities/gpu_macro.cuh"
+#include "utilities/read_file.cuh"
+#include <cstring>
+
+namespace
+{
+__global__ void gpu_copy_position(
+  const int num_atoms,
+  const int* g_atom_list,
+  const double* g_x_i,
+  const double* g_y_i,
+  const double* g_z_i,
+  double* g_x_o,
+  double* g_y_o,
+  double* g_z_o)
+{
+  const int n = threadIdx.x + blockIdx.x * blockDim.x;
+  if (n < num_atoms) {
+    const int m = g_atom_list[n];
+    g_x_o[n] = g_x_i[m];
+    g_y_o[n] = g_y_i[m];
+    g_z_o[n] = g_z_i[m];
+  }
+}
+
+__global__ void gpu_find_msd(
+  const int num_atoms,
+  const int correlation_step,
+  const double* g_x,
+  const double* g_y,
+  const double* g_z,
+  const double* g_x_all,
+  const double* g_y_all,
+  const double* g_z_all,
+  double* g_msd_x,
+  double* g_msd_y,
+  double* g_msd_z)
+{
+  int tid = threadIdx.x;
+  int bid = blockIdx.x;
+  int size_sum = bid * num_atoms;
+  int number_of_rounds = (num_atoms - 1) / 128 + 1;
+  __shared__ double s_msd_x[128];
+  __shared__ double s_msd_y[128];
+  __shared__ double s_msd_z[128];
+  double msd_x = 0.0;
+  double msd_y = 0.0;
+  double msd_z = 0.0;
+
+  for (int round = 0; round < number_of_rounds; ++round) {
+    int n = tid + round * 128;
+    if (n < num_atoms) {
+      double tmp = g_x[n] - g_x_all[size_sum + n];
+      msd_x += tmp * tmp;
+      tmp = g_y[n] - g_y_all[size_sum + n];
+      msd_y += tmp * tmp;
+      tmp = g_z[n] - g_z_all[size_sum + n];
+      msd_z += tmp * tmp;
+    }
+  }
+  s_msd_x[tid] = msd_x;
+  s_msd_y[tid] = msd_y;
+  s_msd_z[tid] = msd_z;
+  __syncthreads();
+
+  for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+    if (tid < offset) {
+      s_msd_x[tid] += s_msd_x[tid + offset];
+      s_msd_y[tid] += s_msd_y[tid + offset];
+      s_msd_z[tid] += s_msd_z[tid + offset];
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    if (bid <= correlation_step) {
+      g_msd_x[correlation_step - bid] += s_msd_x[0];
+      g_msd_y[correlation_step - bid] += s_msd_y[0];
+      g_msd_z[correlation_step - bid] += s_msd_z[0];
+    } else {
+      g_msd_x[correlation_step + gridDim.x - bid] += s_msd_x[0];
+      g_msd_y[correlation_step + gridDim.x - bid] += s_msd_y[0];
+      g_msd_z[correlation_step + gridDim.x - bid] += s_msd_z[0];
+    }
+  }
+}
+} //namespace
+
+void IC::preprocess(
+  const int number_of_steps,
+  const double time_step,
+  Integrate& integrate,
+  std::vector<Group>& groups, 
+  Atom& atom,
+  Box& box,
+  Force& force)
+{
+  if (!compute_)
+    return;
+  
+  if (num_correlation_steps_ > number_of_steps / sample_interval_) {
+    PRINT_INPUT_ERROR("Correlation times sampling interval should be <= number of MD steps.\n");
+  }
+    
+  std::vector<int> temp_list;
+  temp_list.reserve(atom.number_of_atoms);
+  
+  for (int i = 0; i < atom.number_of_atoms; ++i) {
+    if (atom.cpu_type[i] == target_type_) {
+      temp_list.push_back(i);
+    }
+  }
+  
+  num_atoms_ = temp_list.size();
+  if (num_atoms_ == 0) {
+    PRINT_INPUT_ERROR("No atoms found for the specified type.\n");
+  }
+  
+  type_atom_list_.resize(num_atoms_);
+  type_atom_list_.copy_from_host(temp_list.data());
+  
+  dt_in_natural_units_ = time_step * sample_interval_;
+  dt_in_ps_ = dt_in_natural_units_ * TIME_UNIT_CONVERSION / 1000.0;
+  x_.resize(num_atoms_ * num_correlation_steps_);
+  y_.resize(num_atoms_ * num_correlation_steps_);
+  z_.resize(num_atoms_ * num_correlation_steps_);
+  msdx_.resize(num_correlation_steps_, 0.0, Memory_Type::managed);
+  msdy_.resize(num_correlation_steps_, 0.0, Memory_Type::managed);
+  msdz_.resize(num_correlation_steps_, 0.0, Memory_Type::managed);
+
+  volume_ = box.get_volume();
+  num_time_origins_ = 0;
+}
+
+void IC::process(
+  const int number_of_steps,
+  int step,
+  const int fixed_group,
+  const int move_group,
+  const double global_time,
+  const double temperature,
+  Integrate& integrate,
+  Box& box,
+  std::vector<Group>& groups, 
+  GPU_Vector<double>& thermo,
+  Atom& atom,
+  Force& force)
+{
+  if (!compute_)
+    return;
+  temperature_ = temperature;
+  if ((step + 1) % sample_interval_ != 0)
+    return;
+
+  const int sample_step = step / sample_interval_;
+  const int correlation_step = sample_step % num_correlation_steps_;
+  const int step_offset = correlation_step * num_atoms_;
+  const int number_of_atoms_total = atom.number_of_atoms;
+
+  gpu_copy_position<<<(num_atoms_ - 1) / 128 + 1, 128>>>(
+    num_atoms_,
+    type_atom_list_.data(), 
+    atom.unwrapped_position.data(),
+    atom.unwrapped_position.data() + number_of_atoms_total,
+    atom.unwrapped_position.data() + 2 * number_of_atoms_total,
+    x_.data() + step_offset,
+    y_.data() + step_offset,
+    z_.data() + step_offset);
+  GPU_CHECK_KERNEL
+
+  if (sample_step >= num_correlation_steps_ - 1) {
+    ++num_time_origins_;
+
+    gpu_find_msd<<<num_correlation_steps_, 128>>>(
+      num_atoms_,
+      correlation_step,
+      x_.data() + step_offset,
+      y_.data() + step_offset,
+      z_.data() + step_offset,
+      x_.data(),
+      y_.data(),
+      z_.data(),
+      msdx_.data(),
+      msdy_.data(),
+      msdz_.data());
+    GPU_CHECK_KERNEL
+  }
+}
+
+void IC::write(const char* filename)
+{
+  CHECK(gpuDeviceSynchronize());
+  
+  std::vector<double> ic_x(num_correlation_steps_, 0.0);
+  std::vector<double> ic_y(num_correlation_steps_, 0.0);
+  std::vector<double> ic_z(num_correlation_steps_, 0.0);
+
+  double factor = 0.0;
+  if (num_time_origins_ > 0) {
+    factor = charge_ * charge_ * 1.602176634e7 * 0.5 / 
+            (TIME_UNIT_CONVERSION * volume_ * K_B * temperature_ * num_time_origins_ * dt_in_natural_units_);
+  }
+
+  for (int nc = 1; nc < num_correlation_steps_; nc++) {
+    ic_x[nc] = (msdx_[nc] - msdx_[nc - 1]) * factor;
+    ic_y[nc] = (msdy_[nc] - msdy_[nc - 1]) * factor;
+    ic_z[nc] = (msdz_[nc] - msdz_[nc - 1]) * factor;
+  }
+
+  FILE* fid = fopen(filename, "a");
+  for (int nc = 0; nc < num_correlation_steps_; nc++) {
+    fprintf(fid, "%g %g %g %g\n",
+      nc * dt_in_ps_,
+      ic_x[nc],
+      ic_y[nc],
+      ic_z[nc]);
+  }
+  fflush(fid);
+  fclose(fid);
+}
+
+void IC::postprocess(
+  Atom& atom,
+  Box& box,
+  Integrate& integrate,
+  const int number_of_steps,
+  const double time_step,
+  const double temperature)
+{
+  if (!compute_)
+    return;
+  write("ic.out");
+  compute_ = false;
+}
+
+IC::IC(const char** param, const int num_param, Atom& atom)
+{
+  parse(param, num_param);
+  if (atom.unwrapped_position.size() < atom.number_of_atoms * 3) {
+    atom.unwrapped_position.resize(atom.number_of_atoms * 3);
+    atom.unwrapped_position.copy_from_device(atom.position_per_atom.data());
+  }
+  if (atom.position_temp.size() < atom.number_of_atoms * 3) {
+    atom.position_temp.resize(atom.number_of_atoms * 3);
+  }
+  property_name = "compute_ic";
+}
+
+void IC::parse(const char** param, const int num_param)
+{
+  printf("Compute ionic conductivity.\n");
+  compute_ = true;
+
+  if (num_param != 5) {
+    PRINT_INPUT_ERROR("compute_ic should have exactly 5 parameters.\n");
+  }
+
+  // sample interval
+  if (!is_valid_int(param[1], &sample_interval_)) {
+    PRINT_INPUT_ERROR("sample interval should be an integer.\n");
+  }
+  if (sample_interval_ <= 0) {
+    PRINT_INPUT_ERROR("sample interval should be positive.\n");
+  }
+  printf("    sample interval is %d.\n", sample_interval_);
+
+  // number of correlation steps
+  if (!is_valid_int(param[2], &num_correlation_steps_)) {
+    PRINT_INPUT_ERROR("number of correlation steps should be an integer.\n");
+  }
+  if (num_correlation_steps_ <= 0) {
+    PRINT_INPUT_ERROR("number of correlation steps should be positive.\n");
+  }
+  printf("    number of correlation steps is %d.\n", num_correlation_steps_);
+
+  if (!is_valid_int(param[3], &target_type_)) {
+    PRINT_INPUT_ERROR("type should be an integer.\n");
+  }
+  if (target_type_ < 0) {
+    PRINT_INPUT_ERROR("type should be non-negative.\n");
+  }
+  printf("    will compute conductivity for atom type = %d.\n", target_type_);
+
+  if (!is_valid_real(param[4], &charge_)) {
+    PRINT_INPUT_ERROR("charge should be a real number.\n");
+  }
+  printf("    will compute conductivity using charge = %g.\n", charge_);
+}

--- a/src/measure/iron_conductivity.cuh
+++ b/src/measure/iron_conductivity.cuh
@@ -1,0 +1,78 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "property.cuh"
+#include "utilities/gpu_vector.cuh"
+#include <vector>
+class Group;
+class Atom;
+
+class IC : public Property
+{
+public:
+  bool compute_ = false;
+  int sample_interval_ = 1;
+  int num_correlation_steps_ = 100;
+
+  virtual void preprocess(
+    const int number_of_steps,
+    const double time_step,
+    Integrate& integrate,
+    std::vector<Group>& group,
+    Atom& atom,
+    Box& box,
+    Force& force);
+
+  virtual void process(
+      const int number_of_steps,
+      int step,
+      const int fixed_group,
+      const int move_group,
+      const double global_time,
+      const double temperature,
+      Integrate& integrate,
+      Box& box,
+      std::vector<Group>& group,
+      GPU_Vector<double>& thermo,
+      Atom& atom,
+      Force& force);
+
+  virtual void postprocess(
+    Atom& atom,
+    Box& box,
+    Integrate& integrate,
+    const int number_of_steps,
+    const double time_step,
+    const double temperature);
+
+  virtual void write(const char* filename);
+
+  IC(const char** param, const int num_param, Atom& atom);
+  void parse(const char** param, const int num_param);
+
+private:
+  int num_atoms_;
+  int num_time_origins_;
+  double dt_in_natural_units_;
+  double dt_in_ps_;
+  int target_type_ = -1; 
+  GPU_Vector<int> type_atom_list_; 
+  GPU_Vector<double> x_, y_, z_;
+  GPU_Vector<double> msdx_, msdy_, msdz_;
+  double charge_ = 0.0;
+  double volume_ = 0.0;
+  double temperature_ = 0.0;
+};


### PR DESCRIPTION
Add the `compute_ic` command
This command currently supports calculating the ionic conductivity of only one element
`compute_ic <sample_interval> <Nc> <type_idx> <charge>`
`sample_interval` and `Nc` are used in the same way as in `compute_msd`; `type_idx` and `charge` correspond to the element index and element charge in the potential function, respectively

Taking Li in LLZO as an example, if the elements in `nep.txt` are:
`nep4_zbl 4 Li La Zr O`
Then in `run.in`, you can write:
`compute_msd  10 5000 group 0 0` # Here, group 0 corresponds to Li
`compute_ic 10 5000 0 1`

After running `gpumd`, the following output will appear on the screen
<img width="502" height="249" alt="image" src="https://github.com/user-attachments/assets/c2a9e9ac-53ea-4736-a199-5b50996dceaf" />

Finally, by processing `msd.out` and `ic.out` separately using a Python script, you can obtain conductance values that are essentially consistent
<img width="472" height="266" alt="image" src="https://github.com/user-attachments/assets/15abea64-fa84-49df-b9ce-8d69c86b07f0" />

<img width="1800" height="1800" alt="ionic_conductivity" src="https://github.com/user-attachments/assets/fa7625a3-fa95-4913-8ac3-0c15457b0896" />

[test_1000K.zip](https://github.com/user-attachments/files/27564287/test_1000K.zip)

