### PR TITLE
extend 4body descriptors 134

### DIFF
--- a/doc/nep/input_parameters/l_max.rst
+++ b/doc/nep/input_parameters/l_max.rst
@@ -8,19 +8,19 @@
 It sets the angular descriptors, see Sect. II.C of [Fan2022b]_.
 The syntax is::
 
-  l_max <l_max_3b> {<has_q_222> <has_q_1111> <has_q_112> <has_q_123> <has_q_233>}
+  l_max <l_max_3b> {<has_q_222> <has_q_1111> <has_q_112> <has_q_123> <has_q_233> <has_q_134>}
 
-where :attr:`l_max_3b` sets the limit for the three-body descriptors, :attr:`has_q_222`, :attr:`has_q_112`, :attr:`has_q_123`, and :attr:`has_q_233` optionally specify which four-body descriptors are used, and :attr:`has_q_1111` specifies if the five-body descriptor is used.
+where :attr:`l_max_3b` sets the limit for the three-body descriptors, :attr:`has_q_222`, :attr:`has_q_112`, :attr:`has_q_123`, :attr:`has_q_233`, and :attr:`has_q_134` optionally specify which four-body descriptors are used, and :attr:`has_q_1111` specifies if the five-body descriptor is used.
 
-:math:`l_\mathrm{max}^\mathrm{3b}` can take values from 2 to 8, and :attr:`has_q_222`, :attr:`has_q_1111`, :attr:`has_q_112`, :attr:`has_q_123`, and :attr:`has_q_233` can be 0 (not to use) or 1 (to use).
+:math:`l_\mathrm{max}^\mathrm{3b}` can take values from 2 to 8, and :attr:`has_q_222`, :attr:`has_q_1111`, :attr:`has_q_112`, :attr:`has_q_123`, :attr:`has_q_233`, and :attr:`has_q_134` can be 0 (not to use) or 1 (to use).
 
 The default values are::
 
-  l_max 4 1 0 0 0 0 # equivalent to l_max 4 1 or the old-style l_max 4 2
+  l_max 4 1 0 0 0 0 0 # equivalent to l_max 4 1 or the old-style l_max 4 2
   
 For high accuracy, one can try::
   
-  l_max 4 1 0 1 1 1
+  l_max 4 1 0 1 1 1 1
 
 The five-body descriptor switch :attr:`has_q_1111` is only provided for backward compatibility. 
 This five-body descriptor is equivalent to the square of two three-body descriptors and thus does not provide new information. It use is strongly discouraged.

--- a/src/force/nep.cu
+++ b/src/force/nep.cu
@@ -236,7 +236,7 @@ NEP::NEP(const char* file_potential, const int num_atoms)
   // l_max
   tokens = get_tokens(input);
   if (tokens.size() < 4) {
-    std::cout << "This line should be l_max l_max_3body has_q_222 has_q_1111 [has_q_112] [has_q_123] [has_q_233]." << std::endl;
+    std::cout << "This line should be l_max l_max_3body has_q_222 has_q_1111 [has_q_112] [has_q_123] [has_q_233] [has_q_134]." << std::endl;
     exit(1);
   }
 
@@ -255,11 +255,15 @@ NEP::NEP(const char* file_potential, const int num_atoms)
   if (tokens.size() >= 7) {
     paramb.has_q_233 = get_int_from_token(tokens[6], __FILE__, __LINE__);
   }
+  if (tokens.size() >= 8) {
+    paramb.has_q_134 = get_int_from_token(tokens[7], __FILE__, __LINE__);
+  }
   printf("    has_q_222 = %d.\n", paramb.has_q_222);
   printf("    has_q_1111 = %d.\n", paramb.has_q_1111);
   printf("    has_q_112 = %d.\n", paramb.has_q_112);
   printf("    has_q_123 = %d.\n", paramb.has_q_123);
   printf("    has_q_233 = %d.\n", paramb.has_q_233);
+  printf("    has_q_134 = %d.\n", paramb.has_q_134);
   if (paramb.has_q_222) {
     paramb.num_L += 1;
   }
@@ -273,6 +277,9 @@ NEP::NEP(const char* file_potential, const int num_atoms)
     paramb.num_L += 1;
   }
   if (paramb.has_q_233) {
+    paramb.num_L += 1;
+  }
+  if (paramb.has_q_134) {
     paramb.num_L += 1;
   }
 
