### PR TITLE
Fix and document the HIP build on ROCm 7.x

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -16,12 +16,28 @@ To compile (and run) :program:`GPUMD` one requires an Nvidia GPU card with compu
 On Linux systems, one also needs a C++ compiler supporting at least the C++11 standard.
 On Windows systems, one also needs the ``cl.exe`` compiler from Microsoft Visual Studio and a `64-bit version of make.exe <http://www.equation.com/servlet/equation.cmd?fa=make>`_.
 
+Alternatively, :program:`GPUMD` can be built for AMD GPUs through ROCm/HIP (see :ref:`Building for AMD GPUs <build_amd_hip>` below); this requires a ROCm installation.
+
 
 Compilation
 ===========
 
 In the ``src`` directory run ``make``, which generates two executables, ``nep`` and ``gpumd``.
 Please check the comments in the beginning of the makefile for some compiling options.
+
+
+.. _build_amd_hip:
+
+Building for AMD GPUs (ROCm/HIP)
+================================
+
+:program:`GPUMD` also runs on AMD GPUs through ROCm/HIP. In the ``src`` directory, build with the HIP makefile instead of the default one::
+
+  make -f makefile.hip
+
+This uses ``hipcc`` and links rocThrust/rocPRIM, hipBLAS, hipSOLVER, and hipFFT, so it requires a ROCm installation. The target GPU architecture defaults to ``gfx90a``; build for another AMD GPU by setting ``HIP_ARCH``::
+
+  make -f makefile.hip HIP_ARCH=gfx1100
 
 
 Examples

--- a/src/makefile.hip
+++ b/src/makefile.hip
@@ -14,9 +14,10 @@
 ###########################################################
 CC = hipcc
 HIP_ARCH ?= gfx90a
-# rocThrust/rocPRIM (pulled in by thrust::exclusive_scan in neighbor.cu etc.)
-# require C++17; CUDA Thrust tolerates C++14 but ROCm does not.
-CFLAGS = -std=c++17 -O3 --offload-arch=$(HIP_ARCH) -DUSE_HIP
+# Leave the C++ standard at the compiler default (C++17): rocThrust/rocPRIM
+# (pulled in by thrust::exclusive_scan in neighbor.cu etc.) require C++17 and
+# hipcc defaults to it, so do not pin -std lower.
+CFLAGS = -O3 --offload-arch=$(HIP_ARCH) -DUSE_HIP
 INC = -I./
 LDFLAGS = 
 LIBS = -lhipblas -lhipsolver -lhipfft

--- a/src/makefile.hip
+++ b/src/makefile.hip
@@ -1,7 +1,8 @@
 ###########################################################
-# Note: 
-# 1) You can modify gfx90a according to your GPU
-#    architecture.
+# Note:
+# 1) Set HIP_ARCH to your GPU architecture, e.g.
+#    make -f makefile.hip HIP_ARCH=gfx1100
+#    (defaults to gfx90a).
 # 2) Do not remove -DUSE_HIP.
 # 3) Add -DUSE_PLUMED to CFLAGS when use the PLUMED plugin
 #    and remove it otherwise.
@@ -12,7 +13,10 @@
 # some flags
 ###########################################################
 CC = hipcc
-CFLAGS = -std=c++14 -O3 --offload-arch=gfx90a -DUSE_HIP
+HIP_ARCH ?= gfx90a
+# rocThrust/rocPRIM (pulled in by thrust::exclusive_scan in neighbor.cu etc.)
+# require C++17; CUDA Thrust tolerates C++14 but ROCm does not.
+CFLAGS = -std=c++17 -O3 --offload-arch=$(HIP_ARCH) -DUSE_HIP
 INC = -I./
 LDFLAGS = 
 LIBS = -lhipblas -lhipsolver -lhipfft


### PR DESCRIPTION
GPUMD already ships a HIP build (`src/makefile.hip` plus the `gpu_macro.cuh` compat header), but it does not build on ROCm 7.x: rocPRIM/rocThrust now hard-require C++17 (the headers use `std::variant` / `std::is_same_v`) while `makefile.hip` inherited `-std=c++14` from the CUDA build, so the three Thrust-using translation units (`neighbor.cu`, `nep_multigpu.cu`, `dp.cu`) fail to compile.

This:
- bumps the HIP build to `-std=c++17`;
- makes the offload arch configurable (`HIP_ARCH ?= gfx90a`) so other AMD targets build with `make -f makefile.hip HIP_ARCH=<arch>` without editing the file;
- documents the HIP build in `doc/installation.rst`, which previously did not mention it (a prerequisites note plus a short "Building for AMD GPUs (ROCm/HIP)" section).

No `.cu`/`.cuh` or CUDA-build changes.

## Test plan

```bash
cd src && make -f makefile.hip clean && make -f makefile.hip -j HIP_ARCH=gfx90a
```

Validated on an AMD MI250X (gfx90a, ROCm 7.2.1) with three shipped MD examples: `carbon` (NEP4 ML potential, NVE) conserves total energy to 2.6e-7 relative drift and matches the committed CUDA reference PE to 5.8e-6; `graphene_dos` (Tersoff + phonon DOS via hipFFT, 20000 steps) conserves energy to 2.2e-6 and the DOS matches the CUDA reference; `graphene_kappa_emd` (Green-Kubo conductivity) runs clean. Run-to-run output is not bit-identical because the neighbor-list build uses atomicAdd ordering (non-deterministic on any GPU, CUDA included), but each run independently conserves energy and matches the reference, which is the correct gate for a chaotic MD trajectory.

This was prepared with the assistance of Claude (AI), reviewed before submission.
