### PR TITLE
Optimize eam/alloy efficiency

### DIFF
--- a/doc/potentials/eam.rst
+++ b/doc/potentials/eam.rst
@@ -137,4 +137,11 @@ The last two parts can be directly copied from the fourth line of the original p
 
 Since the first three lines are comments, this modification does not affect usage in LAMMPS.
 
+Maximum neighbour count (``eam/alloy``)
+----------------------------------------
+
+For the ``eam/alloy`` form, the :ref:`potential <kw_potential>` keyword accepts an optional second argument that sets the per-atom upper bound on neighbours used to allocate the neighbour list on the GPU::
+
+   potential <potential_file>          # default: max_neighbor = 400
+   potential <potential_file> 150      # smaller value to save GPU memory
 

--- a/src/force/eam_alloy.cu
+++ b/src/force/eam_alloy.cu
@@ -24,32 +24,21 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-#define BLOCK_SIZE_FORCE 64
+#define BLOCK_SIZE_FORCE 256
 
 // LAMMPS-style Hermite cubic spline using centered finite-difference derivatives.
-// Input: y has n values at positions r = 0, h, 2h, ..., (n-1)h
-// Output: coefficients a, b, c, d (each length n) so that for interval m ∈ [0, n-2]:
-//   f(r) = a[m] + b[m]*dx + c[m]*dx^2 + d[m]*dx^3, dx = r - m*h
-// For m = n-1 the stored values give a linear extrapolation (c=d=0).
-static void compute_lammps_spline(
-  float h,
-  const std::vector<float>& y,
-  std::vector<float>& a,
-  std::vector<float>& b,
-  std::vector<float>& c,
-  std::vector<float>& d)
+// Fills `out[m] = (a, b, c, d)` so that on interval m ∈ [0, n-2]:
+//   f(r) = a + b*dx + c*dx^2 + d*dx^3,  dx = r - m*h
+// For m = n-1 we store (y[n-1], y'(n-1)/h, 0, 0) — a linear extrapolation guard.
+static void compute_lammps_spline(float h, const std::vector<float>& y, std::vector<float4>& out)
 {
   const int n = static_cast<int>(y.size());
-  a.assign(n, 0.0f);
-  b.assign(n, 0.0f);
-  c.assign(n, 0.0f);
-  d.assign(n, 0.0f);
+  out.assign(n, make_float4(0.0f, 0.0f, 0.0f, 0.0f));
   if (n < 2)
     return;
 
   // Derivative with respect to the normalized coordinate p = r/h (so dp per grid step = 1)
   std::vector<float> fp(n, 0.0f);
-
   fp[0] = y[1] - y[0];
   fp[n - 1] = y[n - 1] - y[n - 2];
   if (n >= 3) {
@@ -66,93 +55,70 @@ static void compute_lammps_spline(
 
   for (int m = 0; m <= n - 2; ++m) {
     float dy = y[m + 1] - y[m];
-    float B2 = 3.0f * dy - 2.0f * fp[m] - fp[m + 1];          // p^2 coefficient
-    float B3 = fp[m] + fp[m + 1] - 2.0f * dy;                 // p^3 coefficient
-    a[m] = y[m];
-    b[m] = fp[m] * inv_h;
-    c[m] = B2 * inv_h2;
-    d[m] = B3 * inv_h3;
+    float B2 = 3.0f * dy - 2.0f * fp[m] - fp[m + 1]; // p^2 coefficient
+    float B3 = fp[m] + fp[m + 1] - 2.0f * dy;        // p^3 coefficient
+    out[m].x = y[m];
+    out[m].y = fp[m] * inv_h;
+    out[m].z = B2 * inv_h2;
+    out[m].w = B3 * inv_h3;
   }
-  // Linear extrapolation slope at the last grid point (used only if ii is clamped to n-1).
-  a[n - 1] = y[n - 1];
-  b[n - 1] = fp[n - 1] * inv_h;
-  c[n - 1] = 0.0f;
-  d[n - 1] = 0.0f;
+  out[n - 1].x = y[n - 1];
+  out[n - 1].y = fp[n - 1] * inv_h;
 }
 
-__device__ float get_cubic(
-  int i,
-  float x,
-  float h,
-  int type,
-  const float* a,
-  const float* b,
-  const float* c,
-  const float* d,
-  int stride)
+// Spline coefficients are stored interleaved as float4 = (a, b, c, d) per (type, interval),
+// so a single 16-byte read fetches all four polynomial coefficients (vs. four scattered
+// 4-byte reads from separate arrays). Loaded via __ldg through the read-only cache.
+__device__ inline float
+spline_value(int i, float dx, int type, const float4* __restrict__ coef, int stride)
 {
-  float dx = x - (i * h);
-  int index = type * stride + i;
-  return a[index] + (b[index] + (c[index] + d[index] * dx) * dx) * dx;
+  float4 c = __ldg(&coef[type * stride + i]);
+  return c.x + (c.y + (c.z + c.w * dx) * dx) * dx;
 }
 
-__device__ float get_cubic_derivative(
-  int i,
-  float x,
-  float h,
-  int type,
-  const float* b,
-  const float* c,
-  const float* d,
-  int stride)
+__device__ inline float
+spline_deriv(int i, float dx, int type, const float4* __restrict__ coef, int stride)
 {
-  float dx = x - (i * h);
-  int index = type * stride + i;
-  return b[index] + (2.0f * c[index] + 3.0f * d[index] * dx) * dx;
+  float4 c = __ldg(&coef[type * stride + i]);
+  return c.y + (2.0f * c.z + 3.0f * c.w * dx) * dx;
 }
 
-__device__ float get_pair(
+__device__ inline float pair_value(
   int i,
-  float x,
-  float h,
+  float dx,
   int i_type,
   int j_type,
   int Nelements,
-  const float* a,
-  const float* b,
-  const float* c,
-  const float* d,
+  const float4* __restrict__ coef,
   int stride)
 {
-  float dx = x - (i * h);
-  int index = (i_type * Nelements + j_type) * stride + i;
-  return a[index] + (b[index] + (c[index] + d[index] * dx) * dx) * dx;
+  float4 c = __ldg(&coef[(i_type * Nelements + j_type) * stride + i]);
+  return c.x + (c.y + (c.z + c.w * dx) * dx) * dx;
 }
 
-__device__ float get_pair_derivative(
+// Combined value + derivative lookup for phi spline: one cache miss instead of two.
+__device__ inline void pair_value_and_deriv(
   int i,
-  float x,
-  float h,
+  float dx,
   int i_type,
   int j_type,
   int Nelements,
-  const float* b,
-  const float* c,
-  const float* d,
-  int stride)
+  const float4* __restrict__ coef,
+  int stride,
+  float& val,
+  float& der)
 {
-  float dx = x - (i * h);
-  int index = (i_type * Nelements + j_type) * stride + i;
-  return b[index] + (2.0f * c[index] + 3.0f * d[index] * dx) * dx;
+  float4 c = __ldg(&coef[(i_type * Nelements + j_type) * stride + i]);
+  val = c.x + (c.y + (c.z + c.w * dx) * dx) * dx;
+  der = c.y + (2.0f * c.z + 3.0f * c.w * dx) * dx;
 }
 
-EAMAlloy::EAMAlloy(const char* filename, const int number_of_atoms)
+EAMAlloy::EAMAlloy(const char* filename, const int number_of_atoms, const int max_neighbor)
 {
-
   initialize_eamalloy(filename, number_of_atoms);
-  eam_data.NN.resize(number_of_atoms);
-  eam_data.NL.resize(number_of_atoms * 400); // very safe for EAM
-  neighbor.initialize(eam_data.rc, number_of_atoms, 400);
+
+  neighbor.initialize(eam_data.rc, number_of_atoms, 1);
+  neighbor.NL.resize(static_cast<size_t>(number_of_atoms) * max_neighbor);
   eam_data.d_F_rho_i_g.resize(number_of_atoms);
 }
 
@@ -196,21 +162,10 @@ void EAMAlloy::initialize_eamalloy(const char* filename, const int number_of_ato
   eam_data.dr = std::stod(data_words[index++]);
   eam_data.rc = std::stod(data_words[index++]);
 
-  eam_data.F_rho.resize(eam_data.Nelements * eam_data.nrho, 0.0f);
-  eam_data.rho_r.resize(eam_data.Nelements * eam_data.nr, 0.0f);
-  eam_data.phi_r.resize(eam_data.Nelements * eam_data.Nelements * eam_data.nr, 0.0f);
-  eam_data.F_rho_a.resize(eam_data.Nelements * eam_data.nrho, 0.0f);
-  eam_data.F_rho_b.resize(eam_data.Nelements * eam_data.nrho, 0.0f);
-  eam_data.F_rho_c.resize(eam_data.Nelements * eam_data.nrho, 0.0f);
-  eam_data.F_rho_d.resize(eam_data.Nelements * eam_data.nrho, 0.0f);
-  eam_data.rho_r_a.resize(eam_data.Nelements * eam_data.nr, 0.0f);
-  eam_data.rho_r_b.resize(eam_data.Nelements * eam_data.nr, 0.0f);
-  eam_data.rho_r_c.resize(eam_data.Nelements * eam_data.nr, 0.0f);
-  eam_data.rho_r_d.resize(eam_data.Nelements * eam_data.nr, 0.0f);
-  eam_data.phi_r_a.resize(eam_data.Nelements * eam_data.Nelements * eam_data.nr, 0.0f);
-  eam_data.phi_r_b.resize(eam_data.Nelements * eam_data.Nelements * eam_data.nr, 0.0f);
-  eam_data.phi_r_c.resize(eam_data.Nelements * eam_data.Nelements * eam_data.nr, 0.0f);
-  eam_data.phi_r_d.resize(eam_data.Nelements * eam_data.Nelements * eam_data.nr, 0.0f);
+  // Host-side raw tabulated values (used only during initialization).
+  std::vector<float> F_rho(eam_data.Nelements * eam_data.nrho, 0.0f);
+  std::vector<float> rho_r(eam_data.Nelements * eam_data.nr, 0.0f);
+  std::vector<float> phi_r(eam_data.Nelements * eam_data.Nelements * eam_data.nr, 0.0f);
 
   // Section reader: reads n_values starting at the current line_idx, one line at a time.
   // After reading the required count, any leftover tokens on the last line are discarded
@@ -234,104 +189,62 @@ void EAMAlloy::initialize_eamalloy(const char* filename, const int number_of_ato
     }
   };
   for (int i = 0; i < eam_data.Nelements; ++i) {
-    // skip the per-element info line (atomic number, mass, etc.)
-    line_idx++;
-    read_section(eam_data.F_rho.data() + i * eam_data.nrho, eam_data.nrho);
-    read_section(eam_data.rho_r.data() + i * eam_data.nr, eam_data.nr);
+    line_idx++; // skip per-element info line
+    read_section(F_rho.data() + i * eam_data.nrho, eam_data.nrho);
+    read_section(rho_r.data() + i * eam_data.nr, eam_data.nr);
   }
 
-  // read phi_r as r*phi(r) (LAMMPS z2r convention); each pair block starts on a new line.
+  // phi_r is stored as r*phi(r) (LAMMPS z2r convention); each pair block starts on a new line.
+  // Lower-triangular (i >= j) blocks are read from the file and mirrored.
   for (int i = 0; i < eam_data.Nelements; ++i) {
     for (int j = 0; j <= i; ++j) {
-      read_section(
-        eam_data.phi_r.data() + (i * eam_data.Nelements + j) * eam_data.nr, eam_data.nr);
-      // mirror to upper triangle
+      read_section(phi_r.data() + (i * eam_data.Nelements + j) * eam_data.nr, eam_data.nr);
       if (i != j) {
         for (int k = 0; k < eam_data.nr; ++k) {
           size_t idx_ij = (i * eam_data.Nelements + j) * eam_data.nr + k;
           size_t idx_ji = (j * eam_data.Nelements + i) * eam_data.nr + k;
-          eam_data.phi_r[idx_ji] = eam_data.phi_r[idx_ij];
+          phi_r[idx_ji] = phi_r[idx_ij];
         }
       }
     }
   }
 
-  // Hermite spline for F(rho).
+  // Build packed (a,b,c,d) coefficient tables and upload to GPU.
+  std::vector<float4> F_rho_packed(eam_data.Nelements * eam_data.nrho);
+  std::vector<float4> rho_r_packed(eam_data.Nelements * eam_data.nr);
+  std::vector<float4> phi_r_packed(eam_data.Nelements * eam_data.Nelements * eam_data.nr);
+
   for (int i = 0; i < eam_data.Nelements; ++i) {
-    std::vector<float> y_sub(
-      eam_data.F_rho.begin() + i * eam_data.nrho,
-      eam_data.F_rho.begin() + (i + 1) * eam_data.nrho);
-    std::vector<float> ca, cb, cc, cd;
-    compute_lammps_spline(eam_data.drho, y_sub, ca, cb, cc, cd);
-    for (int j = 0; j < eam_data.nrho; ++j) {
-      size_t idx = i * eam_data.nrho + j;
-      eam_data.F_rho_a[idx] = ca[j];
-      eam_data.F_rho_b[idx] = cb[j];
-      eam_data.F_rho_c[idx] = cc[j];
-      eam_data.F_rho_d[idx] = cd[j];
-    }
+    std::vector<float> y(
+      F_rho.begin() + i * eam_data.nrho, F_rho.begin() + (i + 1) * eam_data.nrho);
+    std::vector<float4> coef;
+    compute_lammps_spline(eam_data.drho, y, coef);
+    std::copy(coef.begin(), coef.end(), F_rho_packed.begin() + i * eam_data.nrho);
   }
 
-  // Hermite spline for rho(r).
   for (int i = 0; i < eam_data.Nelements; ++i) {
-    std::vector<float> y_sub(
-      eam_data.rho_r.begin() + i * eam_data.nr,
-      eam_data.rho_r.begin() + (i + 1) * eam_data.nr);
-    std::vector<float> ca, cb, cc, cd;
-    compute_lammps_spline(eam_data.dr, y_sub, ca, cb, cc, cd);
-    for (int j = 0; j < eam_data.nr; ++j) {
-      size_t idx = i * eam_data.nr + j;
-      eam_data.rho_r_a[idx] = ca[j];
-      eam_data.rho_r_b[idx] = cb[j];
-      eam_data.rho_r_c[idx] = cc[j];
-      eam_data.rho_r_d[idx] = cd[j];
-    }
+    std::vector<float> y(rho_r.begin() + i * eam_data.nr, rho_r.begin() + (i + 1) * eam_data.nr);
+    std::vector<float4> coef;
+    compute_lammps_spline(eam_data.dr, y, coef);
+    std::copy(coef.begin(), coef.end(), rho_r_packed.begin() + i * eam_data.nr);
   }
 
-  // Hermite spline for r*phi(r) (stored as phi_r_* on GPU; divided by r at lookup).
   for (int i = 0; i < eam_data.Nelements; ++i) {
     for (int j = 0; j < eam_data.Nelements; ++j) {
-      std::vector<float> y_sub(
-        eam_data.phi_r.begin() + (i * eam_data.Nelements + j) * eam_data.nr,
-        eam_data.phi_r.begin() + (i * eam_data.Nelements + j + 1) * eam_data.nr);
-      std::vector<float> ca, cb, cc, cd;
-      compute_lammps_spline(eam_data.dr, y_sub, ca, cb, cc, cd);
-      for (int k = 0; k < eam_data.nr; ++k) {
-        size_t idx = (i * eam_data.Nelements + j) * eam_data.nr + k;
-        eam_data.phi_r_a[idx] = ca[k];
-        eam_data.phi_r_b[idx] = cb[k];
-        eam_data.phi_r_c[idx] = cc[k];
-        eam_data.phi_r_d[idx] = cd[k];
-      }
+      const size_t base = (i * eam_data.Nelements + j) * eam_data.nr;
+      std::vector<float> y(phi_r.begin() + base, phi_r.begin() + base + eam_data.nr);
+      std::vector<float4> coef;
+      compute_lammps_spline(eam_data.dr, y, coef);
+      std::copy(coef.begin(), coef.end(), phi_r_packed.begin() + base);
     }
   }
 
-  // GPU memory copy
-  eam_data.F_rho_a_g.resize(eam_data.F_rho_a.size());
-  eam_data.F_rho_b_g.resize(eam_data.F_rho_b.size());
-  eam_data.F_rho_c_g.resize(eam_data.F_rho_c.size());
-  eam_data.F_rho_d_g.resize(eam_data.F_rho_d.size());
-  eam_data.rho_r_a_g.resize(eam_data.rho_r_a.size());
-  eam_data.rho_r_b_g.resize(eam_data.rho_r_b.size());
-  eam_data.rho_r_c_g.resize(eam_data.rho_r_c.size());
-  eam_data.rho_r_d_g.resize(eam_data.rho_r_d.size());
-  eam_data.phi_r_a_g.resize(eam_data.phi_r_a.size());
-  eam_data.phi_r_b_g.resize(eam_data.phi_r_b.size());
-  eam_data.phi_r_c_g.resize(eam_data.phi_r_c.size());
-  eam_data.phi_r_d_g.resize(eam_data.phi_r_d.size());
-
-  eam_data.F_rho_a_g.copy_from_host(eam_data.F_rho_a.data(), eam_data.F_rho_a.size());
-  eam_data.F_rho_b_g.copy_from_host(eam_data.F_rho_b.data(), eam_data.F_rho_b.size());
-  eam_data.F_rho_c_g.copy_from_host(eam_data.F_rho_c.data(), eam_data.F_rho_c.size());
-  eam_data.F_rho_d_g.copy_from_host(eam_data.F_rho_d.data(), eam_data.F_rho_d.size());
-  eam_data.rho_r_a_g.copy_from_host(eam_data.rho_r_a.data(), eam_data.rho_r_a.size());
-  eam_data.rho_r_b_g.copy_from_host(eam_data.rho_r_b.data(), eam_data.rho_r_b.size());
-  eam_data.rho_r_c_g.copy_from_host(eam_data.rho_r_c.data(), eam_data.rho_r_c.size());
-  eam_data.rho_r_d_g.copy_from_host(eam_data.rho_r_d.data(), eam_data.rho_r_d.size());
-  eam_data.phi_r_a_g.copy_from_host(eam_data.phi_r_a.data(), eam_data.phi_r_a.size());
-  eam_data.phi_r_b_g.copy_from_host(eam_data.phi_r_b.data(), eam_data.phi_r_b.size());
-  eam_data.phi_r_c_g.copy_from_host(eam_data.phi_r_c.data(), eam_data.phi_r_c.size());
-  eam_data.phi_r_d_g.copy_from_host(eam_data.phi_r_d.data(), eam_data.phi_r_d.size());
+  eam_data.F_rho_g.resize(F_rho_packed.size());
+  eam_data.rho_r_g.resize(rho_r_packed.size());
+  eam_data.phi_r_g.resize(phi_r_packed.size());
+  eam_data.F_rho_g.copy_from_host(F_rho_packed.data(), F_rho_packed.size());
+  eam_data.rho_r_g.copy_from_host(rho_r_packed.data(), rho_r_packed.size());
+  eam_data.phi_r_g.copy_from_host(phi_r_packed.data(), phi_r_packed.size());
 }
 
 EAMAlloy::~EAMAlloy(void)
@@ -344,11 +257,9 @@ static __global__ void find_force_eam_step1(
   const int N1,
   const int N2,
   const Box box,
-  const int* g_NN_global,
-  const int* g_NL_global,
-  int* g_NN_local,
-  int* g_NL_local,
-  const int* g_type,
+  const int* __restrict__ g_NN_global,
+  const int* __restrict__ g_NL_global,
+  const int* __restrict__ g_type,
   const int nr,
   const int nrho,
   const int Nelements,
@@ -357,25 +268,16 @@ static __global__ void find_force_eam_step1(
   const float dr_inv,
   const float drho,
   const float drho_inv,
-  const float* F_rho_a,
-  const float* F_rho_b,
-  const float* F_rho_c,
-  const float* F_rho_d,
-  const float* rho_r_a,
-  const float* rho_r_b,
-  const float* rho_r_c,
-  const float* rho_r_d,
-  const float* phi_r_a,
-  const float* phi_r_b,
-  const float* phi_r_c,
-  const float* phi_r_d,
+  const float4* __restrict__ F_rho_coef,
+  const float4* __restrict__ rho_r_coef,
+  const float4* __restrict__ phi_r_coef,
   float* d_F_rho_i,
   const double* __restrict__ g_x,
   const double* __restrict__ g_y,
   const double* __restrict__ g_z,
   double* g_pe)
 {
-  int n1 = blockIdx.x * blockDim.x + threadIdx.x + N1; // particle index
+  int n1 = blockIdx.x * blockDim.x + threadIdx.x + N1;
 
   if (n1 < N2) {
     int NN = g_NN_global[n1];
@@ -384,7 +286,7 @@ static __global__ void find_force_eam_step1(
     double z1 = g_z[n1];
     const int i_type = g_type[n1];
     float rho = 0.0f;
-    int count_local = 0;
+    float pe_local = 0.0f;
 
     for (int i1 = 0; i1 < NN; ++i1) {
       int n2 = g_NL_global[n1 + N * i1];
@@ -399,28 +301,36 @@ static __global__ void find_force_eam_step1(
         int ii = static_cast<int>(d12 * dr_inv);
         if (ii > nr - 2)
           ii = nr - 2;
+        float dx = d12 - ii * dr;
 
-        float z2 = get_pair(
-          ii, d12, dr, i_type, j_type, Nelements, phi_r_a, phi_r_b, phi_r_c, phi_r_d, nr);
-        float phi_ij = z2 / d12;
-        g_pe[n1] += phi_ij * 0.5f;
-        rho += get_cubic(ii, d12, dr, j_type, rho_r_a, rho_r_b, rho_r_c, rho_r_d, nr);
+        float z2 = pair_value(ii, dx, i_type, j_type, Nelements, phi_r_coef, nr);
+        pe_local += (z2 / d12) * 0.5f;
+        rho += spline_value(ii, dx, j_type, rho_r_coef, nr);
       }
-
-      g_NL_local[count_local++ * N + n1] = n2;
     }
 
-    g_NN_local[n1] = count_local;
-
+    // F(rho) lookup with LAMMPS-style p-clamping and linear extrapolation for rho > rhomax.
+    // The cubic on each interval is only valid for dx ∈ [0, drho]; clamping prevents the
+    // polynomial from blowing up when atoms get very close and rho exceeds the table.
+    const float rhomax = (nrho - 1) * drho;
     int jj = static_cast<int>(rho * drho_inv);
     if (jj > nrho - 2)
       jj = nrho - 2;
     if (jj < 0)
       jj = 0;
-
-    g_pe[n1] += get_cubic(jj, rho, drho, i_type, F_rho_a, F_rho_b, F_rho_c, F_rho_d, nrho);
-    d_F_rho_i[n1] =
-      get_cubic_derivative(jj, rho, drho, i_type, F_rho_b, F_rho_c, F_rho_d, nrho);
+    float dx_F = rho - jj * drho;
+    if (dx_F > drho)
+      dx_F = drho;
+    if (dx_F < 0.0f)
+      dx_F = 0.0f;
+    float4 Fc = __ldg(&F_rho_coef[i_type * nrho + jj]);
+    float F_val = Fc.x + (Fc.y + (Fc.z + Fc.w * dx_F) * dx_F) * dx_F;
+    float fp_local = Fc.y + (2.0f * Fc.z + 3.0f * Fc.w * dx_F) * dx_F;
+    if (rho > rhomax) {
+      F_val += fp_local * (rho - rhomax);
+    }
+    g_pe[n1] += pe_local + F_val;
+    d_F_rho_i[n1] = fp_local;
   }
 }
 
@@ -429,38 +339,26 @@ static __global__ void find_force_eam_step2(
   const int N1,
   const int N2,
   const Box box,
-  const int* g_NN,
-  const int* g_NL,
-  const int* g_type,
+  const int* __restrict__ g_NN,
+  const int* __restrict__ g_NL,
+  const int* __restrict__ g_type,
   const int nr,
-  const int nrho,
   const int Nelements,
   const float rc,
   const float dr,
   const float dr_inv,
-  const float* F_rho_a,
-  const float* F_rho_b,
-  const float* F_rho_c,
-  const float* F_rho_d,
-  const float* rho_r_a,
-  const float* rho_r_b,
-  const float* rho_r_c,
-  const float* rho_r_d,
-  const float* phi_r_a,
-  const float* phi_r_b,
-  const float* phi_r_c,
-  const float* phi_r_d,
-  float* d_F_rho_i,
+  const float4* __restrict__ rho_r_coef,
+  const float4* __restrict__ phi_r_coef,
+  const float* __restrict__ d_F_rho_i,
   const double* __restrict__ g_x,
   const double* __restrict__ g_y,
   const double* __restrict__ g_z,
   double* g_fx,
   double* g_fy,
   double* g_fz,
-  double* g_virial,
-  double* g_pe)
+  double* g_virial)
 {
-  int n1 = blockIdx.x * blockDim.x + threadIdx.x + N1; // particle index
+  int n1 = blockIdx.x * blockDim.x + threadIdx.x + N1;
 
   if (n1 < N2) {
     int NN = g_NN[n1];
@@ -468,7 +366,12 @@ static __global__ void find_force_eam_step2(
     double y1 = g_y[n1];
     double z1 = g_z[n1];
     const int i_type = g_type[n1];
-    float Fp1 = d_F_rho_i[n1];
+    float Fp1 = __ldg(&d_F_rho_i[n1]);
+
+    float fx_sum = 0.0f, fy_sum = 0.0f, fz_sum = 0.0f;
+    float vxx = 0.0f, vyy = 0.0f, vzz = 0.0f;
+    float vxy = 0.0f, vxz = 0.0f, vyz = 0.0f;
+
     for (int i1 = 0; i1 < NN; ++i1) {
       int n2 = g_NL[n1 + N * i1];
       float xij = g_x[n2] - x1;
@@ -477,56 +380,53 @@ static __global__ void find_force_eam_step2(
       apply_mic(box, xij, yij, zij);
       float r = sqrt(xij * xij + yij * yij + zij * zij);
       if (r <= rc) {
-        const int j_type = g_type[n2];
-        float Fp2 = d_F_rho_i[n2];
+        const int j_type = __ldg(&g_type[n2]);
+        float Fp2 = __ldg(&d_F_rho_i[n2]);
 
         int ii = static_cast<int>(r * dr_inv);
         if (ii > nr - 2)
           ii = nr - 2;
+        float dx = r - ii * dr;
 
         float rinv = 1.0f / r;
-        float z2 = get_pair(
-          ii, r, dr, i_type, j_type, Nelements, phi_r_a, phi_r_b, phi_r_c, phi_r_d, nr);
-        float dz2_dr = get_pair_derivative(
-          ii, r, dr, i_type, j_type, Nelements, phi_r_b, phi_r_c, phi_r_d, nr);
+        float z2, dz2_dr;
+        pair_value_and_deriv(ii, dx, i_type, j_type, Nelements, phi_r_coef, nr, z2, dz2_dr);
         float phi_ij = z2 * rinv;
-        float d_phi_r_i = (dz2_dr - phi_ij) * rinv;  // dphi/dr
+        float d_phi_r_i = (dz2_dr - phi_ij) * rinv;
 
-        float d_F_i =
-          get_cubic_derivative(ii, r, dr, j_type, rho_r_b, rho_r_c, rho_r_d, nr) * Fp1;
-        float d_F_j =
-          get_cubic_derivative(ii, r, dr, i_type, rho_r_b, rho_r_c, rho_r_d, nr) * Fp2;
+        float d_F_i = spline_deriv(ii, dx, j_type, rho_r_coef, nr) * Fp1;
+        float d_F_j = spline_deriv(ii, dx, i_type, rho_r_coef, nr) * Fp2;
 
         float fij = d_phi_r_i + d_F_i + d_F_j;
         float fx = fij * xij * rinv;
         float fy = fij * yij * rinv;
         float fz = fij * zij * rinv;
 
-        // save force
-        g_fx[n1] += fx;
-        g_fy[n1] += fy;
-        g_fz[n1] += fz;
-        float sxx = fx * xij * 0.5f;
-        float syy = fy * yij * 0.5f;
-        float szz = fz * zij * 0.5f;
-        float sxy = fx * yij * 0.5f;
-        float sxz = fx * zij * 0.5f;
-        float syz = fy * zij * 0.5f;
-        // save virial
-        // xx xy xz    0 3 4
-        // yx yy yz    6 1 5
-        // zx zy zz    7 8 2
-        g_virial[n1 + 0 * N] -= sxx;
-        g_virial[n1 + 1 * N] -= syy;
-        g_virial[n1 + 2 * N] -= szz;
-        g_virial[n1 + 3 * N] -= sxy;
-        g_virial[n1 + 4 * N] -= sxz;
-        g_virial[n1 + 5 * N] -= syz;
-        g_virial[n1 + 6 * N] -= sxy;
-        g_virial[n1 + 7 * N] -= sxz;
-        g_virial[n1 + 8 * N] -= syz;
+        fx_sum += fx;
+        fy_sum += fy;
+        fz_sum += fz;
+
+        vxx -= fx * xij * 0.5f;
+        vyy -= fy * yij * 0.5f;
+        vzz -= fz * zij * 0.5f;
+        vxy -= fx * yij * 0.5f;
+        vxz -= fx * zij * 0.5f;
+        vyz -= fy * zij * 0.5f;
       }
     }
+
+    g_fx[n1] += fx_sum;
+    g_fy[n1] += fy_sum;
+    g_fz[n1] += fz_sum;
+    g_virial[n1 + 0 * N] += vxx;
+    g_virial[n1 + 1 * N] += vyy;
+    g_virial[n1 + 2 * N] += vzz;
+    g_virial[n1 + 3 * N] += vxy;
+    g_virial[n1 + 4 * N] += vxz;
+    g_virial[n1 + 5 * N] += vyz;
+    g_virial[n1 + 6 * N] += vxy;
+    g_virial[n1 + 7 * N] += vxz;
+    g_virial[n1 + 8 * N] += vyz;
   }
 }
 
@@ -543,11 +443,11 @@ void EAMAlloy::compute(
 
   int grid_size = (N2 - N1 - 1) / BLOCK_SIZE_FORCE + 1;
 
-  neighbor.find_neighbor_global(
-    eam_data.rc,
-    box,
-    type,
-    position_per_atom);
+  neighbor.find_neighbor_global(eam_data.rc, box, type, position_per_atom);
+
+  const float4* F_rho_coef = eam_data.F_rho_g.data();
+  const float4* rho_r_coef = eam_data.rho_r_g.data();
+  const float4* phi_r_coef = eam_data.phi_r_g.data();
 
   eam_data.d_F_rho_i_g.fill(0.0f);
   find_force_eam_step1<<<grid_size, BLOCK_SIZE_FORCE>>>(
@@ -557,8 +457,6 @@ void EAMAlloy::compute(
     box,
     neighbor.NN.data(),
     neighbor.NL.data(),
-    eam_data.NN.data(),
-    eam_data.NL.data(),
     type.data(),
     eam_data.nr,
     eam_data.nrho,
@@ -568,18 +466,9 @@ void EAMAlloy::compute(
     1.0f / eam_data.dr,
     eam_data.drho,
     1.0f / eam_data.drho,
-    eam_data.F_rho_a_g.data(),
-    eam_data.F_rho_b_g.data(),
-    eam_data.F_rho_c_g.data(),
-    eam_data.F_rho_d_g.data(),
-    eam_data.rho_r_a_g.data(),
-    eam_data.rho_r_b_g.data(),
-    eam_data.rho_r_c_g.data(),
-    eam_data.rho_r_d_g.data(),
-    eam_data.phi_r_a_g.data(),
-    eam_data.phi_r_b_g.data(),
-    eam_data.phi_r_c_g.data(),
-    eam_data.phi_r_d_g.data(),
+    F_rho_coef,
+    rho_r_coef,
+    phi_r_coef,
     eam_data.d_F_rho_i_g.data(),
     position_per_atom.data(),
     position_per_atom.data() + number_of_atoms,
@@ -592,27 +481,16 @@ void EAMAlloy::compute(
     N1,
     N2,
     box,
-    eam_data.NN.data(),
-    eam_data.NL.data(),
+    neighbor.NN.data(),
+    neighbor.NL.data(),
     type.data(),
     eam_data.nr,
-    eam_data.nrho,
     eam_data.Nelements,
     eam_data.rc,
     eam_data.dr,
     1.0f / eam_data.dr,
-    eam_data.F_rho_a_g.data(),
-    eam_data.F_rho_b_g.data(),
-    eam_data.F_rho_c_g.data(),
-    eam_data.F_rho_d_g.data(),
-    eam_data.rho_r_a_g.data(),
-    eam_data.rho_r_b_g.data(),
-    eam_data.rho_r_c_g.data(),
-    eam_data.rho_r_d_g.data(),
-    eam_data.phi_r_a_g.data(),
-    eam_data.phi_r_b_g.data(),
-    eam_data.phi_r_c_g.data(),
-    eam_data.phi_r_d_g.data(),
+    rho_r_coef,
+    phi_r_coef,
     eam_data.d_F_rho_i_g.data(),
     position_per_atom.data(),
     position_per_atom.data() + number_of_atoms,
@@ -620,7 +498,6 @@ void EAMAlloy::compute(
     force_per_atom.data(),
     force_per_atom.data() + number_of_atoms,
     force_per_atom.data() + 2 * number_of_atoms,
-    virial_per_atom.data(),
-    potential_per_atom.data());
+    virial_per_atom.data());
   GPU_CHECK_KERNEL
 }

--- a/src/force/eam_alloy.cuh
+++ b/src/force/eam_alloy.cuh
@@ -21,20 +21,10 @@
 
 struct EAMAlloy_Data {
 
-  GPU_Vector<int> NN, NL;
-  GPU_Vector<float> F_rho_a_g;
-  GPU_Vector<float> F_rho_b_g;
-  GPU_Vector<float> F_rho_c_g;
-  GPU_Vector<float> F_rho_d_g;
-  GPU_Vector<float> rho_r_a_g;
-  GPU_Vector<float> rho_r_b_g;
-  GPU_Vector<float> rho_r_c_g;
-  GPU_Vector<float> rho_r_d_g;
-  GPU_Vector<float> phi_r_a_g;
-  GPU_Vector<float> phi_r_b_g;
-  GPU_Vector<float> phi_r_c_g;
-  GPU_Vector<float> phi_r_d_g;
-  GPU_Vector<float> d_F_rho_i_g;
+  GPU_Vector<float4> F_rho_g;    // size = Nelements * nrho
+  GPU_Vector<float4> rho_r_g;    // size = Nelements * nr
+  GPU_Vector<float4> phi_r_g;    // size = Nelements * Nelements * nr   (r*phi)
+  GPU_Vector<float> d_F_rho_i_g; // dF/drho per atom
 
   int Nelements;
   std::vector<std::string> elements_list;
@@ -43,28 +33,14 @@ struct EAMAlloy_Data {
   int nr;
   float dr;
   float rc;
-  std::vector<float> F_rho;
-  std::vector<float> rho_r;
-  std::vector<float> phi_r;
-  std::vector<float> F_rho_a;
-  std::vector<float> F_rho_b;
-  std::vector<float> F_rho_c;
-  std::vector<float> F_rho_d;
-  std::vector<float> rho_r_a;
-  std::vector<float> rho_r_b;
-  std::vector<float> rho_r_c;
-  std::vector<float> rho_r_d;
-  std::vector<float> phi_r_a;
-  std::vector<float> phi_r_b;
-  std::vector<float> phi_r_c;
-  std::vector<float> phi_r_d;
 };
 
 class EAMAlloy : public Potential
 {
 public:
   using Potential::compute;
-  EAMAlloy(const char*, const int number_of_atoms);
+
+  EAMAlloy(const char*, const int number_of_atoms, const int max_neighbor = 400);
   virtual ~EAMAlloy(void);
   virtual void compute(
     Box& box,

--- a/src/force/force.cu
+++ b/src/force/force.cu
@@ -101,7 +101,14 @@ void Force::parse_potential(
   } else if (strcmp(potential_name, "eam_dai_2006") == 0) {
     potential.reset(new EAM(fid_potential, potential_name, num_types, number_of_atoms));
   } else if (strcmp(potential_name, "eam/alloy") == 0) {
-    potential.reset(new EAMAlloy(param[1], number_of_atoms));
+    int max_neigh = 400;
+    if (num_param == 3) {
+      if (!is_valid_int(param[2], &max_neigh) || max_neigh <= 0 || max_neigh > 1024) {
+        PRINT_INPUT_ERROR(
+          "max_neighbor for eam/alloy must be a positive integer in (0, 1024].");
+      }
+    }
+    potential.reset(new EAMAlloy(param[1], number_of_atoms, max_neigh));
   } else if (strcmp(potential_name, "adp") == 0) {
     potential.reset(new ADP(param[1], number_of_atoms));
   } else if (strcmp(potential_name, "fcp") == 0) {


### PR DESCRIPTION
## Summary

This PR fixes one corner-case bug, adds a major GPU optimisation, and exposes a new option for memory tuning.

1. **`rho > rho_max` handling.** Only triggers when atoms get unusually close; equilibrium MD never hits this. We now clamp the normalised variable and add a linear `F'(rho_max) * (rho − rho_max)` term, matching LAMMPS.

2. **Spline coefficients packed into `float4`** (loaded via `__ldg` through the read-only cache), plus register accumulation of force/virial and a fused value+derivative pair lookup. Roughly **2.6× speed-up**.

3. **Optional `max_neighbor` argument on the `potential` keyword:**

```bash
potential test.eam.alloy           # default: max_neighbor = 400
potential test.eam.alloy 150       # tighter bound, saves GPU memory
```

Default 400 is a safe over-estimate; large systems can lower it to shrink the neighbour-list footprint.

## Validation

Single-point on Cr / Co / CrCoNi / a close-pair stress test, and a 1 ps NVE on 500-atom CrCoNi with bit-matched initial velocities. All agree with LAMMPS-CPU (double precision):
```
test           comparison                         e_max      e_rms       f_max      f_rms       v_max      v_rms
------------------------------------------------------------------------------------------------------------------------
test_Cr        GPUMD vs LMP-CPU(double)        3.51e-06  1.14e-06    4.55e-05  1.32e-05    6.80e-05  1.48e-05
test_Cr        GPUMD vs LMP-GPU(mixed)         3.84e-06  1.26e-06    5.04e-05  1.35e-05    7.07e-05  1.50e-05
test_Cr        LMP-GPU(mixed) vs LMP-CPU       1.51e-06  5.37e-07    1.10e-05  2.48e-06    9.08e-06  1.80e-06

test_Co        GPUMD vs LMP-CPU(double)        7.24e-07  2.58e-07    1.50e-05  4.12e-06    4.04e-05  7.99e-06
test_Co        GPUMD vs LMP-GPU(mixed)         1.26e-06  3.31e-07    2.28e-05  4.81e-06    4.32e-05  8.08e-06
test_Co        LMP-GPU(mixed) vs LMP-CPU       8.01e-07  2.10e-07    1.03e-05  2.43e-06    5.41e-06  1.19e-06

test_CrCoNi    GPUMD vs LMP-CPU(double)        2.15e-06  4.77e-07    3.99e-05  8.36e-06    6.64e-05  9.97e-06
test_CrCoNi    GPUMD vs LMP-GPU(mixed)         2.24e-06  5.50e-07    4.10e-05  8.81e-06    6.77e-05  1.00e-05
test_CrCoNi    LMP-GPU(mixed) vs LMP-CPU       1.09e-06  2.70e-07    1.07e-05  2.43e-06    7.56e-06  1.39e-06

test_close     GPUMD vs LMP-CPU(double)        1.72e-05  1.44e-06    3.48e-04  2.16e-05    1.77e-04  1.32e-05
test_close     GPUMD vs LMP-GPU(mixed)         6.70e-05  6.15e-06    5.95e-04  4.14e-05    3.07e-04  1.81e-05
test_close     LMP-GPU(mixed) vs LMP-CPU       6.74e-05  5.99e-06    6.77e-04  3.52e-05    2.86e-04  1.16e-05
```

## Efficiency

Benchmarked vs single-core LAMMPS CPU and LAMMPS GPU (mixed precision) on an RTX 4060 Laptop:
<img width="2504" height="716" alt="bench_alloy_scaling" src="https://github.com/user-attachments/assets/181eafbe-a914-4f40-a880-68ae58b45f01" />