@@ -531,7 +538,7 @@ static __global__ void find_descriptor(
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
       }
       find_q(
-        paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+        paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
@@ -796,7 +803,7 @@ static __global__ void find_partial_force_angular(
         }
         accumulate_f12(
           paramb.L_max,
-          paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+          paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
           paramb.num_L,
           n,
           paramb.n_max_angular + 1,
@@ -1424,7 +1431,7 @@ static __global__ void find_descriptor(
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
       }
       find_q(
-        paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+        paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];

--- a/src/force/nep.cuh
+++ b/src/force/nep.cuh
@@ -60,6 +60,7 @@ public:
     int has_q_112 = 0;
     int has_q_123 = 0;
     int has_q_233 = 0;
+    int has_q_134 = 0;
     int num_L;
     int basis_size_radial = 8;  // for nep3
     int basis_size_angular = 8; // for nep3

--- a/src/force/nep_charge.cu
+++ b/src/force/nep_charge.cu
@@ -241,7 +241,7 @@ NEP_Charge::NEP_Charge(const char* file_potential, const int num_atoms)
   // l_max
   tokens = get_tokens(input);
   if (tokens.size() < 4) {
-    std::cout << "This line should be l_max l_max_3body has_q_222 has_q_1111 [has_q_112] [has_q_123] [has_q_233]." << std::endl;
+    std::cout << "This line should be l_max l_max_3body has_q_222 has_q_1111 [has_q_112] [has_q_123] [has_q_233] [has_q_134]." << std::endl;
     exit(1);
   }
 
@@ -260,11 +260,15 @@ NEP_Charge::NEP_Charge(const char* file_potential, const int num_atoms)
   if (tokens.size() >= 7) {
     paramb.has_q_233 = get_int_from_token(tokens[6], __FILE__, __LINE__);
   }
+  if (tokens.size() >= 8) {
+    paramb.has_q_134 = get_int_from_token(tokens[7], __FILE__, __LINE__);
+  }
   printf("    has_q_222 = %d.\n", paramb.has_q_222);
   printf("    has_q_1111 = %d.\n", paramb.has_q_1111);
   printf("    has_q_112 = %d.\n", paramb.has_q_112);
   printf("    has_q_123 = %d.\n", paramb.has_q_123);
   printf("    has_q_233 = %d.\n", paramb.has_q_233);
+  printf("    has_q_134 = %d.\n", paramb.has_q_134);
   if (paramb.has_q_222) {
     paramb.num_L += 1;
   }
@@ -278,6 +282,9 @@ NEP_Charge::NEP_Charge(const char* file_potential, const int num_atoms)
     paramb.num_L += 1;
   }
   if (paramb.has_q_233) {
+    paramb.num_L += 1;
+  }
+  if (paramb.has_q_134) {
     paramb.num_L += 1;
   }
 
@@ -525,7 +532,7 @@ static __global__ void find_descriptor(
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
       }
       find_q(
-        paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+        paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
@@ -796,7 +803,7 @@ static __global__ void find_bec_angular(
         }
         accumulate_f12(
           paramb.L_max,
-          paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+          paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
           paramb.num_L,
           n,
           paramb.n_max_angular + 1,
@@ -1031,7 +1038,7 @@ static __global__ void find_partial_force_angular(
         }
         accumulate_f12(
           paramb.L_max,
-          paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+          paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
           paramb.num_L,
           n,
           paramb.n_max_angular + 1,

--- a/src/force/nep_charge.cuh
+++ b/src/force/nep_charge.cuh
@@ -73,6 +73,7 @@ public:
     int has_q_112 = 0;
     int has_q_123 = 0;
     int has_q_233 = 0;
+    int has_q_134 = 0;
     int num_L;
     int basis_size_radial = 8;  // for nep3
     int basis_size_angular = 8; // for nep3

--- a/src/force/nep_charge_small_box.cuh
+++ b/src/force/nep_charge_small_box.cuh
@@ -206,7 +206,7 @@ static __global__ void find_descriptor_small_box(
         accumulate_s(paramb.L_max, d12, r12[0], r12[1], r12[2], gn12, s);
       }
       find_q(
-        paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+        paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
@@ -573,7 +573,7 @@ static __global__ void find_force_angular_small_box(
         }
         accumulate_f12(
           paramb.L_max,
-          paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+          paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
           paramb.num_L,
           n,
           paramb.n_max_angular + 1,
@@ -764,7 +764,7 @@ static __global__ void find_bec_angular_small_box(
         }
         accumulate_f12(
           paramb.L_max,
-          paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+          paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
           paramb.num_L,
           n,
           paramb.n_max_angular + 1,

--- a/src/force/nep_multigpu.cu
+++ b/src/force/nep_multigpu.cu
@@ -239,7 +239,7 @@ NEP_MULTIGPU::NEP_MULTIGPU(
   // l_max
   tokens = get_tokens(input);
   if (tokens.size() < 4) {
-    std::cout << "This line should be l_max l_max_3body has_q_222 has_q_1111 [has_q_112] [has_q_123] [has_q_233]." << std::endl;
+    std::cout << "This line should be l_max l_max_3body has_q_222 has_q_1111 [has_q_112] [has_q_123] [has_q_233] [has_q_134]." << std::endl;
     exit(1);
   }
 
@@ -258,11 +258,15 @@ NEP_MULTIGPU::NEP_MULTIGPU(
   if (tokens.size() >= 7) {
     paramb.has_q_233 = get_int_from_token(tokens[6], __FILE__, __LINE__);
   }
+  if (tokens.size() >= 8) {
+    paramb.has_q_134 = get_int_from_token(tokens[7], __FILE__, __LINE__);
+  }
   printf("    has_q_222 = %d.\n", paramb.has_q_222);
   printf("    has_q_1111 = %d.\n", paramb.has_q_1111);
   printf("    has_q_112 = %d.\n", paramb.has_q_112);
   printf("    has_q_123 = %d.\n", paramb.has_q_123);
   printf("    has_q_233 = %d.\n", paramb.has_q_233);
+  printf("    has_q_134 = %d.\n", paramb.has_q_134);
   if (paramb.has_q_222) {
     paramb.num_L += 1;
   }
@@ -276,6 +280,9 @@ NEP_MULTIGPU::NEP_MULTIGPU(
     paramb.num_L += 1;
   }
   if (paramb.has_q_233) {
+    paramb.num_L += 1;
+  }
+  if (paramb.has_q_134) {
     paramb.num_L += 1;
   }
 
@@ -867,7 +874,7 @@ static __global__ void find_descriptor(
         }
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
       }
-      find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+      find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
@@ -1114,7 +1121,7 @@ static __global__ void find_partial_force_angular(
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
-        accumulate_f12(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+        accumulate_f12(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
           paramb.num_L, n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
       }
       g_f12x[index] = f12[0];
@@ -1876,7 +1883,7 @@ static __global__ void find_descriptor(
         }
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
       }
-      find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+      find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];

--- a/src/force/nep_multigpu.cuh
+++ b/src/force/nep_multigpu.cuh
@@ -91,6 +91,7 @@ public:
     int has_q_112 = 0;
     int has_q_123 = 0;
     int has_q_233 = 0;
+    int has_q_134 = 0;
     int dim_angular;
     int num_L;
     int basis_size_radial = 8;  // for nep3

--- a/src/force/nep_small_box.cuh
+++ b/src/force/nep_small_box.cuh
@@ -210,7 +210,7 @@ static __global__ void find_descriptor_small_box(
         accumulate_s(paramb.L_max, d12, r12[0], r12[1], r12[2], gn12, s);
       }
       find_q(
-        paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+        paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
@@ -367,7 +367,7 @@ static __global__ void find_descriptor_small_box(
         accumulate_s(paramb.L_max, d12, r12[0], r12[1], r12[2], gn12, s);
       }
       find_q(
-        paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+        paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
@@ -553,7 +553,7 @@ static __global__ void find_force_angular_small_box(
         }
         accumulate_f12(
           paramb.L_max,
-          paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+          paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
           paramb.num_L,
           n,
           paramb.n_max_angular + 1,

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -382,14 +382,17 @@ void Fitness::write_nep_txt(FILE* fid_nep, Parameters& para, float* elite)
   fprintf(fid_nep, "n_max %d %d\n", para.n_max_radial, para.n_max_angular);
   fprintf(fid_nep, "basis_size %d %d\n", para.basis_size_radial, para.basis_size_angular);
   fprintf(fid_nep, "l_max %d %d %d ", para.L_max, (para.has_q_222 ? 2 : 0), para.has_q_1111);
-  if (para.has_q_112 || para.has_q_123 || para.has_q_233) {
+  if (para.has_q_112 || para.has_q_123 || para.has_q_233 || para.has_q_134) {
     fprintf(fid_nep, "%d ", para.has_q_112);
   }
-  if (para.has_q_123 || para.has_q_233) {
+  if (para.has_q_123 || para.has_q_233 || para.has_q_134) {
     fprintf(fid_nep, "%d ", para.has_q_123);
   }
-  if (para.has_q_233) {
+  if (para.has_q_233 || para.has_q_134) {
     fprintf(fid_nep, "%d ", para.has_q_233);
+  }
+  if (para.has_q_134) {
+    fprintf(fid_nep, "%d ", para.has_q_134);
   }
   fprintf(fid_nep, "\n");
 

--- a/src/main_nep/nep.cu
+++ b/src/main_nep/nep.cu
@@ -124,7 +124,7 @@ static __global__ void find_descriptors_angular(
         }
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
       }
-      find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.n_max_angular + 1, n, s, q);
+      find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134, paramb.n_max_angular + 1, n, s, q);
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
       }
@@ -163,6 +163,7 @@ NEP::NEP(
   paramb.has_q_112 = para.has_q_112;
   paramb.has_q_123 = para.has_q_123;
   paramb.has_q_233 = para.has_q_233;
+  paramb.has_q_134 = para.has_q_134;
   paramb.num_L = paramb.L_max;
   if (para.has_q_222) {
     paramb.num_L += 1;
@@ -177,6 +178,9 @@ NEP::NEP(
     paramb.num_L += 1;
   }
   if (para.has_q_233) {
+    paramb.num_L += 1;
+  }
+  if (para.has_q_134) {
     paramb.num_L += 1;
   }
   paramb.dim_angular = (para.n_max_angular + 1) * paramb.num_L;
@@ -533,7 +537,7 @@ static __global__ void find_force_angular(
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
-        accumulate_f12(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, 
+        accumulate_f12(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134, 
           paramb.num_L, n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
       }
 

--- a/src/main_nep/nep.cuh
+++ b/src/main_nep/nep.cuh
@@ -46,6 +46,7 @@ public:
     int has_q_112;
     int has_q_123;
     int has_q_233;
+    int has_q_134;
     int num_L;
     int num_types = 0;
     int num_types_sq = 0;

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -124,7 +124,7 @@ static __global__ void find_descriptors_angular(
         }
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
       }
-      find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.n_max_angular + 1, n, s, q);
+      find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134, paramb.n_max_angular + 1, n, s, q);
       for (int abc = 0; abc < NUM_OF_ABC; ++abc) {
         g_sum_fxyz[(n * NUM_OF_ABC + abc) * N + n1] = s[abc];
       }
@@ -163,6 +163,7 @@ NEP_Charge::NEP_Charge(
   paramb.has_q_112 = para.has_q_112;
   paramb.has_q_123 = para.has_q_123;
   paramb.has_q_233 = para.has_q_233;
+  paramb.has_q_134 = para.has_q_134;
   paramb.num_L = paramb.L_max;
   if (para.has_q_222) {
     paramb.num_L += 1;
@@ -177,6 +178,9 @@ NEP_Charge::NEP_Charge(
     paramb.num_L += 1;
   }
   if (para.has_q_233) {
+    paramb.num_L += 1;
+  }
+  if (para.has_q_134) {
     paramb.num_L += 1;
   }
   paramb.dim_angular = (para.n_max_angular + 1) * paramb.num_L;
@@ -525,7 +529,7 @@ static __global__ void find_force_angular(
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
-        accumulate_f12(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, 
+        accumulate_f12(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134, 
           paramb.num_L, n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
       }
 
@@ -683,7 +687,7 @@ static __global__ void find_bec_angular(
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
-        accumulate_f12(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, 
+        accumulate_f12(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134, 
           paramb.num_L, n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
       }
 

--- a/src/main_nep/nep_charge.cuh
+++ b/src/main_nep/nep_charge.cuh
@@ -40,6 +40,7 @@ public:
     int has_q_112;
     int has_q_123;
     int has_q_233;
+    int has_q_134;
     int num_L;
     int num_types = 0;
     int num_types_sq = 0;

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -91,6 +91,7 @@ void Parameters::set_default_parameters()
   has_q_112 = 0;               // default is not to include q_112
   has_q_123 = 0;               // default is not to include q_123
   has_q_233 = 0;               // default is not to include q_233
+  has_q_134 = 0;               // default is not to include q_233
   num_neurons1 = 30;           // a relatively small value to achieve high speed
   lambda_1 = lambda_2 = -1.0f; // automatic regularization
   lambda_e = lambda_f = 1.0f;  // energy and force are more important
@@ -217,6 +218,9 @@ void Parameters::calculate_parameters()
     dim_angular += n_max_angular + 1;
   }
   if (has_q_233) {
+    dim_angular += n_max_angular + 1;
+  }
+  if (has_q_134) {
     dim_angular += n_max_angular + 1;
   }
 
@@ -485,6 +489,7 @@ void Parameters::report_inputs()
     printf("    (input)   has_q_112 = %d.\n", has_q_112);
     printf("    (input)   has_q_123 = %d.\n", has_q_123);
     printf("    (input)   has_q_233 = %d.\n", has_q_233);
+    printf("    (input)   has_q_134 = %d.\n", has_q_134);
   } else {
     printf("    (default) l_max_3body = %d.\n", L_max);
     printf("    (default) has_q_222 = %d.\n", has_q_222);
@@ -492,6 +497,7 @@ void Parameters::report_inputs()
     printf("    (default) has_q_112 = %d.\n", has_q_112);
     printf("    (default) has_q_123 = %d.\n", has_q_123);
     printf("    (default) has_q_233 = %d.\n", has_q_233);
+    printf("    (default) has_q_134 = %d.\n", has_q_134);
   }
 
   if (is_neuron_set) {
@@ -953,8 +959,8 @@ void Parameters::parse_l_max(const char** param, int num_param)
 {
   is_l_max_set = true;
 
-  if (num_param < 2 || num_param > 7) {
-    PRINT_INPUT_ERROR("l_max should have 1 to 6 parameters.\n");
+  if (num_param < 2 || num_param > 8) {
+    PRINT_INPUT_ERROR("l_max should have 1 to 7 parameters.\n");
   }
   if (!is_valid_int(param[1], &L_max)) {
     PRINT_INPUT_ERROR("l_max for 3-body descriptors should be an integer.\n");
@@ -995,6 +1001,13 @@ void Parameters::parse_l_max(const char** param, int num_param)
       PRINT_INPUT_ERROR("has_q_233 should be an integer.\n");
     }
   }
+
+  if (num_param >= 8) {
+    if (!is_valid_int(param[7], &has_q_134)) {
+      PRINT_INPUT_ERROR("has_q_134 should be an integer.\n");
+    }
+  }
+
 }
 
 void Parameters::parse_neuron(const char** param, int num_param)

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -91,7 +91,7 @@ void Parameters::set_default_parameters()
   has_q_112 = 0;               // default is not to include q_112
   has_q_123 = 0;               // default is not to include q_123
   has_q_233 = 0;               // default is not to include q_233
-  has_q_134 = 0;               // default is not to include q_233
+  has_q_134 = 0;               // default is not to include q_134
   num_neurons1 = 30;           // a relatively small value to achieve high speed
   lambda_1 = lambda_2 = -1.0f; // automatic regularization
   lambda_e = lambda_f = 1.0f;  // energy and force are more important

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -46,6 +46,7 @@ public:
   int has_q_112;          // has q_112
   int has_q_123;          // has q_123
   int has_q_233;          // has q_233
+  int has_q_134;          // has q_134
   float lambda_1;         // weight parameter for L1 regularization loss
   float lambda_2;         // weight parameter for L2 regularization loss
   float lambda_e;         // weight parameter for energy RMSE loss

--- a/src/main_nep/tnep.cu
+++ b/src/main_nep/tnep.cu
@@ -126,7 +126,7 @@ static __global__ void find_descriptors_angular(
         }
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
       }
-      find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.n_max_angular + 1, n, s, q);
+      find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134, paramb.n_max_angular + 1, n, s, q);
       for (int abc = 0; abc < NUM_OF_ABC; ++abc) {
         g_sum_fxyz[(n * NUM_OF_ABC + abc) * N + n1] = s[abc];
       }
@@ -163,6 +163,7 @@ TNEP::TNEP(
   paramb.has_q_112 = para.has_q_112;
   paramb.has_q_123 = para.has_q_123;
   paramb.has_q_233 = para.has_q_233;
+  paramb.has_q_134 = para.has_q_134;
   paramb.num_L = paramb.L_max;
   if (para.has_q_222) {
     paramb.num_L += 1;
@@ -177,6 +178,9 @@ TNEP::TNEP(
     paramb.num_L += 1;
   }
   if (para.has_q_233) {
+    paramb.num_L += 1;
+  }
+  if (para.has_q_134) {
     paramb.num_L += 1;
   }
   paramb.dim_angular = (para.n_max_angular + 1) * paramb.num_L;
@@ -584,7 +588,7 @@ static __global__ void find_force_angular(
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
-        accumulate_f12(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, 
+        accumulate_f12(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134, 
           paramb.num_L, n, paramb.n_max_angular + 1, d12, r12, gn12, gnp12, Fp, sum_fxyz, f12);
       }
 

--- a/src/main_nep/tnep.cuh
+++ b/src/main_nep/tnep.cuh
@@ -44,6 +44,7 @@ public:
     int has_q_112;
     int has_q_123;
     int has_q_233;
+    int has_q_134;
     int num_L;
     int num_types = 0;
     int num_types_sq = 0;

--- a/src/mc/nep_energy.cu
+++ b/src/mc/nep_energy.cu
@@ -196,7 +196,7 @@ void NEP_Energy::initialize(const char* file_potential)
   // l_max
   tokens = get_tokens(input);
   if (tokens.size() < 4) {
-    std::cout << "This line should be l_max l_max_3body has_q_222 has_q_1111 [has_q_112] [has_q_123] [has_q_233]." << std::endl;
+    std::cout << "This line should be l_max l_max_3body has_q_222 has_q_1111 [has_q_112] [has_q_123] [has_q_233] [has_q_134]." << std::endl;
     exit(1);
   }
 
@@ -215,11 +215,15 @@ void NEP_Energy::initialize(const char* file_potential)
   if (tokens.size() >= 7) {
     paramb.has_q_233 = get_int_from_token(tokens[6], __FILE__, __LINE__);
   }
+  if (tokens.size() >= 8) {
+    paramb.has_q_134 = get_int_from_token(tokens[7], __FILE__, __LINE__);
+  }
   printf("    has_q_222 = %d.\n", paramb.has_q_222);
   printf("    has_q_1111 = %d.\n", paramb.has_q_1111);
   printf("    has_q_112 = %d.\n", paramb.has_q_112);
   printf("    has_q_123 = %d.\n", paramb.has_q_123);
   printf("    has_q_233 = %d.\n", paramb.has_q_233);
+  printf("    has_q_134 = %d.\n", paramb.has_q_134);
   if (paramb.has_q_222) {
     paramb.num_L += 1;
   }
@@ -233,6 +237,9 @@ void NEP_Energy::initialize(const char* file_potential)
     paramb.num_L += 1;
   }
   if (paramb.has_q_233) {
+    paramb.num_L += 1;
+  }
+  if (paramb.has_q_134) {
     paramb.num_L += 1;
   }
 
@@ -390,7 +397,7 @@ static __global__ void find_energy_nep(
         }
         accumulate_s(paramb.L_max, d12, r12[0], r12[1], r12[2], gn12, s);
       }
-      find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233,
+      find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
     }
 

--- a/src/mc/nep_energy.cuh
+++ b/src/mc/nep_energy.cuh
@@ -40,6 +40,7 @@ public:
     int has_q_112 = 0;
     int has_q_123 = 0;
     int has_q_233 = 0;
+    int has_q_134 = 0;
     int num_L;
     int basis_size_radial = 8;  // for nep3
     int basis_size_angular = 8; // for nep3

--- a/src/utilities/nep_utilities.cuh
+++ b/src/utilities/nep_utilities.cuh
@@ -70,7 +70,19 @@ __constant__ float C4B_233[10] = {
   0.038576792858337f, 
   0.128589309527790f, 
   0.192883964291685f, 
-  0.321473273819474};
+  0.321473273819474f};
+
+__constant__ float C4B_134[10] = {
+  0.003645164295772f, 
+  0.004860219061029f, 
+  0.006075273826286f, 
+  0.018225821478859f, 
+  0.024301095305146f,
+  0.036451642957719f, 
+  0.042526916784005f, 
+  0.072903285915437f, 
+  0.085053833568010f, 
+  0.255161500704030f};
 
 __constant__ float Z_COEFFICIENT_1[2][2] = {{0.0f, 1.0f}, {1.0f, 0.0f}};
 
@@ -1063,6 +1075,224 @@ static __device__ __forceinline__ void get_f12_4body_233(
     f12[2] += tmp1 * r12[2];
 }
 
+static __device__ __forceinline__ void get_f12_4body_134(
+  const float d12,
+  const float d12inv,
+  const float fn1,
+  const float fnp1,
+  const float fn3,
+  const float fnp3,
+  const float fn4,
+  const float fnp4,
+  const float Fp,
+  const float* s1,
+  const float* s3,
+  const float* s4,
+  const float* r12,
+  float* f12)
+{
+  // s1
+  float fn_factor = Fp * fn1;
+  float fnp_factor = Fp * fnp1 * d12inv;
+
+  // derivative wrt s1[0]
+  float tmp0 = C4B_134[1] * s4[0] * s3[0] +
+               C4B_134[5] * (s3[2] * s4[2] + s4[1] * s3[1]) +
+               C4B_134[7] * (s3[3] * s4[3] + s3[4] * s4[4]) +
+               C4B_134[8] * (s3[5] * s4[5] + s3[6] * s4[6]);
+  float tmp1 = tmp0 * r12[2] * fnp_factor;
+  float tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0];
+  f12[1] += tmp1 * r12[1];
+  f12[2] += tmp1 * r12[2] + tmp2;
+
+  // derivative wrt s1[1]
+  tmp0 = -C4B_134[0] * s4[0] * s3[1] +
+         C4B_134[2] * (-s3[5] * s4[3] - s3[6] * s4[4]) +
+         C4B_134[3] * (s3[2] * s4[4] + s4[3] * s3[1]) +
+         C4B_134[4] * s4[1] * s3[0] +
+         C4B_134[5] * (-s3[3] * s4[1] - s3[4] * s4[2]) +
+         C4B_134[6] * (s3[5] * s4[7] + s3[6] * s4[8]) +
+         C4B_134[9] * (s3[3] * s4[5] + s3[4] * s4[6]);
+  tmp1 = tmp0 * r12[0] * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] + tmp2;
+  f12[1] += tmp1 * r12[1];
+  f12[2] += tmp1 * r12[2];
+
+  // derivative wrt s1[2]
+  tmp0 = -C4B_134[0] * s3[2] * s4[0] +
+         C4B_134[2] * (-s3[6] * s4[3] + s3[5] * s4[4]) +
+         C4B_134[3] * (-s3[2] * s4[3] + s4[4] * s3[1]) +
+         C4B_134[4] * s4[2] * s3[0] +
+         C4B_134[5] * (-s3[4] * s4[1] + s3[3] * s4[2]) +
+         C4B_134[6] * (-s3[6] * s4[7] + s3[5] * s4[8]) +
+         C4B_134[9] * (-s3[4] * s4[5] + s3[3] * s4[6]);
+  tmp1 = tmp0 * r12[1] * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0];
+  f12[1] += tmp1 * r12[1] + tmp2;
+  f12[2] += tmp1 * r12[2];
+
+  // s3
+  fn_factor = Fp * fn3;
+  fnp_factor = Fp * fnp3 * d12inv;
+
+  // derivative wrt s3[0]
+  tmp0 = C4B_134[1] * s1[0] * s4[0] +
+         C4B_134[4] * (s1[1] * s4[1] + s1[2] * s4[2]);
+  tmp1 = tmp0 * (5.0f * r12[2] * r12[2] - 3.0f * d12 * d12) * r12[2] * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] - tmp2 * 6.0f * r12[2] * r12[0];
+  f12[1] += tmp1 * r12[1] - tmp2 * 6.0f * r12[2] * r12[1];
+  f12[2] += tmp1 * r12[2] + tmp2 * (9.0f * r12[2] * r12[2] - 3.0f * d12 * d12);
+
+  // derivative wrt s3[1]
+  tmp0 = -C4B_134[0] * s1[1] * s4[0] +
+         C4B_134[3] * (s1[1] * s4[3] + s1[2] * s4[4]) +
+         C4B_134[5] * s1[0] * s4[1];
+  tmp1 = tmp0 * (5.0f * r12[2] * r12[2] - d12 * d12) * r12[0] * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] + tmp2 * (4.0f * r12[2] * r12[2] - 3.0f * r12[0] * r12[0] - r12[1] * r12[1]);
+  f12[1] += tmp1 * r12[1] - tmp2 * (2.0f * r12[0] * r12[1]);
+  f12[2] += tmp1 * r12[2] + tmp2 * (8.0f * r12[0] * r12[2]);
+
+  // derivative wrt s3[2]
+  tmp0 = -C4B_134[0] * s4[0] * s1[2] +
+         C4B_134[3] * (-s4[3] * s1[2] + s1[1] * s4[4]) +
+         C4B_134[5] * s1[0] * s4[2];
+  tmp1 = tmp0 * (5.0f * r12[2] * r12[2] - d12 * d12) * r12[1]  * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] - tmp2 * (2.0f * r12[0] * r12[1]);
+  f12[1] += tmp1 * r12[1] + tmp2 * (4.0f * r12[2] * r12[2] - r12[0] * r12[0] - 3.0f * r12[1] * r12[1]);
+  f12[2] += tmp1 * r12[2] + tmp2 * (8.0f * r12[1] * r12[2]);
+
+  // derivative wrt s3[3]
+  tmp0 = C4B_134[5] * (-s1[1] * s4[1] + s1[2] * s4[2]) +
+         C4B_134[7] * s1[0] * s4[3] +
+         C4B_134[9] * (s1[1] * s4[5] + s1[2] * s4[6]);
+  tmp1 = tmp0 * (r12[0] * r12[0] - r12[1] * r12[1]) * r12[2] * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] + tmp2 * (2.0f * r12[0] * r12[2]);
+  f12[1] += tmp1 * r12[1] - tmp2 * (2.0f * r12[1] * r12[2]);
+  f12[2] += tmp1 * r12[2] + tmp2 * (r12[0] * r12[0] - r12[1] * r12[1]);
+
+  // derivative wrt s3[4]
+  tmp0 = C4B_134[5] * (-s1[1] * s4[2] - s1[2] * s4[1]) +
+         C4B_134[7] * s1[0] * s4[4] +
+         C4B_134[9] * (s1[1] * s4[6] - s1[2] * s4[5]);
+  tmp1 = tmp0 * (2.0f * r12[0] * r12[1] * r12[2]) * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] + tmp2 * (2.0f * r12[1] * r12[2]);
+  f12[1] += tmp1 * r12[1] + tmp2 * (2.0f * r12[0] * r12[2]);
+  f12[2] += tmp1 * r12[2] + tmp2 * (2.0f * r12[0] * r12[1]);
+
+  // derivative wrt s3[5]
+  tmp0 = C4B_134[2] * (-s1[1] * s4[3] + s1[2] * s4[4]) +
+         C4B_134[6] * (s1[1] * s4[7] + s1[2] * s4[8]) +
+         C4B_134[8] * s1[0] * s4[5];
+  tmp1 = tmp0 * (r12[0] * r12[0] - 3.0f * r12[1] * r12[1]) * r12[0] * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] + tmp2 * (3.0f * (r12[0] * r12[0] - r12[1] * r12[1]));
+  f12[1] += tmp1 * r12[1] - tmp2 * (6.0f * r12[0] * r12[1]);
+  f12[2] += tmp1 * r12[2];
+
+  // derivative wrt s3[6]
+  tmp0 = C4B_134[2] * (-s1[1] * s4[4] - s1[2] * s4[3]) +
+         C4B_134[6] * (s1[1] * s4[8] - s1[2] * s4[7]) +
+         C4B_134[8] * s1[0] * s4[6];
+  tmp1 = tmp0 * (3.0f * r12[0] * r12[0] - r12[1] * r12[1]) * r12[1] * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] + tmp2 * (6.0f * r12[0] * r12[1]);
+  f12[1] += tmp1 * r12[1] + tmp2 * (3.0f * (r12[0] * r12[0] - r12[1] * r12[1]));
+  f12[2] += tmp1 * r12[2];
+
+  // s4
+  fn_factor = Fp * fn4;
+  fnp_factor = Fp * fnp4 * d12inv;
+
+  // derivative wrt s4[0]
+  tmp0 = C4B_134[0] * (-s3[2] * s1[2] - s1[1] * s3[1]) +
+         C4B_134[1] * s1[0] * s3[0];
+  tmp1 = tmp0 * (35.0f * r12[2] * r12[2] * r12[2] * r12[2] - 30.0f * d12 * d12 * r12[2] * r12[2] + 3.0f * d12 * d12 * d12 * d12) * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] + tmp2 * 12.0f * r12[0] * (r12[0] * r12[0] + r12[1] * r12[1] - 4.0f * r12[2] * r12[2]);
+  f12[1] += tmp1 * r12[1] + tmp2 * 12.0f * r12[1] * (r12[0] * r12[0] + r12[1] * r12[1] - 4.0f * r12[2] * r12[2]);
+  f12[2] += tmp1 * r12[2] + tmp2 * 16.0f * r12[2] * (-3.0f * r12[0] * r12[0] - 3.0f * r12[1] * r12[1] + 2.0f * r12[2] * r12[2]);
+
+  // derivative wrt s4[1]
+  tmp0 = C4B_134[4] * s1[1] * s3[0] +
+         C4B_134[5] * (s1[0] * s3[1] - s1[1] * s3[3] - s1[2] * s3[4]);
+  tmp1 = tmp0 * (7.0f * r12[2] * r12[2] - 3.0f * d12 * d12) * r12[0] * r12[2] * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] + tmp2 * r12[2] * (-9.0f * r12[0] * r12[0] - 3.0f * r12[1] * r12[1] + 4.0f * r12[2] * r12[2]);
+  f12[1] += tmp1 * r12[1] - tmp2 * 6.0f * r12[0] * r12[1] * r12[2];
+  f12[2] += tmp1 * r12[2] - tmp2 * 3.0f * r12[0] * (r12[0] * r12[0] + r12[1] * r12[1] - 4.0f * r12[2] * r12[2]);
+
+  // derivative wrt s4[2]
+  tmp0 = C4B_134[4] * s1[2] * s3[0] +
+         C4B_134[5] * (s1[0] * s3[2] - s1[1] * s3[4] + s1[2] * s3[3]);
+  tmp1 = tmp0 * (7.0f * r12[2] * r12[2] - 3.0f * d12 * d12) * r12[1] * r12[2] * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] - tmp2 * 6.0f * r12[0] * r12[1] * r12[2];
+  f12[1] += tmp1 * r12[1] + tmp2 * r12[2] * (-3.0f * r12[0] * r12[0] - 9.0f * r12[1] * r12[1] + 4.0f * r12[2] * r12[2]);
+  f12[2] += tmp1 * r12[2] - tmp2 * 3.0f * r12[1] * (r12[0] * r12[0] + r12[1] * r12[1] - 4.0f * r12[2] * r12[2]);
+
+  // derivative wrt s4[3]
+  tmp0 = C4B_134[2] * (-s1[1] * s3[5] - s1[2] * s3[6]) +
+         C4B_134[3] * (-s3[2] * s1[2] + s1[1] * s3[1]) +
+         C4B_134[7] * s1[0] * s3[3];
+  tmp1 = tmp0 * (7.0f * r12[2] * r12[2] - d12 * d12) * (r12[0] * r12[0] - r12[1] * r12[1]) * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] - tmp2 * 4.0f * r12[0] * (r12[0] * r12[0] - 3.0f * r12[2] * r12[2]);
+  f12[1] += tmp1 * r12[1] + tmp2 * 4.0f * r12[1] * (r12[1] * r12[1] - 3.0f * r12[2] * r12[2]);
+  f12[2] += tmp1 * r12[2] + tmp2 * 12.0f * r12[2] * (r12[0] * r12[0] - r12[1] * r12[1]);
+
+  // derivative wrt s4[4]
+  tmp0 = C4B_134[2] * (-s1[1] * s3[6] + s1[2] * s3[5]) +
+         C4B_134[3] * (s1[1] * s3[2] + s1[2] * s3[1]) +
+         C4B_134[7] * s1[0] * s3[4];
+  tmp1 = tmp0 * (7.0f * r12[2] * r12[2] - d12 * d12) * 2.0f * r12[0] * r12[1] * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] - tmp2 * 2.0f * r12[1] * (3.0f * r12[0] * r12[0] + r12[1] * r12[1] - 6.0f * r12[2] * r12[2]);
+  f12[1] += tmp1 * r12[1] - tmp2 * 2.0f * r12[0] * (r12[0] * r12[0] + 3.0f * r12[1] * r12[1] - 6.0f * r12[2] * r12[2]);
+  f12[2] += tmp1 * r12[2] + tmp2 * 24.0f * r12[0] * r12[1] * r12[2];
+
+  // derivative wrt s4[5]
+  tmp0 = C4B_134[8] * s1[0] * s3[5] +
+         C4B_134[9] * (s1[1] * s3[3] - s1[2] * s3[4]);
+  tmp1 = tmp0 * (r12[0] * r12[0] - 3.0f * r12[1] * r12[1]) * r12[0] * r12[2] * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] + tmp2 * 3.0f * r12[2] * (r12[0] * r12[0] - r12[1] * r12[1]);
+  f12[1] += tmp1 * r12[1] - tmp2 * 6.0f * r12[0] * r12[1] * r12[2];
+  f12[2] += tmp1 * r12[2] + tmp2 * r12[0] * (r12[0] * r12[0] - 3.0f * r12[1] * r12[1]);
+
+  // derivative wrt s4[6]
+  tmp0 = C4B_134[8] * s1[0] * s3[6] +
+         C4B_134[9] * (s1[1] * s3[4] + s1[2] * s3[3]);
+  tmp1 = tmp0 * (3.0f * r12[0] * r12[0] - r12[1] * r12[1]) * r12[1] * r12[2] * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] + tmp2 * 6.0f * r12[0] * r12[1] * r12[2];
+  f12[1] += tmp1 * r12[1] + tmp2 * 3.0f * r12[2] * (r12[0] * r12[0] - r12[1] * r12[1]);
+  f12[2] += tmp1 * r12[2] + tmp2 * r12[1] * (3.0f * r12[0] * r12[0] - r12[1] * r12[1]);
+
+  // derivative wrt s4[7]
+  tmp0 = C4B_134[6] * (s1[1] * s3[5] - s1[2] * s3[6]);
+  tmp1 = tmp0 * (r12[0] * r12[0] * r12[0] * r12[0] - 6.0f * r12[0] * r12[0] * r12[1] * r12[1] + r12[1] * r12[1] * r12[1] * r12[1]) * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] + tmp2 * 4.0f * r12[0] * (r12[0] * r12[0] - 3.0f * r12[1] * r12[1]);
+  f12[1] += tmp1 * r12[1] + tmp2 * 4.0f * r12[1] * (-3.0f * r12[0] * r12[0] + r12[1] * r12[1]);
+  f12[2] += tmp1 * r12[2];
+
+  // derivative wrt s4[8]
+  tmp0 = C4B_134[6] * (s1[1] * s3[6] + s1[2] * s3[5]);
+  tmp1 = tmp0 * 4.0f * r12[0] * r12[1] * (r12[0] * r12[0] - r12[1] * r12[1]) * fnp_factor;
+  tmp2 = tmp0 * fn_factor;
+  f12[0] += tmp1 * r12[0] + tmp2 * 4.0f * r12[1] * (3.0f * r12[0] * r12[0] - r12[1] * r12[1]);
+  f12[1] += tmp1 * r12[1] + tmp2 * 4.0f * r12[0] * (r12[0] * r12[0] - 3.0f * r12[1] * r12[1]);
+  f12[2] += tmp1 * r12[2];
+}
+
 template <int L>
 static __device__ __forceinline__ void calculate_s_one(
   const int n, const int n_max_angular_plus_1, const float* Fp, const float* sum_fxyz, float* s)
