### PR TITLE
fix reciprocal lattice vector

### DIFF
--- a/src/phonon/hessian.cu
+++ b/src/phonon/hessian.cu
@@ -55,7 +55,7 @@ namespace
     Mat3 rec;
     for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 3; ++j) {
-        rec[i][j] = 2.0 * PI * cxyz[i] * box.cpu_h[9 + i * 3 + j];
+        rec[j][i] = 2.0 * PI * cxyz[i] * box.cpu_h[9 + i * 3 + j];
       }
     }
     return rec;


### PR DESCRIPTION
In versions 5.1 and 5.2, the calculation of the reciprocal lattice vector lacks transposition.
The test directory is tests/gpumd/silicon_dispersion
The comparison is as follows,
<img width="1108" height="274" alt="image" src="https://github.com/user-attachments/assets/71cc08f3-a57f-42ff-8612-5defa28f5869" />
After correcting the code
<img width="1072" height="272" alt="image" src="https://github.com/user-attachments/assets/a2545f49-bdd5-4219-8a7e-ba229e336b98" />

For triclinic crystal systems
<img width="2140" height="1995" alt="phonon_NEP" src="https://github.com/user-attachments/assets/dcee224b-cbdc-4ab6-89c9-3bcdd05367b7" />

For monoclinic crystal systems
<img width="2119" height="1995" alt="phonon_NEP" src="https://github.com/user-attachments/assets/c46f5559-131c-4e2a-a659-0bebfabb263b" />

For orthorhombic crystal systems
<img width="2145" height="1997" alt="phonon_NEP" src="https://github.com/user-attachments/assets/209076bc-9062-44b9-9a8c-fcfe2f31dc44" />

