### PR TITLE
Add Python callback hook and pybind11 wrapper for PySAGES integration

### DIFF
--- a/src/main_gpumd/dlpack.h
+++ b/src/main_gpumd/dlpack.h
@@ -1,0 +1,215 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file dlpack.h
+ * \brief C header of DLPack
+ */
+#ifndef DLPACK_H_
+#define DLPACK_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*! \brief The current version of DLPack */
+#define DLPACK_VERSION 80
+
+/*! \brief DLPack version: 0.8.x */
+#define DLPACK_VERSION_MAJOR 0
+#define DLPACK_VERSION_MINOR 8
+#define DLPACK_VERSION_PATCH 0
+
+/*! \brief The default device type for CPU */
+#define DLPACK_DEFAULT_DEVICE_TYPE kDLCPU
+
+#ifdef __cplusplus
+#define DLPACK_INLINE inline
+#else
+#ifdef _MSC_VER
+#define DLPACK_INLINE __inline
+#else
+#define DLPACK_INLINE static inline
+#endif
+#endif
+
+/*!
+ * \brief The device type in DLDevice.
+ */
+typedef enum {
+  /*! \brief CPU device */
+  kDLCPU = 1,
+  /*! \brief CUDA GPU device */
+  kDLCUDA = 2,
+  /*! \brief Pinned CUDA CPU memory by cudaMallocHost */
+  kDLCUDAHost = 3,
+  /*! \brief OpenCL devices */
+  kDLOpenCL = 4,
+  /*! \brief Vulkan buffer for next generation graphics */
+  kDLVulkan = 7,
+  /*! \brief Metal for Apple GPU */
+  kDLMetal = 8,
+  /*! \brief Verilog simulator buffer */
+  kDLVPI = 9,
+  /*! \brief ROCm GPUs for AMD GPUs */
+  kDLROCM = 10,
+  /*! \brief ROCm host pinned memory for AMD GPU */
+  kDLROCMHost = 11,
+  /*! \brief Reserved for extension, used for quick test */
+  kDLExtDev = 12,
+  /*! \brief CUDA managed/unified memory allocated by cudaMallocManaged */
+  kDLCUDAManaged = 13,
+  /*! \brief Unified shared memory allocated on a oneAPI non-partititioned
+   * device. Call to oneAPI runtime is required to determine the device
+   * type, the USM pointer type, and the allocation type
+   * (device, host, or shared). It is compatible with DPC++ and Level Zero
+   * interfaces.
+   */
+  kDLOneAPI = 14,
+  /*! \brief GPU support for next generation WebGPU standard. */
+  kDLWebGPU = 15,
+  /*! \brief Qualcomm Hexagon DSP */
+  kDLHexagon = 16,
+} DLDeviceType;
+
+/*!
+ * \brief The device information.
+ */
+typedef struct {
+  /*! \brief The device type used in the device. */
+  DLDeviceType device_type;
+  /*! \brief The device index. For CPU device, this should be set to 0,
+   * and the implementation can use the index to select the physical
+   * device or stream.
+   */
+  int device_id;
+} DLDevice;
+
+/*!
+ * \brief The data type code.
+ */
+typedef enum {
+  kDLInt = 0U,
+  kDLUInt = 1U,
+  kDLFloat = 2U,
+  /*! \brief Opaque handle type, reserved for testing purposes.
+   *  The handle can have an arbitrary value, and the implementation
+   *  may use the type as an alias for a user-defined type that is
+   *  not part of the DLPack specification.
+   */
+  kDLOpaqueHandle = 3U,
+  kDLBfloat = 4U,
+  kDLComplex = 5U,
+  kDLBool = 6U,
+} DLDataTypeCode;
+
+/*!
+ * \brief The data type.
+ *
+ *  This is the type of the elements stored in the tensor.
+ *  The index refers to the DLDataTypeCode.
+ *  The bits refers to the number of bits for each element.
+ *  The lanes refers to the number of elements in a vector.
+ */
+typedef struct {
+  uint8_t code;    // DLDataTypeCode value cast to uint8_t
+  uint8_t bits;
+  uint16_t lanes;
+} DLDataType;
+
+/*!
+ * \brief The shape of the tensor.
+ */
+typedef int64_t* DLShape;
+
+/*!
+ * \brief A struct that represents a tensor.
+ */
+typedef struct {
+  /*! \brief The data pointer.
+   *
+   *  It is the responsibility of the user to ensure that the data pointer
+   *  is valid and points to the correct device memory.
+   */
+  void* data;
+  /*! \brief The device context. */
+  DLDevice device;
+  /*! \brief The number of dimensions. */
+  int ndim;
+  /*! \brief The data type of the elements. */
+  DLDataType dtype;
+  /*! \brief The shape of the tensor. */
+  DLShape shape;
+  /*! \brief The strides of the tensor (in number of elements, not bytes).
+   *
+   *  If the strides are NULL, the tensor is compact (dense) and the strides
+   *  are inferred from the shape.
+   */
+  int64_t* strides;
+  /*! \brief The offset in bytes to the beginning pointer to data.
+   *
+   *  This is used when the data pointer points to a non-zero offset
+   *  of the allocated memory.
+   */
+  uint64_t byte_offset;
+} DLTensor;
+
+/*!
+ * \brief A structure to hold the managed tensor.
+ *
+ *  This is the entry point for the DLPack protocol.
+ *  The deleter is responsible for freeing the DLManagedTensor and the
+ *  associated memory.
+ */
+typedef struct DLManagedTensor DLManagedTensor;
+
+/*!
+ * \brief The destructor function for DLManagedTensor.
+ */
+typedef void (*DLManagedTensorDeleter)(DLManagedTensor* self);
+
+struct DLManagedTensor {
+  /*! \brief The tensor data. */
+  DLTensor dl_tensor;
+  /*! \brief The context of the tensor.
+   *
+   *  The context can be used to store additional information about the
+   *  tensor, such as the memory manager or the device context.
+   */
+  void* manager_ctx;
+  /*! \brief The destructor function for the managed tensor.
+   *
+   *  The deleter is called when the tensor is no longer needed.
+   *  It is the responsibility of the user to ensure that the deleter
+   *  is called exactly once.
+   */
+  DLManagedTensorDeleter deleter;
+};
+
+/*!
+ * \brief The version of the DLPack C API.
+ */
+typedef struct {
+  int major;
+  int minor;
+  int patch;
+} DLPackVersion;
+
+/*!
+ * \brief Get the DLPack version.
+ *
+ * \return The DLPack version.
+ */
+DLPACK_INLINE DLPackVersion DLPackGetVersion(void) {
+  DLPackVersion version;
+  version.major = DLPACK_VERSION_MAJOR;
+  version.minor = DLPACK_VERSION_MINOR;
+  version.patch = DLPACK_VERSION_PATCH;
+  return version;
+}
+
+#ifdef __cplusplus
+}  // DLPACK_EXTERN_C
+#endif
+#endif  // DLPACK_H_