@@ -1266,6 +1496,7 @@ static __device__ __forceinline__ void accumulate_f12(
   const int has_q_112,
   const int has_q_123,
   const int has_q_233,
+  const int has_q_134,
   const int num_L,
   const int n,
   const int n_max_angular_plus_1,
@@ -1377,6 +1608,34 @@ static __device__ __forceinline__ void accumulate_f12(
         get_f12_4body_233(d12, d12inv, fn2, fnp2, fn3, fnp3, Fp[(L_index++) * n_max_angular_plus_1 + n], s2, s3, r12, f12);
       }
     }
+    if (has_q_134) {
+      float fnp3 = fnp2 * d12inv - fn2 * d12inv * d12inv;
+      float fn3 = fn2 * d12inv;
+      float s3[7] = {
+        sum_fxyz[n * NUM_OF_ABC + 8],
+        sum_fxyz[n * NUM_OF_ABC + 9],
+        sum_fxyz[n * NUM_OF_ABC + 10],
+        sum_fxyz[n * NUM_OF_ABC + 11],
+        sum_fxyz[n * NUM_OF_ABC + 12],
+        sum_fxyz[n * NUM_OF_ABC + 13],
+        sum_fxyz[n * NUM_OF_ABC + 14]
+      };
+      float fnp4 = fnp3 * d12inv - fn3 * d12inv * d12inv;
+      float fn4 = fn3 * d12inv;
+      float s4[9] = {
+        sum_fxyz[n * NUM_OF_ABC + 15],
+        sum_fxyz[n * NUM_OF_ABC + 16],
+        sum_fxyz[n * NUM_OF_ABC + 17],
+        sum_fxyz[n * NUM_OF_ABC + 18],
+        sum_fxyz[n * NUM_OF_ABC + 19],
+        sum_fxyz[n * NUM_OF_ABC + 20],
+        sum_fxyz[n * NUM_OF_ABC + 21],
+        sum_fxyz[n * NUM_OF_ABC + 22],
+        sum_fxyz[n * NUM_OF_ABC + 23]
+      };
+      get_f12_4body_134(d12, d12inv, fn, fnp, fn3, fnp3, fn4, fnp4, Fp[(L_index++) * n_max_angular_plus_1 + n], s1, s3, s4, r12, f12);
+    }
+
   }
 
 }
