### PR TITLE
feat: add PyTorch backend support for DeePMD-kit potential

### DIFF
--- a/potentials/DP/README.md
+++ b/potentials/DP/README.md
@@ -3,22 +3,46 @@
 ## Necessary instructions
 
 - This is a test version.
-- Only potential function files ending with `.pb` in deepmd are supported, that is, the potential function files of the tensorflow version generated using `dp --tf` freeze.
+- Supports DeePMD-kit potential files with both TensorFlow and PyTorch backends:
+  - `.pb` files: TensorFlow backend (generated using `dp --tf freeze`)
+  - `.pth` files: PyTorch backend (generated using `dp --pt freeze`)
+  - `.pt` files: PyTorch AOTInductor backend (recommended for DPA4-Neo and other modern models)
+- The DeePMD-kit C++ API (`deepmd::DeepPot`) automatically detects the backend from the file extension at runtime.
 
 ## Installation Dependencies
 
-- You must ensure that the new version of `DP` is installed and can run normally. This program contains `DP`-related dependencies.
+- You must ensure that the new version of DeePMD-kit (v3.x or later) is installed and can run normally. This program contains DeePMD-related dependencies.
+- For PyTorch backend support, you also need libtorch installed and linked during compilation.
 - The installation environment requirements of `GPUMD` itself must be met.
+
+## Compilation
+
+To enable DeePMD support, modify the `src/makefile`:
+
+1. Add `-DUSE_DEEPMD` to `CFLAGS`
+2. Add DeePMD-kit include and library paths
+3. For PyTorch backend, also add libtorch library paths
+
+See the commented section in `src/makefile` for detailed instructions.
+
+**Note:** The old `USE_TENSORFLOW` flag is still supported for backward compatibility, but `USE_DEEPMD` is now the recommended flag name.
 
 ## Run Test
 
-This `DP` interface requires two files: a setting file and a `DP` potential file. The first file is very simple and is used to inform `GPUMD` of the atom number and types. For example, the `dp.txt` is shown in here for use the `potential dp.txt DP_POTENTIAL_FILE.pb` command in the `run.in` file:
+This `DP` interface requires two files: a setting file and a `DP` potential file. The first file is very simple and is used to inform `GPUMD` of the atom number and types. For example, the `dp_settings.txt` is shown here for use with the `potential dp_settings.txt DP_POTENTIAL_FILE` command in the `run.in` file:
 
 ```dp 2 O H```
 
+The potential file can be:
+- `model.pb` (TensorFlow backend)
+- `model.pth` (PyTorch backend)
+- `model.pt` (PyTorch AOTInductor backend)
+
+The `dp_settings.txt` format is the same regardless of which backend you use.
+
 ## Notice
 
-The type list of setting file and potential file must be the same.
+The type list in the setting file and potential file must be the same.
 
 ## References
 

--- a/src/force/dp.cu
+++ b/src/force/dp.cu
@@ -17,7 +17,7 @@
 The class dealing with the Deep Potential(DP).
 ------------------------------------------------------------------------------*/
 
-#ifdef USE_TENSORFLOW
+#if defined(USE_DEEPMD) || defined(USE_TENSORFLOW)
 #include "dp.cuh"
 #include "neighbor.cuh"
 #include "utilities/error.cuh"
@@ -624,4 +624,4 @@ nghost = calc_ghost_atom_number(
     nghost);
   GPU_CHECK_KERNEL
 }
-#endif
+#endif // defined(USE_DEEPMD) || defined(USE_TENSORFLOW)

--- a/src/force/dp.cuh
+++ b/src/force/dp.cuh
@@ -13,7 +13,7 @@
     along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef USE_TENSORFLOW
+#if defined(USE_DEEPMD) || defined(USE_TENSORFLOW)
 #pragma once
 #include "DeepPot.h"
 #include "potential.cuh"
@@ -155,4 +155,4 @@ protected:
   void set_dp_coeff();
   void release_pinned_host_buffers();
 };
-#endif
+#endif // defined(USE_DEEPMD) || defined(USE_TENSORFLOW)

--- a/src/force/force.cu
+++ b/src/force/force.cu
@@ -161,7 +161,7 @@ void Force::parse_potential(
     is_nep = true;
     // Check if the types for this potential are compatible with the possibly other potentials
     check_types(param[1]);
-#ifdef USE_TENSORFLOW
+#if defined(USE_DEEPMD) || defined(USE_TENSORFLOW)
   } else if (strcmp(potential_name, "dp") == 0) {
     if (num_param != 3) {
       PRINT_INPUT_ERROR(
@@ -169,7 +169,7 @@ void Force::parse_potential(
         "potential file name.\n");
     }
     potential.reset(new DP(param[2], number_of_atoms));
-#endif
+#endif // defined(USE_DEEPMD) || defined(USE_TENSORFLOW)
 #ifdef USE_NNAP
   } else if (strcmp(potential_name, "nnap") == 0) {
     if (num_param != 3) {

--- a/src/makefile
+++ b/src/makefile
@@ -27,6 +27,19 @@ LIBS = -lcublas -lcusolver -lcufft
 
 
 ###########################################################
+# DeePMD-kit support (TensorFlow or PyTorch backend)
+# Uncomment and adjust paths for your installation:
+# CFLAGS += -DUSE_DEEPMD
+# INC += -I/path/to/deepmd-kit-install/include/deepmd
+# LDFLAGS += -L/path/to/deepmd-kit-install/lib
+# LIBS += -ldeepmd_cc
+# For PyTorch backend, also add libtorch paths:
+# LDFLAGS += -L/path/to/libtorch/lib
+# LIBS += -ltorch -ltorch_cpu -lc10
+###########################################################
+
+
+###########################################################
 # source files
 ###########################################################
 SOURCES_GPUMD =                   \


### PR DESCRIPTION
- Rename compile guard USE_TENSORFLOW to USE_DEEPMD (backward compatible)
- Update makefile with DeePMD-kit build instructions for both backends
- Update documentation with PyTorch model format (.pth/.pt) support
- No runtime code changes needed: DeepPot API auto-detects backend from file extension

**Summary**

**Modification**

**Others**