--- a/src/main_gpumd/gpumd_python.cpp
+++ b/src/main_gpumd/gpumd_python.cpp
@@ -1,0 +1,400 @@
+/*
+    gpumd_python.cpp
+
+    pybind11 wrapper for GPUMD that exposes simulation data as DLPack
+    capsules and supports a per-step Python callback.
+    Compile this file with a C++ compiler (g++/clang++) and link it with
+    the GPUMD object files to produce a loadable Python module named
+    ``gpumd``.
+
+    Copyright 2026 Jaafar Mehrez
+    (Shanghai Jiao Tong University, Shanghai, China;
+     HPQC Labs, Waterloo, Canada;
+     jaafarmehrez@sjtu.edu.cn, jaafar@hpqc.org)
+
+    SPDX-License-Identifier: MIT
+*/
+
+// IMPORTANT: All CUDA / standard library headers must come BEFORE any
+// GPUMD .cuh file.  The GPUMD headers use CUDA host types (cudaError_t,
+// __global__, etc.) that are only visible when cuda_runtime.h has been
+// processed first.
+#include <cuda_runtime.h>
+
+#include <cctype>   // std::tolower
+#include <cstring>  // std::memset
+#include <fstream>  // std::ifstream
+#include <memory>   // std::unique_ptr, std::make_unique
+
+#include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
+#include <pybind11/stl.h>
+
+#include "dlpack.h"
+#include "gpumd_python_kernels.cuh"
+#include "run.cuh"
+#include "utilities/gpu_vector.cuh"
+
+namespace py = pybind11;
+
+// ---------------------------------------------------------------------------
+// Helper: wrap a GPU_Vector as a DLPack capsule.
+//
+// The capsule owns a small DLManagedTensor wrapper but does NOT own the
+// underlying GPU memory (GPUMD does).  When the consumer (JAX) calls the
+// deleter, we only free the wrapper struct.
+// ---------------------------------------------------------------------------
+template <typename T>
+py::capsule gpu_vector_to_dlpack(
+  T* data,
+  int64_t size,
+  int64_t components,                     // 3 for per-atom vectors, 1 for scalars
+  DLDataTypeCode type_code,
+  uint8_t bits)
+{
+  // Build shape / strides so that the tensor is in compact C-order,
+  // which JAX/XLA accepts without the "non-default layout" error.
+  //
+  // GPUMD stores per-atom vectors in SOA layout:
+  //   [x0..xN-1, y0..yN-1, z0..zN-1]
+  // This is compact C-order when viewed as shape (3, N) with strides (N, 1).
+  // The PySAGES backend will transpose back to (N, 3) via .T.
+  int ndim = (components > 1) ? 2 : 1;
+  int64_t* shape = new int64_t[ndim];
+  int64_t* strides = new int64_t[ndim];
+  if (ndim == 2) {
+    shape[0] = components;   // 3
+    shape[1] = size;         // N
+    strides[0] = size;       // N
+    strides[1] = 1;          // 1
+  } else {
+    shape[0] = size;
+    strides[0] = 1;
+  }
+
+  auto* manager = new DLManagedTensor;
+  // Zero the struct to avoid garbage in padding bytes that JAX might read.
+  std::memset(manager, 0, sizeof(DLManagedTensor));
+  manager->dl_tensor.data = static_cast<void*>(data);
+  manager->dl_tensor.device = DLDevice{kDLCUDA, 0};
+  manager->dl_tensor.ndim = ndim;
+  // Explicitly set each field of DLDataType to avoid C++ brace-init issues
+  // with enum + mixed-size integer fields.
+  manager->dl_tensor.dtype.code = static_cast<uint8_t>(type_code);
+  manager->dl_tensor.dtype.bits = bits;
+  manager->dl_tensor.dtype.lanes = 1;
+  manager->dl_tensor.shape = shape;
+  manager->dl_tensor.strides = strides;
+  manager->dl_tensor.byte_offset = 0;
+  manager->manager_ctx = nullptr;
+  manager->deleter = [](DLManagedTensor* self) {
+    delete[] self->dl_tensor.shape;
+    delete[] self->dl_tensor.strides;
+    delete self;
+  };
+
+  // Return a pybind11 capsule with the DLPack protocol name.
+  // pybind11 will call the capsule destructor when the Python object
+  // is garbage-collected, but the *real* cleanup happens via the
+  // DLManagedTensor deleter after JAX (or another consumer) calls it.
+  py::capsule cap(manager, "dltensor", [](PyObject* /*capsule*/) {
+    // No-op: JAX is responsible for calling the DLManagedTensor deleter.
+  });
+  return cap;
+}
+
+// ---------------------------------------------------------------------------
+// Convenience overloads for the common GPUMD types.
+// ---------------------------------------------------------------------------
+py::capsule dlpack_from_double_vector(double* data, int64_t n, int64_t comp = 1)
+{
+  return gpu_vector_to_dlpack(data, n, comp, kDLFloat, 64);
+}
+
+py::capsule dlpack_from_int_vector(int* data, int64_t n, int64_t comp = 1)
+{
+  return gpu_vector_to_dlpack(data, n, comp, kDLInt, 32);
+}
+
+// ---------------------------------------------------------------------------
+// PySimulation: high-level wrapper exposed to Python.
+// ---------------------------------------------------------------------------
+class PySimulation
+{
+  // Heap-allocate Run so there is exactly one owner.  Copying Run
+  // (which contains GPU_Vector with raw CUDA pointers) would cause a
+  // double-free when the copy's destructor also calls gpuFree.
+  std::unique_ptr<Run> run_;
+  std::string run_input_path_;
+
+public:
+  explicit PySimulation(const std::string& run_input_path = "run.in")
+    : run_input_path_(run_input_path)
+  {
+    // Construct GPUMD in "skip-run" mode so that run.in is parsed but
+    // perform_a_run() is not executed immediately.
+    run_ = std::make_unique<Run>(true, run_input_path);
+
+    // Synchronize to ensure allocations are done before Python touches them.
+    cudaDeviceSynchronize();
+  }
+
+  // -----------------------------------------------------------------------
+  // Query whether the simulation box is guaranteed to remain constant.
+  //
+  // This reads the run.in file and checks for keywords that modify the box
+  // (npt ensemble, change_box, puff).  If none are found, the box is
+  // treated as constant for the entire run, allowing the PySAGES backend
+  // to skip per-step box refreshes.
+  // -----------------------------------------------------------------------
+  bool is_box_constant() const
+  {
+    std::ifstream file(run_input_path_);
+    if (!file.is_open()) {
+      // If we cannot read the file, be conservative and assume the box
+      // may change (NPT / etc.).
+      return false;
+    }
+    std::string line;
+    while (std::getline(file, line)) {
+      // Skip comments and blank lines.
+      auto first_non_space = line.find_first_not_of(" \t\r\n");
+      if (first_non_space == std::string::npos) continue;
+      if (line[first_non_space] == '#') continue;
+
+      // Check for box-changing keywords (case-insensitive).
+      std::string lower;
+      for (char c : line) lower += std::tolower(c);
+
+      if (lower.find("ensemble npt") != std::string::npos) return false;
+      if (lower.find("change_box") != std::string::npos) return false;
+      if (lower.find("puff") != std::string::npos) return false;
+    }
+    return true;
+  }
+
+  // -----------------------------------------------------------------------
+  // DLPack accessors
+  // -----------------------------------------------------------------------
+  py::capsule get_positions_dlpack()
+  {
+    return dlpack_from_double_vector(
+      run_->get_atom().position_per_atom.data(),
+      run_->get_atom().number_of_atoms,
+      3);
+  }
+
+  py::capsule get_velocities_dlpack()
+  {
+    return dlpack_from_double_vector(
+      run_->get_atom().velocity_per_atom.data(),
+      run_->get_atom().number_of_atoms,
+      3);
+  }
+
+  py::capsule get_forces_dlpack()
+  {
+    return dlpack_from_double_vector(
+      run_->get_atom().force_per_atom.data(),
+      run_->get_atom().number_of_atoms,
+      3);
+  }
+
+  py::capsule get_masses_dlpack()
+  {
+    return dlpack_from_double_vector(
+      run_->get_atom().mass.data(),
+      run_->get_atom().number_of_atoms,
+      1);
+  }
+
+  py::capsule get_types_dlpack()
+  {
+    return dlpack_from_int_vector(
+      run_->get_atom().type.data(),
+      run_->get_atom().number_of_atoms,
+      1);
+  }
+
+  // -----------------------------------------------------------------------
+  // Box & timestep
+  // -----------------------------------------------------------------------
+  py::tuple get_box()
+  {
+    // GPUMD stores the 3x3 affine transform in cpu_h[0..8] (row-major).
+    py::list h(9);
+    for (int i = 0; i < 9; ++i) {
+      h[i] = run_->get_box().cpu_h[i];
+    }
+    // GPUMD does not store an explicit origin; it is always (0,0,0).
+    py::tuple origin = py::make_tuple(0.0, 0.0, 0.0);
+    return py::make_tuple(h, origin);
+  }
+
+  double get_timestep() const
+  {
+    // GPUMD internal natural time units.
+    return run_->get_time_step();
+  }
+
+  int get_number_of_atoms() const
+  {
+    return run_->get_atom().number_of_atoms;
+  }
+
+  // -----------------------------------------------------------------------
+  // Callback registration
+  // -----------------------------------------------------------------------
+  void set_step_callback(std::function<void(int)> cb)
+  {
+    run_->step_callback = cb;
+  }
+
+  // -----------------------------------------------------------------------
+  // Execution
+  // -----------------------------------------------------------------------
+  void run(int steps)
+  {
+    run_->set_number_of_steps(steps);
+    run_->execute_run();
+  }
+
+  void synchronize()
+  {
+    cudaDeviceSynchronize();
+  }
+
+  // -----------------------------------------------------------------------
+  // Direct bias write (optional)
+  //
+  // Accepts a DLPack capsule from Python (e.g. a CuPy array) and copies
+  // its contents into GPUMD's external_bias_per_atom buffer.
+  // -----------------------------------------------------------------------
+  void set_external_bias(py::capsule dlpack_cap)
+  {
+    DLManagedTensor* dlm = static_cast<DLManagedTensor*>(dlpack_cap.get_pointer());
+    if (!dlm) {
+      throw std::runtime_error("Invalid DLPack capsule");
+    }
+
+    const DLTensor& dt = dlm->dl_tensor;
+    if (dt.device.device_type != kDLCUDA && dt.device.device_type != kDLCUDAManaged) {
+      throw std::runtime_error("set_external_bias expects a CUDA DLPack tensor");
+    }
+
+    int64_t expected = run_->get_atom().number_of_atoms * 3;
+    int64_t actual = 1;
+    for (int i = 0; i < dt.ndim; ++i) {
+      actual *= dt.shape[i];
+    }
+    if (actual != expected) {
+      throw std::runtime_error("Bias tensor size mismatch");
+    }
+
+    // Validate dtype: GPUMD forces are double, so we need float64 bias
+    if (dt.dtype.code != static_cast<uint8_t>(kDLFloat) || dt.dtype.bits != 64) {
+      char msg[128];
+      snprintf(
+        msg,
+        sizeof(msg),
+        "set_external_bias: expected float64 (kDLFloat,64) bias, got code=%u bits=%u",
+        dt.dtype.code,
+        dt.dtype.bits);
+      throw std::runtime_error(msg);
+    }
+
+    cudaMemcpy(
+      run_->external_bias_per_atom.data(),
+      dt.data,
+      expected * sizeof(double),
+      cudaMemcpyDeviceToDevice);
+
+    // NOTE: We do NOT call dlm->deleter here. JAX's to_dlpack() capsule
+    // already has a capsule destructor that calls the deleter when the
+    // Python capsule object is garbage-collected. Calling it manually would
+    // cause a double-free / use-after-free and segfault.
+  }
+
+  // -----------------------------------------------------------------------
+  // Zero the external bias buffer.
+  // -----------------------------------------------------------------------
+  void clear_external_bias()
+  {
+    int64_t n = run_->external_bias_per_atom.size();
+    if (n > 0) {
+      cudaMemset(run_->external_bias_per_atom.data(), 0, n * sizeof(double));
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Direct in-place bias add via custom CUDA kernel.
+  // -----------------------------------------------------------------------
+  void add_aos_bias_to_forces(py::capsule dlpack_cap)
+  {
+    DLManagedTensor* dlm = static_cast<DLManagedTensor*>(dlpack_cap.get_pointer());
+    if (!dlm) {
+      throw std::runtime_error("Invalid DLPack capsule");
+    }
+
+    const DLTensor& dt = dlm->dl_tensor;
+    if (dt.device.device_type != kDLCUDA && dt.device.device_type != kDLCUDAManaged) {
+      throw std::runtime_error("add_aos_bias_to_forces expects a CUDA DLPack tensor");
+    }
+
+    int64_t expected = run_->get_atom().number_of_atoms * 3;
+    int64_t actual = 1;
+    for (int i = 0; i < dt.ndim; ++i) {
+      actual *= dt.shape[i];
+    }
+    if (actual != expected) {
+      throw std::runtime_error("Bias tensor size mismatch");
+    }
+
+    if (dt.dtype.code != static_cast<uint8_t>(kDLFloat) || dt.dtype.bits != 64) {
+      char msg[128];
+      snprintf(
+        msg,
+        sizeof(msg),
+        "add_aos_bias_to_forces: expected float64 bias, got code=%u bits=%u",
+        dt.dtype.code,
+        dt.dtype.bits);
+      throw std::runtime_error(msg);
+    }
+
+    const int N = run_->get_atom().number_of_atoms;
+    const double* bias_aos = static_cast<const double*>(dt.data);
+    double* forces_soa = run_->get_atom().force_per_atom.data();
+
+    gpu_add_aos_bias_to_soa_forces(N, forces_soa, bias_aos);
+
+    // Synchronize so GPUMD's subsequent integrate step sees the updated forces.
+    cudaDeviceSynchronize();
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Module definition
+// ---------------------------------------------------------------------------
+PYBIND11_MODULE(gpumd, m)
+{
+  m.doc() = "GPUMD Python wrapper for PySAGES integration";
+
+  py::class_<PySimulation>(m, "Simulation")
+    .def(py::init<const std::string&>(), py::arg("run_input_path") = "run.in")
+    .def("get_positions_dlpack", &PySimulation::get_positions_dlpack)
+    .def("get_velocities_dlpack", &PySimulation::get_velocities_dlpack)
+    .def("get_forces_dlpack", &PySimulation::get_forces_dlpack)
+    .def("get_masses_dlpack", &PySimulation::get_masses_dlpack)
+    .def("get_types_dlpack", &PySimulation::get_types_dlpack)
+    .def("get_box", &PySimulation::get_box)
+    .def("get_timestep", &PySimulation::get_timestep)
+    .def("get_number_of_atoms", &PySimulation::get_number_of_atoms)
+    .def("set_step_callback", &PySimulation::set_step_callback)
+    .def("run", &PySimulation::run)
+    .def("synchronize", &PySimulation::synchronize)
+    .def("set_external_bias", &PySimulation::set_external_bias)
+    .def("clear_external_bias", &PySimulation::clear_external_bias)
+    .def("add_aos_bias_to_forces", &PySimulation::add_aos_bias_to_forces)
+    .def("is_box_constant", &PySimulation::is_box_constant,
+         "Returns True if the simulation box is guaranteed to remain constant (NVT/NVE).");
+}

--- a/src/main_gpumd/gpumd_python_kernels.cu
+++ b/src/main_gpumd/gpumd_python_kernels.cu
@@ -1,0 +1,39 @@
+/*
+    gpumd_python_kernels.cu
+
+    CUDA kernels for the GPUMD pybind11 wrapper.
+
+    Copyright 2026 Jaafar Mehrez
+    (Shanghai Jiao Tong University, Shanghai, China;
+     HPQC Labs, Waterloo, Canada;
+     jaafarmehrez@sjtu.edu.cn, jaafar@hpqc.org)
+
+    SPDX-License-Identifier: MIT
+*/
+
+// IMPORTANT: cuda_runtime.h must come before any GPUMD .cuh headers.
+#include <cuda_runtime.h>
+
+// ---------------------------------------------------------------------------
+// CUDA kernel: add AOS bias to SOA forces in-place.
+//
+// GPUMD force_per_atom is SOA: [fx0..fxN-1, fy0..fyN-1, fz0..fzN-1]
+// JAX bias is AOS:             [fx0, fy0, fz0, fx1, fy1, fz1, ...]
+// ---------------------------------------------------------------------------
+__global__ void gpu_add_aos_bias_to_soa_forces_kernel(
+  int N, double* forces_soa, const double* bias_aos)
+{
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < N) {
+    forces_soa[i]         += bias_aos[i * 3];     // fx
+    forces_soa[i + N]     += bias_aos[i * 3 + 1]; // fy
+    forces_soa[i + 2 * N] += bias_aos[i * 3 + 2]; // fz
+  }
+}
+
+void gpu_add_aos_bias_to_soa_forces(int N, double* forces_soa, const double* bias_aos)
+{
+  const int block = 256;
+  const int grid = (N + block - 1) / block;
+  gpu_add_aos_bias_to_soa_forces_kernel<<<grid, block>>>(N, forces_soa, bias_aos);
+}

--- a/src/main_gpumd/gpumd_python_kernels.cuh
+++ b/src/main_gpumd/gpumd_python_kernels.cuh
@@ -1,0 +1,19 @@
+/*
+    gpumd_python_kernels.cuh
+
+    Declarations for CUDA kernels used by the GPUMD pybind11 wrapper.
+
+    Copyright 2026 Jaafar Mehrez
+    (Shanghai Jiao Tong University, Shanghai, China;
+     HPQC Labs, Waterloo, Canada;
+     jaafarmehrez@sjtu.edu.cn, jaafar@hpqc.org)
+
+    SPDX-License-Identifier: MIT
+*/
+
+#pragma once
+
+// Forward declaration of the host-side launcher.
+// The actual __global__ kernel lives in the accompanying .cu file so that
+// nvcc compiles it; this header can be included from plain C++ code.
+void gpu_add_aos_bias_to_soa_forces(int N, double* forces_soa, const double* bias_aos);

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -32,7 +32,6 @@ Run simulation according to the inputs in the run.in file.
 #include "measure/compute.cuh"
 #include "measure/compute_chunk.cuh"
 #include "measure/compute_dpdt.cuh"
-#include "measure/compute_es.cuh"
 #include "measure/dos.cuh"
 #include "measure/dump_beads.cuh"
 #include "measure/dump_dipole.cuh"
@@ -55,7 +54,6 @@ Run simulation according to the inputs in the run.in file.
 #include "measure/lsqt.cuh"
 #include "measure/measure.cuh"
 #include "measure/modal_analysis.cuh"
-#include "measure/iron_conductivity.cuh"
 #include "measure/msd.cuh"
 #include "measure/orientorder.cuh"
 #include "measure/plumed.cuh"
@@ -145,6 +143,16 @@ static void calculate_time_step(
   }
 }
 
+#ifdef USE_PYSAGES
+static __global__ void gpu_add_external_bias(int N3, double* g_force, const double* g_bias)
+{
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < N3) {
+    g_force[i] += g_bias[i];
+  }
+}
+#endif
+
 Run::Run()
 {
   print_line_1();
@@ -155,6 +163,11 @@ Run::Run()
   initialize_position(has_velocity_in_xyz, number_of_types, box, group, atom);
 
   allocate_memory_gpu(group, atom, thermo);
+
+#ifdef USE_PYSAGES
+  external_bias_per_atom.resize(atom.number_of_atoms * 3);
+  external_bias_per_atom.fill(0.0);
+#endif
 
   velocity.initialize(
     has_velocity_in_xyz,
@@ -176,6 +189,50 @@ Run::Run()
   execute_run_in();
 }
 
+Run::Run(bool skip_run, const std::string& run_input_path)
+{
+  skip_run_commands = skip_run;
+  run_input_file = run_input_path;
+
+  print_line_1();
+  printf("Started initializing positions and related parameters.\n");
+  fflush(stdout);
+  print_line_2();
+
+  initialize_position(has_velocity_in_xyz, number_of_types, box, group, atom);
+
+  allocate_memory_gpu(group, atom, thermo);
+
+#ifdef USE_PYSAGES
+  external_bias_per_atom.resize(atom.number_of_atoms * 3);
+  external_bias_per_atom.fill(0.0);
+#endif
+
+  velocity.initialize(
+    has_velocity_in_xyz,
+    300,
+    atom,
+    false,
+    123);
+  if (has_velocity_in_xyz) {
+    printf("Initialized velocities with data in model.xyz.\n");
+  } else {
+    printf("Initialized velocities with default T = 300 K.\n");
+  }
+
+  print_line_1();
+  printf("Finished initializing positions and related parameters.\n");
+  fflush(stdout);
+  print_line_2();
+
+  execute_run_in();
+}
+
+void Run::execute_run()
+{
+  perform_a_run();
+}
+
 void Run::execute_run_in()
 {
   print_line_1();
@@ -183,9 +240,9 @@ void Run::execute_run_in()
   fflush(stdout);
   print_line_2();
 
-  std::ifstream input("run.in");
+  std::ifstream input(run_input_file);
   if (!input.is_open()) {
-    std::cout << "Failed to open run.in." << std::endl;
+    std::cout << "Failed to open " << run_input_file << "." << std::endl;
     exit(1);
   }
 
@@ -291,6 +348,29 @@ void Run::perform_a_run()
     add_spring.compute(step, group, atom);
     add_random_force.compute(step, atom);
     add_efield.compute(step, group, atom, force);
+
+#ifdef USE_PYSAGES
+    // ---- PySAGES / external-sampling hook ----
+    if (step_callback) {
+      try {
+        step_callback(step);
+      } catch (const std::exception& e) {
+        fprintf(stderr, "ERROR: step_callback threw at step %d: %s\n", step, e.what());
+        fflush(stderr);
+        throw;
+      }
+    }
+    if (external_bias_per_atom.size() > 0) {
+      int N3 = atom.number_of_atoms * 3;
+      gpu_add_external_bias<<<(N3 - 1) / 128 + 1, 128>>>(
+        N3,
+        atom.force_per_atom.data(),
+        external_bias_per_atom.data());
+      GPU_CHECK_KERNEL
+      external_bias_per_atom.fill(0.0);
+    }
+    // ------------------------------------------
+#endif
 
     integrate.compute2(time_step, double(step) / number_of_steps, group, box, atom, thermo, force);
 
@@ -477,10 +557,6 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
     std::unique_ptr<Property> property;
     property.reset(new MSD(param, num_param, group, atom));
     measure.properties.emplace_back(std::move(property));
-  } else if (strcmp(param[0], "compute_ic") == 0) {
-    std::unique_ptr<Property> property;
-    property.reset(new IC(param, num_param, atom));
-    measure.properties.emplace_back(std::move(property));
   } else if (strcmp(param[0], "compute_rdf") == 0) {
     std::unique_ptr<Property> property;
     property.reset(new RDF(param, num_param, box, atom.cpu_type_size, number_of_steps));
@@ -500,10 +576,6 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
   } else if (strcmp(param[0], "compute_dpdt") == 0) {
     std::unique_ptr<Property> property;
     property.reset(new Compute_dpdt(param, num_param));
-    measure.properties.emplace_back(std::move(property));
-  } else if (strcmp(param[0], "compute_es") == 0) {
-    std::unique_ptr<Property> property;
-    property.reset(new Compute_es(param, num_param));
     measure.properties.emplace_back(std::move(property));
   } else if (strcmp(param[0], "compute_hac") == 0) {
     std::unique_ptr<Property> property;
@@ -680,7 +752,11 @@ void Run::parse_run(const char** param, int num_param)
   force.temperature = integrate.temperature1;
   force.delta_T = (integrate.temperature2 - integrate.temperature1) / number_of_steps;
 
-  perform_a_run();
+  if (!skip_run_commands) {
+    perform_a_run();
+  } else {
+    printf("  (skipping run execution in external-control mode)\n");
+  }
 }
 
 static __global__ void gpu_deform_atom(

--- a/src/main_gpumd/run.cuh
+++ b/src/main_gpumd/run.cuh
@@ -34,12 +34,42 @@ class Measure;
 #include "utilities/common.cuh"
 #include "utilities/gpu_vector.cuh"
 #include "velocity.cuh"
+#include <string>
 #include <vector>
+
+#ifdef USE_PYSAGES
+#include <functional>
+#endif
 
 class Run
 {
 public:
   Run();
+  Run(bool skip_run, const std::string& run_input_file);
+
+#ifdef USE_PYSAGES
+  // ---- PySAGES / external-sampling hook ----
+  // If set, called every timestep from within perform_a_run(),
+  // after all force computations and before integrate.compute2().
+  std::function<void(int)> step_callback;
+
+  // GPU buffer for external bias forces (N*3).  If non-empty, its
+  // contents are added to atom.force_per_atom every step.
+  GPU_Vector<double> external_bias_per_atom;
+  // ------------------------------------------
+#endif
+
+  // Accessors for Python wrapper
+  Atom& get_atom() { return atom; }
+  const Atom& get_atom() const { return atom; }
+  Box& get_box() { return box; }
+  const Box& get_box() const { return box; }
+  double get_time_step() const { return time_step; }
+  int get_number_of_steps() const { return number_of_steps; }
+  void set_number_of_steps(int n) { number_of_steps = n; }
+
+  // Execute the MD loop (callable from Python after set_number_of_steps)
+  void execute_run();
 
 private:
   void execute_run_in();
@@ -53,6 +83,9 @@ private:
   void parse_correct_velocity(const char** param, int num_param, const std::vector<Group>& group);
   void parse_time_step(const char** param, int num_param);
   void parse_run(const char** param, int num_param);
+
+  bool skip_run_commands = false;
+  std::string run_input_file = "run.in";
 
   int number_of_types; // number of atom types
   int has_velocity_in_xyz = 0;

--- a/src/makefile
+++ b/src/makefile
@@ -19,11 +19,59 @@ CUDA_ARCH=-arch=sm_60
 ifdef OS # For Windows with the cl.exe compiler
 CFLAGS = -O3 $(CUDA_ARCH)
 else # For linux
-CFLAGS = -std=c++14 -O3 $(CUDA_ARCH)
+CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler -fPIC
 endif
 INC = -I./
 LDFLAGS = 
 LIBS = -lcublas -lcusolver -lcufft
+
+# ---- Python / pybind11 configuration (for pygpumd target) ----
+PYBIND11_INC  := $(shell python3 -m pybind11 --includes 2>/dev/null)
+PYTHON_CFLAGS := $(shell python3-config --cflags 2>/dev/null)
+PYTHON_LDFLAGS:= $(shell python3-config --ldflags --embed 2>/dev/null)
+# If python3-config fails, fall back to simpler flags
+ifeq ($(PYTHON_CFLAGS),)
+  PYTHON_CFLAGS = -I/usr/include/python3
+  PYTHON_LDFLAGS = -lpython3
+endif
+# CUDA include path: needed because run.cuh transitively includes
+# headers (e.g. add_random_force.cuh) that require curand_kernel.h.
+# nvcc 11.x does not support --print-search-dirs, so we check common paths.
+ifneq ($(wildcard /usr/local/cuda-11.6/include/curand_kernel.h),)
+  CUDA_INC := /usr/local/cuda-11.6/include
+else ifneq ($(wildcard /usr/local/cuda-11.7/include/curand_kernel.h),)
+  CUDA_INC := /usr/local/cuda-11.7/include
+else ifneq ($(wildcard /usr/local/cuda-11.8/include/curand_kernel.h),)
+  CUDA_INC := /usr/local/cuda-11.8/include
+else ifneq ($(wildcard /usr/local/cuda-12.2/include/curand_kernel.h),)
+  CUDA_INC := /usr/local/cuda-12.2/include
+else ifneq ($(wildcard /usr/local/cuda/include/curand_kernel.h),)
+  CUDA_INC := /usr/local/cuda/include
+else
+  # last resort: user must override
+  CUDA_INC := /usr/local/cuda/targets/x86_64-linux/include
+endif
+# CUDA library path: needed for linking cublas, cusolver, cufft, cudart
+# nvcc 11.x does not support --print-search-dirs, so we rely on pkg-config
+# or a set of common CUDA install paths.
+CUDA_LIB := $(shell \
+  pkg-config --libs cuda 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($$i ~ /^-L/) print substr($$i,3)}' | head -1 || \
+  echo '/usr/local/cuda/targets/x86_64-linux/lib')
+# As a fallback, check known CUDA 11.x locations
+ifneq ($(wildcard $(CUDA_LIB)/libcusolver.so),)
+  # path is valid
+else ifneq ($(wildcard /usr/local/cuda-11.6/targets/x86_64-linux/lib/libcusolver.so),)
+  CUDA_LIB := /usr/local/cuda-11.6/targets/x86_64-linux/lib
+else ifneq ($(wildcard /usr/local/cuda-11.7/targets/x86_64-linux/lib/libcusolver.so),)
+  CUDA_LIB := /usr/local/cuda-11.7/targets/x86_64-linux/lib
+else ifneq ($(wildcard /usr/local/cuda-12.2/targets/x86_64-linux/lib/libcusolver.so),)
+  CUDA_LIB := /usr/local/cuda-12.2/targets/x86_64-linux/lib
+else ifneq ($(wildcard /usr/local/cuda/lib64/libcusolver.so),)
+  CUDA_LIB := /usr/local/cuda/lib64
+else
+  # last resort: user must override
+endif
+# --------------------------------------------------------------
 
 
 ###########################################################
@@ -99,6 +147,39 @@ gnep: $(OBJ_GNEP)
 	@echo =================================================
 
 
+# ---- pygpumd: Python extension module for PySAGES integration ----
+# NOTE: run "make clean" before "make pygpumd" if you previously built
+# the standard gpumd executable, because this target adds -DUSE_PYSAGES
+# to CFLAGS and the object files must be recompiled.
+PYGPUMD_SRC = main_gpumd/gpumd_python.cpp
+
+ifdef OS
+PYGPUMD_OBJ = $(PYGPUMD_SRC:.cpp=.obj)
+else
+PYGPUMD_OBJ = $(PYGPUMD_SRC:.cpp=.o)
+endif
+
+# Exclude main.cu (contains int main) from the shared library.
+PY_OBJ_GPUMD = $(filter-out %/main.o %/main.obj,$(OBJ_GPUMD)) $(PYGPUMD_OBJ)
+
+# Enable PYSAGES hooks in the GPUMD core when building the Python module.
+pygpumd: CFLAGS += -DUSE_PYSAGES
+pygpumd: $(PY_OBJ_GPUMD)
+ifdef OS
+	@echo Windows Python module build not yet implemented in makefile.
+else
+	# Link with CUDA runtime (-lcudart) and set RPATH so Python can find
+	# the libraries at load time without needing LD_LIBRARY_PATH.
+	g++ -shared -fPIC $(LDFLAGS) $^ -o gpumd.so \
+	  -L$(CUDA_LIB) -Wl,-rpath,$(CUDA_LIB) \
+	  $(LIBS) -lcudart $(PYTHON_LDFLAGS)
+	@echo =================================================
+	@echo The gpumd Python module is successfully compiled!
+	@echo =================================================
+endif
+# -----------------------------------------------------------------
+
+
 ###########################################################
 # rules for building object files
 ###########################################################
@@ -148,6 +229,12 @@ main_nep/%.o: main_nep/%.cu $(HEADERS)
 	$(CC) $(CFLAGS) $(INC) -c $< -o $@
 main_gnep/%.o: main_gnep/%.cu $(HEADERS)
 	$(CC) $(CFLAGS) $(INC) -c $< -o $@
+
+# Compile the pybind11 wrapper with the host C++ compiler.
+# Do NOT pass $(CFLAGS) here — it contains nvcc-only flags (-arch, -Xcompiler).
+# We add -DUSE_PYSAGES explicitly so the wrapper sees the callback members.
+main_gpumd/%.o: main_gpumd/%.cpp $(HEADERS)
+	g++ -std=c++14 -O3 -fPIC -DUSE_PYSAGES $(PYBIND11_INC) $(PYTHON_CFLAGS) -I$(CUDA_INC) $(INC) -c $< -o $@
 endif
 
 
@@ -158,6 +245,6 @@ clean:
 ifdef OS
 	del /s *.obj *.exp *.lib *.exe
 else
-	rm -f */*.o gpumd nep gnep
+	rm -f */*.o main_gpumd/*.o gpumd nep gnep gpumd.so
 endif
 

--- a/src/utilities/gpu_vector.cuh
+++ b/src/utilities/gpu_vector.cuh
@@ -18,16 +18,21 @@
 #include "error.cuh"
 #include "gpu_macro.cuh"
 
+// Define the CUDA fill kernel only when compiling with nvcc.
+// When compiled by g++/clang++ (no __CUDACC__), gpu_fill is never
+// instantiated and fill() falls through to the CPU for-loop.
+#ifdef __CUDACC__
 namespace
 {
 template <typename T>
-void __global__ gpu_fill(const size_t size, const T value, T* data)
+__global__ void gpu_fill(const size_t size, const T value, T* data)
 {
   const int i = blockDim.x * blockIdx.x + threadIdx.x;
   if (i < size)
     data[i] = value;
 }
 } // anonymous namespace
+#endif // __CUDACC__
 
 enum class Memory_Type {
   global = 0, // global memory, also called (linear) device memory
@@ -179,10 +184,16 @@ public:
   void fill(const T value)
   {
     if (memory_type_ == Memory_Type::global) {
+#ifdef __CUDACC__
       const int block_size = 128;
       const int grid_size = (size_ + block_size - 1) / block_size;
       gpu_fill<<<grid_size, block_size>>>(size_, value, data_);
       GPU_CHECK_KERNEL
+#else
+      // Host compiler: nothing to do for global memory (only used when
+      // GPU_Vector is instantiated by nvcc; host code uses managed memory).
+      (void)value; // suppress unused-parameter warning
+#endif
     } else // managed (or unified) memory
     {
       for (int i = 0; i < size_; ++i)


### PR DESCRIPTION
## Summary

Add Python callback hook and pybind11 wrapper to enable enhanced-sampling integration with [PySAGES](https://github.com/SSAGESLabs/PySAGES). This PR adds C++ infrastructure needed to drive GPUMD from Python and receive per-step callbacks so that PySAGES can compute bias forces on the GPU and inject them back into GPUMD's MD loop.

## What changed

### C++ core (`run.cuh` / `run.cu`)

- Added `#ifdef USE_PYSAGES` guarded members to `Run`:
  - `std::function<void(int)> step_callback` — invoked every timestep after force computation and before `integrate.compute2()`.
  - `GPU_Vector<double> external_bias_per_atom` — buffer for external bias forces (N×3 doubles).
- Added accessors (`get_atom`, `get_box`, `get_time_step`, `get_number_of_steps`, `set_number_of_steps`, `execute_run`) needed by the Python wrapper.
- Added `gpu_add_external_bias` CUDA kernel that adds the bias buffer to `atom.force_per_atom`.
- The new code is **completely opt-in**: default `make gpumd` does not define `USE_PYSAGES`, so the standard executable is unchanged and requires only the CUDA toolkit.

### Python wrapper (`gpumd_python.cpp`, new)

- Exposes simulation data as **DLPack capsules** for zero-copy exchange with JAX / CuPy / PyTorch.
  - `get_positions_dlpack()`, `get_velocities_dlpack()`, `get_forces_dlpack()`, `get_masses_dlpack()`, `get_types_dlpack()`
- `set_step_callback(fn)` registers a Python callable that receives the current timestep.
- `run(steps)` executes the deferred MD loop.
- `is_box_constant()` inspects `run.in` to determine if the simulation box can change.
- `add_aos_bias_to_forces()` accepts a DLPack tensor in AOS layout and adds it directly to GPUMD's SOA `force_per_atom` via a custom CUDA kernel — no intermediate copies.
- `set_external_bias()` / `clear_external_bias()` — legacy path for backward compatibility.

### CUDA kernel (`gpumd_python_kernels.cu` / `.cuh`, new)

- `gpu_add_aos_bias_to_soa_forces_kernel`: single kernel, no extra device to device copies.

### Build system (`makefile`)

- Added `pygpumd` target that compiles the wrapper into `gpumd.so`.
  - Automatically adds `-DUSE_PYSAGES` to `CFLAGS`.
  - Handles pybind11 includes, Python config, and CUDA runtime linking.

### DLPack header (`dlpack.h`, new — vendored)

- Standard v0.8 DLPack header for zero-copy array exchange. Vendored because it is a single 200-line file with no dependencies (same approach used by JAX, PyTorch, TensorFlow).

### `gpu_vector.cuh`

- Added `#ifdef __CUDACC__` guards around the `__global__ gpu_fill` kernel so that the file can be included when compiling the wrapper with `g++`.


## Testing

- `make gpumd` — standard executable builds successfully (no Python dependencies).
- `make pygpumd` — Python module builds successfully on Linux + CUDA 11.x/12.x.

## Dependency

This PR is required by the companion PySAGES backend [PR](https://github.com/SSAGESLabs/PySAGES/pull/379) .

## Author

Jaafar Mehrez
- Shanghai Jiao Tong University, Shanghai, China
- HPQC Labs, Waterloo, Canada
- jaafarmehrez@sjtu.edu.cn, jaafar@hpqc.org