@@ -1533,6 +1792,7 @@ static __device__ __forceinline__ void find_q(
   const int has_q_112,
   const int has_q_123,
   const int has_q_233,
+  const int has_q_134,
   const int n_max_angular_plus_1,
   const int n,
   const float* s,
@@ -1638,4 +1898,19 @@ static __device__ __forceinline__ void find_q(
                         + s[13]*s[11]*s[4] - s[13]*s[12]*s[5]);
     q[(L_index++) * n_max_angular_plus_1 + n] = val;
   }
+  
+  if (has_q_134) {
+    q[(L_index++) * n_max_angular_plus_1 + n] =
+      C4B_134[0] * (-s[10] * s[15] * s[2] - s[1] * s[15] * s[9]) +
+      C4B_134[1] * (s[0] * s[15] * s[8]) +
+      C4B_134[2] * (-s[1] * s[13] * s[18] - s[1] * s[14] * s[19] - s[2] * s[14] * s[18] + s[2] * s[13] * s[19]) +
+      C4B_134[3] * (-s[10] * s[18] * s[2] + s[1] * s[10] * s[19] + s[1] * s[18] * s[9] + s[2] * s[19] * s[9]) +
+      C4B_134[4] * (s[1] * s[16] * s[8] + s[2] * s[17] * s[8]) +
+      C4B_134[5] * (s[0] * s[10] * s[17] + s[0] * s[16] * s[9] - s[1] * s[11] * s[16] - s[1] * s[12] * s[17] - s[2] * s[12] * s[16] + s[2] * s[11] * s[17]) +
+      C4B_134[6] * (s[1] * s[13] * s[22] + s[1] * s[14] * s[23] - s[2] * s[14] * s[22] + s[2] * s[13] * s[23]) +
+      C4B_134[7] * (s[0] * s[11] * s[18] + s[0] * s[12] * s[19]) +
+      C4B_134[8] * (s[0] * s[13] * s[20] + s[0] * s[14] * s[21]) +
+      C4B_134[9] * (s[1] * s[11] * s[20] + s[1] * s[12] * s[21] - s[2] * s[12] * s[20] + s[2] * s[11] * s[21]);
+  }
+
 }


### PR DESCRIPTION
**Summary**

Extend the many-body descriptors with the new 4-body term `q_134`.
Syntax
```
l_max <l_max_3body> <has_q_222> <has_q_1111> <has_q_112> <has_q_123> <has_q_233> <has_q_134>
```
All `<has_...>` arguments accept 1 (enabled) or 0 (disabled).

**Modification**

**Others**
