### PR TITLE
use a uniform q_scaler of 0.1 in the future

### DIFF
--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -169,7 +169,7 @@ void Fitness::compute(
         para,
         dummy_solution.data(),
         train_set[n],
-        (para.fine_tune ? false : true),
+        false,
         true,
         deviceCount);
     }

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -249,7 +249,7 @@ void Parameters::calculate_parameters()
     lambda_2 = sqrt(number_of_variables * 1.0e-6f / num_types);
   }
 
-  q_scaler_cpu.resize(dim, 1.0e10f);
+  q_scaler_cpu.resize(dim, 0.1f);
   if (fine_tune) {
     std::ifstream input(fine_tune_nep_txt);
     if (!input.is_open()) {


### PR DESCRIPTION
This seems to be better. 
* It weights 4-body and 5-body descriptors better than before.
* There will be no jump of loss upon restarting with added structures due to descriptor re-normalization.