### PR TITLE
Add tools/Format_Conversion/gpumd_to_kaldo: export NEP force constants to kaldo

### DIFF
--- a/tools/Format_Conversion/README.md
+++ b/tools/Format_Conversion/README.md
@@ -6,6 +6,7 @@
 | dp2xyz      | Ke Xu        | twtdq@qq.com               | Convert `DP` training data to `xyz` format.                  |
 | exyz2pdb    | Zherui Chen  | chenzherui0124@foxmail.com | Convert `exyz` to `pdb`.                                     |
 | gmx2exyz    | Zherui Chen  | chenzherui0124@foxmail.com | Convert the `trr` trajectory of `gmx` to the `exyz` trajectory. |
+| gpumd_to_kaldo | Giuseppe Barbalinardo | giuseppp@gmail.com | Export NEP-derived 2nd/3rd-order force constants to kaldo (`format='gpumd'`). |
 | mtp2xyz     | Ke Xu        | twtdq@qq.com               | Convert `MTP` training data to xyz format.                   |
 | orca2xyz    | Zherui Chen  | chenzherui0124@foxmail.com | Automatically process `ORCA` calculations and sample configurations. |
 | runner2xyz  | Ke Xu        | twtdq@qq.com               | Convert `RUNNER` training data to `xyz` format.              |

--- a/tools/Format_Conversion/gpumd_to_kaldo/README.md
+++ b/tools/Format_Conversion/gpumd_to_kaldo/README.md
@@ -1,0 +1,156 @@
+# gpumd_to_kaldo — NEP force-constant exporter for kaldo
+
+Export second- and third-order interatomic force constants (IFCs) derived from
+a GPUMD NEP potential into kaldo's `format='gpumd'` on-disk layout
+(`gpumd_fc.npz`).  The pipeline runs entirely on the CPU and requires neither
+a GPU nor a running GPUMD simulation: calorine's `CPUNEP` evaluates forces on
+phono3py-generated displaced supercells, and the resulting IFCs are remapped
+into kaldo's canonical C-grid replica order, optionally corrected with the
+acoustic sum rule, and written to a single compressed numpy archive.
+
+---
+
+## Dependencies
+
+**Required (core pipeline):**
+
+| Package | Purpose |
+|---|---|
+| `ase` | Atoms object, structure I/O |
+| `calorine` | CPUNEP ASE calculator |
+| `phonopy` | Harmonic (fc2) finite displacements |
+| `phono3py` | Anharmonic (fc3) finite displacements |
+| `numpy` | Array operations |
+| `scipy` | Lattice-constant relaxation (Brent) |
+| `sparse` | COO storage for fc3 |
+
+**Required only for the cross-check tests** (`test_fc2_layout_matches_hiphive_oracle`,
+`test_fc3_matches_hiphive_oracle`, and the kaldo round-trip / end-to-end tests):
+
+| Package | Purpose |
+|---|---|
+| `kaldo` | kaldo `format='gpumd'` reader; grid utilities |
+| `hiphive` | Independent fc2/fc3 oracle for element-wise comparison |
+
+The pure-NEP tests (B.1/B.2 — structure helpers, force evaluation, phonopy fc2,
+phono3py fc3) run without kaldo or hiphive installed.
+
+---
+
+## `gpumd_fc.npz` format
+
+A single `np.savez_compressed` archive.  All arrays are numpy-native; no
+additional libraries are needed to read it beyond numpy and sparse.
+
+| key | dtype | shape | meaning |
+|---|---|---|---|
+| `format_version` | int | scalar | starts at `1` |
+| `atomic_numbers` | int | `(n_uc,)` | unit-cell species |
+| `positions` | float64 | `(n_uc, 3)` | unit-cell Cartesian positions (Å) |
+| `cell` | float64 | `(3, 3)` | unit-cell vectors (Å) |
+| `supercell` | int | `(3,)` | diagonal supercell for `fc2` |
+| `third_supercell` | int | `(3,)` | diagonal supercell for `fc3` |
+| `fc2` | float64 | `(1, n_uc, 3, n_rep2, n_uc, 3)` | second-order IFC, eV/Å², kaldo C-grid replica order, reference cell at axis 0 |
+| `fc3_coords` | int32 | `(3, nnz)` | flattened COO coords for the `(n_uc·3, n_rep3·n_uc·3, n_rep3·n_uc·3)` array |
+| `fc3_data` | float64 | `(nnz,)` | third-order IFC values, eV/Å³ |
+| `fc3_shape` | int | `(3,)` | `(n_uc·3, n_rep3·n_uc·3, n_rep3·n_uc·3)` |
+| `units_fc2` / `units_fc3` | str | scalar | `'eV/angstrom^2'` / `'eV/angstrom^3'` |
+| `grid_order` | str | scalar | `'C'` |
+| `acoustic_sum_applied` | bool | scalar | whether ASR was applied by the writer |
+| `nep_potential` / `generator` | str | scalar | provenance: NEP filename + sha256; tool name + version |
+
+**Index convention:** replica index `r ∈ [0, n_rep)` corresponds to cell-image
+grid index `np.unravel_index(r, supercell, order='C')`, i.e. exactly
+`kaldo.grid.Grid(supercell, 'C').grid(is_wrapping=False)[r]`.
+`fc2[0, i, α, r, j, β]` = Φ²(ref-cell atom *i*, direction α; atom *j* in
+image *r*, direction β), eV/Å² (bare IFCs, not mass-weighted).
+
+---
+
+## CLI usage
+
+### Default: built-in silicon example
+
+```bash
+python gpumd_to_kaldo.py \
+    --nep /path/to/nep.txt \
+    --supercell 3 3 3 \
+    --acoustic-sum \
+    --out gpumd_fc.npz
+```
+
+The script relaxes the Si lattice constant automatically (`--a` overrides it).
+
+### Any ASE-readable structure
+
+Pass any POSCAR, extxyz, CIF, or other ASE-readable file with `--structure`:
+
+```bash
+python gpumd_to_kaldo.py \
+    --nep /path/to/nep.txt \
+    --structure my_unitcell.vasp \
+    --supercell 3 3 3 \
+    --acoustic-sum \
+    --out gpumd_fc.npz
+```
+
+The structure is used **as provided** — no relaxation is performed.  Ensure
+the cell is at (or close to) its equilibrium geometry for the given NEP so
+that the force-constant expansion is well-conditioned.  The `--a` flag is
+ignored when `--structure` is given.
+
+### All options
+
+```
+--nep PATH            Path to the NEP potential file (required).
+--out PATH            Output .npz path (default: gpumd_fc.npz).
+--supercell NX NY NZ  Supercell for fc2 and fc3 (default: 3 3 3).
+--third-supercell NX NY NZ
+                      Separate supercell for fc3 (default: same as --supercell).
+--structure PATH      Any ASE-readable unit cell; used as-is.
+--a FLOAT             Si lattice constant in Å (default: auto-relaxed).
+                      Ignored when --structure is given.
+--threshold FLOAT     Drop fc3 entries with |value| <= threshold (default: 0).
+--acoustic-sum        Apply the acoustic sum rule to fc2 before writing.
+```
+
+---
+
+## Silicon example
+
+```bash
+cd example_silicon
+bash run.sh
+```
+
+`run.sh` runs a (3, 3, 3) supercell on the in-repo Si NEP and prints the kaldo
+load command.  The output `gpumd_fc.npz` lands in `example_silicon/`.
+
+---
+
+## How kaldo reads it
+
+```python
+from kaldo.forceconstants import ForceConstants
+
+fc = ForceConstants.from_folder('.', format='gpumd')
+# fc.second  — SecondOrder in kaldo C-grid layout
+# fc.third   — ThirdOrder sparse COO
+```
+
+kaldo rebuilds the replicated supercell from the stored `supercell` vector (no
+`replicated_atoms.xyz` needed) and loads fc3 directly into a `sparse.COO`
+without any index remapping.
+
+---
+
+## Running the tests
+
+```bash
+cd tools/Format_Conversion/gpumd_to_kaldo
+conda run -n gpumd-kaldo python -m pytest test_gpumd_to_kaldo.py -v
+```
+
+Tests that require kaldo or hiphive are automatically skipped if those packages
+are not installed, so GPUMD's own CI (which need not install kaldo) can still
+run the pure-NEP subset.

--- a/tools/Format_Conversion/gpumd_to_kaldo/example_silicon/run.sh
+++ b/tools/Format_Conversion/gpumd_to_kaldo/example_silicon/run.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python ../gpumd_to_kaldo.py \
+  --nep ../../../../potentials/nep/Si_2022_NEP4_4body.txt \
+  --supercell 3 3 3 --acoustic-sum --out gpumd_fc.npz
+echo "Load in kaldo: ForceConstants.from_folder('.', format='gpumd')"

--- a/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
@@ -11,6 +11,9 @@ Dependencies:
 import numpy as np
 from ase import Atoms
 from calorine.calculators import CPUNEP
+from phonopy import Phonopy
+from phonopy.structure.atoms import PhonopyAtoms
+from phono3py import Phono3py
 from scipy.optimize import minimize_scalar
 
 
@@ -83,3 +86,109 @@ def relaxed_lattice_constant(nep_path, a_min=5.40, a_max=5.47):
     result = minimize_scalar(_energy, bounds=(a_min, a_max), method='bounded',
                              options={'xatol': 1e-5})
     return float(result.x)
+
+
+# ---------------------------------------------------------------------------
+# B.2 — fc2 (phonopy) and fc3 (phono3py)
+# ---------------------------------------------------------------------------
+
+def _to_phonopy_atoms(atoms):
+    """Convert an ase.Atoms object to phonopy PhonopyAtoms."""
+    return PhonopyAtoms(symbols=atoms.get_chemical_symbols(),
+                        scaled_positions=atoms.get_scaled_positions(),
+                        cell=atoms.cell[:])
+
+
+def _forces_on_phonopy_supercell(phonopy_sc, nep_path):
+    """Evaluate NEP forces on a PhonopyAtoms supercell.
+
+    Parameters
+    ----------
+    phonopy_sc : phonopy.structure.atoms.PhonopyAtoms
+        Displaced supercell from phonopy/phono3py.
+    nep_path : str
+        Path to the NEP potential file.
+
+    Returns
+    -------
+    numpy.ndarray, shape (n_atoms, 3)
+        Forces in eV/Å.
+    """
+    ase_atoms = Atoms(symbols=phonopy_sc.symbols,
+                      scaled_positions=phonopy_sc.scaled_positions,
+                      cell=phonopy_sc.cell, pbc=True)
+    ase_atoms.calc = CPUNEP(nep_path)
+    return ase_atoms.get_forces()
+
+
+def compute_fc2(atoms, nep_path, supercell=(3, 3, 3), displacement=0.01):
+    """Compute second-order force constants via phonopy finite displacements.
+
+    Parameters
+    ----------
+    atoms : ase.Atoms
+        Primitive unit cell (e.g. from ``silicon_unitcell``).
+    nep_path : str
+        Path to the NEP potential file.
+    supercell : tuple of int
+        Supercell repetitions along each lattice vector.
+    displacement : float
+        Displacement amplitude in Angstrom.
+
+    Returns
+    -------
+    phonopy.Phonopy
+        Phonopy object with force constants set.  Call
+        ``ph.run_mesh([1, 1, 1])`` and ``ph.get_mesh_dict()`` for
+        frequencies.
+    """
+    ph = Phonopy(_to_phonopy_atoms(atoms),
+                 supercell_matrix=np.diag(supercell),
+                 primitive_matrix='auto')
+    ph.generate_displacements(distance=displacement)
+    forces = [_forces_on_phonopy_supercell(sc, nep_path)
+              for sc in ph.supercells_with_displacements if sc is not None]
+    ph.forces = forces
+    ph.produce_force_constants()
+    return ph
+
+
+def compute_fc3(atoms, nep_path, supercell=(3, 3, 3), displacement=0.03):
+    """Compute third- and second-order force constants via phono3py.
+
+    Uses a single supercell matrix for both fc2 and fc3 (the default
+    phono3py workflow without a separate ``phonon_supercell_matrix``).
+    When no separate phonon_supercell_matrix is set, phono3py 4.1.0
+    uses ``ph3.forces`` (fc3 displacements) for both fc2 and fc3 via
+    ``produce_fc3()`` + ``produce_fc2()``.
+
+    Parameters
+    ----------
+    atoms : ase.Atoms
+        Primitive unit cell.
+    nep_path : str
+        Path to the NEP potential file.
+    supercell : tuple of int
+        Supercell repetitions along each lattice vector.
+    displacement : float
+        Displacement amplitude in Angstrom.
+
+    Returns
+    -------
+    phono3py.Phono3py
+        Phono3py object with ``fc2`` and ``fc3`` attributes set.
+    """
+    ph3 = Phono3py(_to_phonopy_atoms(atoms),
+                   supercell_matrix=np.diag(supercell),
+                   primitive_matrix='auto')
+    ph3.generate_displacements(distance=displacement)
+
+    scs = ph3.supercells_with_displacements
+    forces = [_forces_on_phonopy_supercell(sc, nep_path)
+              for sc in scs if sc is not None]
+    ph3.forces = forces
+    ph3.produce_fc3()
+    # When phonon_supercell_matrix is not set, produce_fc2 falls back to
+    # ph3.dataset (same displacements as fc3), so forces are already set.
+    ph3.produce_fc2()
+    return ph3

--- a/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
@@ -14,7 +14,7 @@ from calorine.calculators import CPUNEP
 from phonopy import Phonopy
 from phonopy.structure.atoms import PhonopyAtoms
 from phono3py import Phono3py
-from scipy.optimize import minimize_scalar
+from scipy.optimize import minimize_scalar as _minimize_scalar
 
 
 # ---------------------------------------------------------------------------
@@ -83,8 +83,8 @@ def relaxed_lattice_constant(nep_path, a_min=5.40, a_max=5.47):
         atoms.calc = CPUNEP(nep_path)
         return atoms.get_potential_energy()
 
-    result = minimize_scalar(_energy, bounds=(a_min, a_max), method='bounded',
-                             options={'xatol': 1e-5})
+    result = _minimize_scalar(_energy, bounds=(a_min, a_max), method='bounded',
+                              options={'xatol': 1e-5})
     return float(result.x)
 
 
@@ -147,7 +147,7 @@ def compute_fc2(atoms, nep_path, supercell=(3, 3, 3), displacement=0.01):
                  primitive_matrix='auto')
     ph.generate_displacements(distance=displacement)
     forces = [_forces_on_phonopy_supercell(sc, nep_path)
-              for sc in ph.supercells_with_displacements if sc is not None]
+              for sc in ph.supercells_with_displacements]
     ph.forces = forces
     ph.produce_force_constants()
     return ph
@@ -181,11 +181,14 @@ def compute_fc3(atoms, nep_path, supercell=(3, 3, 3), displacement=0.03):
     ph3 = Phono3py(_to_phonopy_atoms(atoms),
                    supercell_matrix=np.diag(supercell),
                    primitive_matrix='auto')
+    # cutoff_pair_distance is intentionally not used: every displaced supercell
+    # is force-evaluated, so phono3py's force ordering stays 1:1 with the
+    # displacement dataset. (With a cutoff, phono3py emits None placeholders and
+    # the forces list must keep them — unsupported here by design.)
     ph3.generate_displacements(distance=displacement)
 
     scs = ph3.supercells_with_displacements
-    forces = [_forces_on_phonopy_supercell(sc, nep_path)
-              for sc in scs if sc is not None]
+    forces = [_forces_on_phonopy_supercell(sc, nep_path) for sc in scs]
     ph3.forces = forces
     ph3.produce_fc3()
     # When phonon_supercell_matrix is not set, produce_fc2 falls back to

--- a/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
@@ -299,6 +299,8 @@ def to_kaldo_layout(ph3, atoms, supercell, third_supercell, threshold=0.0):
     fc2_arr = np.array(ph3.fc2, dtype=np.float64)
     n_satom2 = len(rep2)
     n_rep2 = int(np.prod(supercell))
+    # Compact-vs-full detection assumes n_uc != n_satom, true for any supercell
+    # larger than (1, 1, 1); a (1, 1, 1) supercell would make both ambiguous.
     is_compact2 = (fc2_arr.shape[0] == n_uc)
     if not is_compact2 and fc2_arr.shape[0] != n_satom2:
         raise ValueError(f"Unexpected fc2 axis-0 length {fc2_arr.shape[0]} "

--- a/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
@@ -448,8 +448,13 @@ def main(argv=None):
     parser.add_argument('--third-supercell', type=int, nargs=3, default=None,
                         metavar=('NX', 'NY', 'NZ'),
                         help='Separate fc3 supercell (defaults to --supercell).')
+    parser.add_argument('--structure', default=None, metavar='PATH',
+                        help='Any ASE-readable unit cell (POSCAR, extxyz, cif, …). '
+                             'Used as-is without relaxation. '
+                             'If omitted, the built-in Si diamond cell is used.')
     parser.add_argument('--a', type=float, default=None,
-                        help='Si lattice constant (Angstrom); default: relaxed value.')
+                        help='Si lattice constant (Angstrom); default: relaxed value. '
+                             'Ignored when --structure is given.')
     parser.add_argument('--threshold', type=float, default=0.0,
                         help='Drop fc3 entries with |value| <= threshold.')
     parser.add_argument('--acoustic-sum', action='store_true',
@@ -457,8 +462,15 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     third = tuple(args.third_supercell) if args.third_supercell else tuple(args.supercell)
-    a0 = args.a if args.a is not None else relaxed_lattice_constant(args.nep)
-    atoms = silicon_unitcell(a=a0)
+
+    if args.structure is not None:
+        import ase.io
+        atoms = ase.io.read(args.structure)
+        print(f'Using structure from {args.structure} as provided (no relaxation).')
+    else:
+        a0 = args.a if args.a is not None else relaxed_lattice_constant(args.nep)
+        atoms = silicon_unitcell(a=a0)
+
     ph3 = compute_fc3(atoms, args.nep, supercell=tuple(args.supercell))
     fc2, fc3 = to_kaldo_layout(ph3, atoms, tuple(args.supercell), third,
                                threshold=args.threshold)

--- a/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
@@ -1,0 +1,85 @@
+"""Export second- and third-order force constants from a GPUMD NEP potential
+into the kaldo ``gpumd_fc.npz`` format (readable by kaldo ``format='gpumd'``).
+
+Pipeline:
+    calorine CPUNEP forces -> phonopy (fc2) + phono3py (fc3) finite
+    displacements -> kaldo-compatible output.
+
+Dependencies:
+    ase, calorine, phonopy, phono3py, numpy, scipy
+"""
+import numpy as np
+from ase import Atoms
+from calorine.calculators import CPUNEP
+from scipy.optimize import minimize_scalar
+
+
+# ---------------------------------------------------------------------------
+# B.1 — Structure helpers and NEP force engine
+# ---------------------------------------------------------------------------
+
+def silicon_unitcell(a=5.43):
+    """Return a 2-atom diamond-cubic Si primitive cell.
+
+    Parameters
+    ----------
+    a : float
+        Cubic lattice constant in Angstrom.
+
+    Returns
+    -------
+    ase.Atoms
+        2-atom Si primitive cell with PBC enabled.
+    """
+    cell = 0.5 * a * np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0]], dtype=float)
+    atoms = Atoms('Si2', cell=cell, pbc=True,
+                  scaled_positions=[[0, 0, 0], [0.25, 0.25, 0.25]])
+    return atoms
+
+
+def nep_forces(atoms, nep_path):
+    """Return forces (eV/Å) on *atoms* from the NEP potential at *nep_path*.
+
+    Parameters
+    ----------
+    atoms : ase.Atoms
+        Structure to evaluate.
+    nep_path : str
+        Path to the NEP potential file.
+
+    Returns
+    -------
+    numpy.ndarray, shape (n_atoms, 3)
+        Forces in eV/Å.
+    """
+    a = atoms.copy()
+    a.calc = CPUNEP(nep_path)
+    return a.get_forces()
+
+
+def relaxed_lattice_constant(nep_path, a_min=5.40, a_max=5.47):
+    """Find the equilibrium cubic lattice constant for the Si NEP potential.
+
+    Minimises the total energy of the 2-atom diamond-cubic primitive cell
+    over the interval [*a_min*, *a_max*] using Brent's method.
+
+    Parameters
+    ----------
+    nep_path : str
+        Path to the NEP potential file.
+    a_min, a_max : float
+        Search bounds in Angstrom.
+
+    Returns
+    -------
+    float
+        Relaxed cubic lattice constant in Angstrom.
+    """
+    def _energy(a):
+        atoms = silicon_unitcell(a=a)
+        atoms.calc = CPUNEP(nep_path)
+        return atoms.get_potential_energy()
+
+    result = minimize_scalar(_energy, bounds=(a_min, a_max), method='bounded',
+                             options={'xatol': 1e-5})
+    return float(result.x)

--- a/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
@@ -6,9 +6,11 @@ Pipeline:
     displacements -> kaldo-compatible output.
 
 Dependencies:
-    ase, calorine, phonopy, phono3py, numpy, scipy
+    ase, calorine, phonopy, phono3py, numpy, scipy, sparse, kaldo (kaldo only
+    for the C-grid replica ordering used by ``to_kaldo_layout``).
 """
 import numpy as np
+import sparse
 from ase import Atoms
 from calorine.calculators import CPUNEP
 from phonopy import Phonopy
@@ -195,3 +197,153 @@ def compute_fc3(atoms, nep_path, supercell=(3, 3, 3), displacement=0.03):
     # ph3.dataset (same displacements as fc3), so forces are already set.
     ph3.produce_fc2()
     return ph3
+
+
+# ---------------------------------------------------------------------------
+# B.3 — remap phono3py force constants into kaldo's canonical C-grid layout
+# ---------------------------------------------------------------------------
+
+def _supercell_atom_to_replica_unit(phono_supercell, primitive, atoms, supercell):
+    """Map each phono3py supercell atom to (kaldo C-grid replica id, unit atom).
+
+    The replica id is the row of ``Grid(supercell, 'C').grid(is_wrapping=False)``
+    whose integer cell index equals the lattice image the supercell atom sits in.
+    The unit-atom index is ``u2u_map[s2u_map[a]]`` (0..n_uc-1).
+
+    Parameters
+    ----------
+    phono_supercell : phonopy.structure.cells.Supercell
+        The phono3py supercell (``ph3.supercell``).
+    primitive : phonopy.structure.cells.Primitive
+        The phono3py primitive cell (``ph3.primitive``); used for ``p2s_map``.
+    atoms : ase.Atoms
+        The primitive unit cell whose ``cell``/positions define the C grid.
+    supercell : tuple of int
+        Supercell repetitions; defines the Grid shape.
+
+    Returns
+    -------
+    rep_of : numpy.ndarray, shape (n_satom,), int
+        Kaldo C-grid replica id for each supercell atom.
+    unit_of : numpy.ndarray, shape (n_satom,), int
+        Unit-atom index (0..n_uc-1) for each supercell atom.
+    compact_row_of : numpy.ndarray, shape (n_satom,), int
+        For each supercell atom, the compact-fc row index of its primitive
+        image (i.e. position of ``s2u_map[a]`` within ``primitive.p2s_map``).
+    """
+    from kaldo.grid import Grid
+
+    grid_cells = Grid(tuple(int(s) for s in supercell), order='C').grid(is_wrapping=False)
+    cell = np.array(atoms.cell, dtype=np.float64)
+    inv_cell = np.linalg.inv(cell)
+    prim_pos = atoms.get_positions()
+    sc_dim = np.array([int(s) for s in supercell])
+
+    s2u = np.array(phono_supercell.s2u_map)
+    u2u = phono_supercell.u2u_map               # dict: supercell index -> 0..n_uc-1
+    p2s = list(np.array(primitive.p2s_map))     # supercell indices of the n_uc prim atoms
+    sc_cart = np.array(phono_supercell.scaled_positions) @ np.array(phono_supercell.cell)
+
+    n_satom = len(sc_cart)
+    rep_of = np.empty(n_satom, dtype=int)
+    unit_of = np.empty(n_satom, dtype=int)
+    compact_row_of = np.empty(n_satom, dtype=int)
+    for a in range(n_satom):
+        prim_satom = int(s2u[a])
+        j = int(u2u[prim_satom])
+        unit_of[a] = j
+        compact_row_of[a] = p2s.index(prim_satom)
+        offset = sc_cart[a] - prim_pos[j]
+        cell_idx = np.rint(offset @ inv_cell).astype(int) % sc_dim
+        match = np.where((grid_cells == cell_idx).all(axis=1))[0]
+        if match.size == 0:
+            raise ValueError(f"Supercell atom {a} cell index {cell_idx} not on the C grid.")
+        rep_of[a] = int(match[0])
+    return rep_of, unit_of, compact_row_of
+
+
+def to_kaldo_layout(ph3, atoms, supercell, third_supercell, threshold=0.0):
+    """Remap phono3py fc2/fc3 into kaldo's canonical C-grid layout.
+
+    Works directly from phono3py structure data (no hiphive). Handles both the
+    compact (axis 0 == n_uc) and full (axis 0 == n_satom) phono3py fc storage.
+
+    Parameters
+    ----------
+    ph3 : phono3py.Phono3py
+        Object with ``fc2``, ``fc3``, ``supercell``, ``primitive`` set.
+    atoms : ase.Atoms
+        Primitive unit cell (defines the C grid and atom ordering).
+    supercell : tuple of int
+        Supercell used for fc2 (the C grid for the second-order replicas).
+    third_supercell : tuple of int
+        Supercell used for fc3 (the C grid for the third-order replicas).
+    threshold : float
+        fc3 entries with ``|value| <= threshold`` are dropped from the COO.
+
+    Returns
+    -------
+    fc2 : numpy.ndarray, float64, shape (1, n_uc, 3, n_rep2, n_uc, 3)
+        Second-order force constants in eV/Angstrom^2.
+    fc3 : sparse.COO, shape (n_uc*3, n_rep3*n_uc*3, n_rep3*n_uc*3)
+        Third-order force constants in eV/Angstrom^3.
+    """
+    n_uc = len(atoms)
+
+    # --- fc2 ---
+    rep2, unit2, crow2 = _supercell_atom_to_replica_unit(
+        ph3.supercell, ph3.primitive, atoms, supercell)
+    fc2_arr = np.array(ph3.fc2, dtype=np.float64)
+    n_satom2 = len(rep2)
+    n_rep2 = int(np.prod(supercell))
+    is_compact2 = (fc2_arr.shape[0] == n_uc)
+    if not is_compact2 and fc2_arr.shape[0] != n_satom2:
+        raise ValueError(f"Unexpected fc2 axis-0 length {fc2_arr.shape[0]} "
+                         f"(expected {n_uc} compact or {n_satom2} full).")
+
+    fc2 = np.zeros((1, n_uc, 3, n_rep2, n_uc, 3), dtype=np.float64)
+    for b in range(n_satom2):
+        j = unit2[b]
+        r = rep2[b]
+        for a in range(n_satom2):
+            i = unit2[a]
+            if rep2[a] != 0:
+                continue                        # first index must be the reference cell
+            if is_compact2:
+                fc2[0, i, :, r, j, :] = fc2_arr[crow2[a], b]
+            else:
+                fc2[0, i, :, r, j, :] = fc2_arr[a, b]
+
+    # --- fc3 ---
+    rep3, unit3, crow3 = _supercell_atom_to_replica_unit(
+        ph3.supercell, ph3.primitive, atoms, third_supercell)
+    fc3_arr = np.array(ph3.fc3, dtype=np.float64)
+    n_satom3 = len(rep3)
+    n_rep3 = int(np.prod(third_supercell))
+    is_compact3 = (fc3_arr.shape[0] == n_uc)
+    if not is_compact3 and fc3_arr.shape[0] != n_satom3:
+        raise ValueError(f"Unexpected fc3 axis-0 length {fc3_arr.shape[0]} "
+                         f"(expected {n_uc} compact or {n_satom3} full).")
+
+    shape3 = (n_uc * 3, n_rep3 * n_uc * 3, n_rep3 * n_uc * 3)
+    rows, cols1, cols2, vals = [], [], [], []
+    ref_atoms = np.where(rep3 == 0)[0]          # supercell atoms in the reference cell
+    for a in ref_atoms:
+        i = unit3[a]
+        a_src = crow3[a] if is_compact3 else a
+        for b in range(n_satom3):
+            j, l2 = unit3[b], rep3[b]
+            for c in range(n_satom3):
+                k, l3 = unit3[c], rep3[c]
+                block = fc3_arr[a_src, b, c]    # (3, 3, 3)
+                nz = np.argwhere(np.abs(block) > threshold)
+                for (al, be, ga) in nz:
+                    rows.append(i * 3 + al)
+                    cols1.append((l2 * n_uc + j) * 3 + be)
+                    cols2.append((l3 * n_uc + k) * 3 + ga)
+                    vals.append(block[al, be, ga])
+    coords = np.array([rows, cols1, cols2], dtype=np.int64)
+    if coords.size == 0:
+        coords = np.zeros((3, 0), dtype=np.int64)
+    fc3 = sparse.COO(coords, np.array(vals, dtype=np.float64), shape=shape3)
+    return fc2, fc3

--- a/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/gpumd_to_kaldo.py
@@ -7,8 +7,11 @@ Pipeline:
 
 Dependencies:
     ase, calorine, phonopy, phono3py, numpy, scipy, sparse, kaldo (kaldo only
-    for the C-grid replica ordering used by ``to_kaldo_layout``).
+    for the C-grid replica ordering used by ``to_kaldo_layout`` / the writer).
 """
+import argparse
+import hashlib
+
 import numpy as np
 import sparse
 from ase import Atoms
@@ -347,3 +350,122 @@ def to_kaldo_layout(ph3, atoms, supercell, third_supercell, threshold=0.0):
         coords = np.zeros((3, 0), dtype=np.int64)
     fc3 = sparse.COO(coords, np.array(vals, dtype=np.float64), shape=shape3)
     return fc2, fc3
+
+
+# ---------------------------------------------------------------------------
+# B.4 — acoustic sum rule, npz writer, and CLI
+# ---------------------------------------------------------------------------
+
+def apply_acoustic_sum_rule(fc2):
+    """Enforce per-reference-atom translational invariance on fc2.
+
+    Mirrors kaldo's ``acoustic_sum_rule``: for each reference atom ``i``,
+    subtract the sum over all (replica, atom) pairs from the on-site block.
+
+    Parameters
+    ----------
+    fc2 : numpy.ndarray, shape (1, n_uc, 3, n_rep, n_uc, 3)
+        Second-order force constants.
+
+    Returns
+    -------
+    numpy.ndarray
+        A copy of ``fc2`` with the acoustic sum rule applied.
+    """
+    fc2 = np.array(fc2, dtype=np.float64, copy=True)
+    n_uc = fc2.shape[1]
+    for i in range(n_uc):
+        off_diag_sum = np.sum(fc2[0, i, :, :, :, :], axis=(-2, -3))   # (3, 3)
+        fc2[0, i, :, 0, i, :] -= off_diag_sum
+    return fc2
+
+
+def _nep_sha256(nep_path):
+    """Return the full hex sha256 digest of the NEP potential file."""
+    h = hashlib.sha256()
+    with open(nep_path, 'rb') as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def write_gpumd_fc(path, atoms, supercell, third_supercell, fc2, fc3,
+                   nep_path, acoustic_sum_applied):
+    """Write a ``gpumd_fc.npz`` archive readable by kaldo ``format='gpumd'``.
+
+    Keys/dtypes match exactly what ``kaldo.interfaces.gpumd_io.read_gpumd_fc``
+    expects (format_version=1, geometry, supercells, fc2 dense, fc3 sparse COO
+    split into coords/data/shape, units, grid_order='C', ASR flag, provenance).
+
+    Parameters
+    ----------
+    path : str
+        Output ``.npz`` path.
+    atoms : ase.Atoms
+        Primitive unit cell.
+    supercell, third_supercell : tuple of int
+        Second- and third-order supercell shapes.
+    fc2 : numpy.ndarray
+        Second-order force constants, shape (1, n_uc, 3, n_rep2, n_uc, 3).
+    fc3 : sparse.COO
+        Third-order force constants.
+    nep_path : str
+        Path to the NEP potential (a sha256 of it is embedded for provenance).
+    acoustic_sum_applied : bool
+        Whether the acoustic sum rule has already been applied to ``fc2``.
+    """
+    nep_hash = _nep_sha256(nep_path)
+    np.savez_compressed(
+        path,
+        format_version=np.int64(1),
+        atomic_numbers=atoms.get_atomic_numbers().astype(np.int64),
+        positions=atoms.get_positions().astype(np.float64),
+        cell=np.array(atoms.cell).astype(np.float64),
+        supercell=np.array(supercell, dtype=np.int64),
+        third_supercell=np.array(third_supercell, dtype=np.int64),
+        fc2=np.ascontiguousarray(fc2, dtype=np.float64),
+        fc3_coords=fc3.coords.astype(np.int32),
+        fc3_data=fc3.data.astype(np.float64),
+        fc3_shape=np.array(fc3.shape, dtype=np.int64),
+        units_fc2='eV/angstrom^2',
+        units_fc3='eV/angstrom^3',
+        grid_order='C',
+        acoustic_sum_applied=np.bool_(acoustic_sum_applied),
+        nep_potential=f'{nep_path}#sha256:{nep_hash}',
+        generator='gpumd_to_kaldo v1')
+
+
+def main(argv=None):
+    """CLI: compute NEP force constants and export a kaldo ``gpumd_fc.npz``."""
+    parser = argparse.ArgumentParser(
+        description='Export NEP force constants to a kaldo gpumd_fc.npz archive.')
+    parser.add_argument('--nep', required=True, help='Path to the NEP potential file.')
+    parser.add_argument('--out', default='gpumd_fc.npz', help='Output npz path.')
+    parser.add_argument('--supercell', type=int, nargs=3, default=[3, 3, 3],
+                        metavar=('NX', 'NY', 'NZ'), help='fc2/fc3 supercell.')
+    parser.add_argument('--third-supercell', type=int, nargs=3, default=None,
+                        metavar=('NX', 'NY', 'NZ'),
+                        help='Separate fc3 supercell (defaults to --supercell).')
+    parser.add_argument('--a', type=float, default=None,
+                        help='Si lattice constant (Angstrom); default: relaxed value.')
+    parser.add_argument('--threshold', type=float, default=0.0,
+                        help='Drop fc3 entries with |value| <= threshold.')
+    parser.add_argument('--acoustic-sum', action='store_true',
+                        help='Apply the acoustic sum rule to fc2 before writing.')
+    args = parser.parse_args(argv)
+
+    third = tuple(args.third_supercell) if args.third_supercell else tuple(args.supercell)
+    a0 = args.a if args.a is not None else relaxed_lattice_constant(args.nep)
+    atoms = silicon_unitcell(a=a0)
+    ph3 = compute_fc3(atoms, args.nep, supercell=tuple(args.supercell))
+    fc2, fc3 = to_kaldo_layout(ph3, atoms, tuple(args.supercell), third,
+                               threshold=args.threshold)
+    if args.acoustic_sum:
+        fc2 = apply_acoustic_sum_rule(fc2)
+    write_gpumd_fc(args.out, atoms, tuple(args.supercell), third, fc2, fc3,
+                   nep_path=args.nep, acoustic_sum_applied=args.acoustic_sum)
+    print('wrote', args.out)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
@@ -107,3 +107,248 @@ def test_fc3_returns_phono3py():
     assert ph3.fc3 is not None, "fc3 should be set after compute_fc3"
     assert ph3.fc2.ndim == 4, f"fc2 should be 4-D, got {ph3.fc2.ndim}-D"
     assert ph3.fc3.ndim == 6, f"fc3 should be 6-D, got {ph3.fc3.ndim}-D"
+
+
+# ---------------------------------------------------------------------------
+# Shared, cached phono3py object for the (expensive) B.3 / B.4 tests
+# ---------------------------------------------------------------------------
+
+_SC = (2, 2, 2)
+
+
+@pytest.fixture(scope='module')
+def si_ph3():
+    """A phono3py object for relaxed Si at supercell (2, 2, 2), computed once."""
+    a0 = g.relaxed_lattice_constant(NEP)
+    atoms = g.silicon_unitcell(a=a0)
+    ph3 = g.compute_fc3(atoms, NEP, supercell=_SC, displacement=0.03)
+    return atoms, ph3
+
+
+def _full_fc2_phonopy(ph3):
+    """Return a FULL (N, N, 3, 3) fc2 in the phono3py supercell atom order.
+
+    Independent of the exporter: expands a compact fc2 by symmetry-translating
+    the reference-cell rows over every lattice image, mirroring how the full
+    array would have been produced.  Used only as test scaffolding.
+    """
+    import numpy as np
+    sc = ph3.supercell
+    s2u = np.array(sc.s2u_map)
+    p2s = list(np.array(ph3.primitive.p2s_map))
+    fc2 = np.array(ph3.fc2, dtype=np.float64)
+    n_satom = len(sc)
+    if fc2.shape[0] == n_satom:
+        return fc2
+    # Compact -> full: row a maps to (prim atom of a) translated to a's image.
+    scaled = np.array(sc.scaled_positions)
+    full = np.zeros((n_satom, n_satom, 3, 3), dtype=np.float64)
+    for a in range(n_satom):
+        prim_satom = s2u[a]                 # supercell index of a's prim image
+        c = p2s.index(prim_satom)           # compact row for that prim atom
+        # lattice shift from the reference image to atom a (in scaled coords)
+        shift = scaled[a] - scaled[prim_satom]
+        for b in range(n_satom):
+            # find b' = b shifted back by the same lattice vector
+            target = (scaled[b] - shift)
+            diff = scaled - target
+            diff -= np.rint(diff)
+            bp = int(np.argmin((diff ** 2).sum(axis=1)))
+            full[a, b] = fc2[c, bp]
+    return full
+
+
+def _kaldo_supercell_order(atoms, supercell):
+    """ase supercell built in kaldo's replication order (rep*n_uc + unit)."""
+    sx, sy, sz = supercell
+    return atoms * (sx, 1, 1) * (1, sy, 1) * (1, 1, sz)
+
+
+def _reorder_fc2_to_kaldo(ph3, atoms, supercell, full_fc2):
+    """Reorder a phono3py-ordered full fc2 into kaldo supercell atom order.
+
+    Maps each kaldo supercell atom (index rep*n_uc + unit) to the phono3py
+    supercell atom occupying the same Cartesian site, then permutes both axes.
+    """
+    import numpy as np
+    from kaldo.grid import Grid
+    sc = ph3.supercell
+    n_uc = len(atoms)
+    n_rep = int(np.prod(supercell))
+    grid = Grid(tuple(supercell), order='C').grid(is_wrapping=False)
+    cell = np.array(atoms.cell)
+    inv = np.linalg.inv(cell)
+    prim_pos = atoms.get_positions()
+    sc_cart = np.array(sc.scaled_positions) @ np.array(sc.cell)
+    s2u = np.array(sc.s2u_map)
+    u2u = sc.u2u_map
+    # phono3py supercell atom -> (rep, unit)
+    perm = np.empty(n_rep * n_uc, dtype=int)  # kaldo idx -> phono3py idx
+    for a in range(len(sc_cart)):
+        j = u2u[s2u[a]]
+        cidx = np.rint((sc_cart[a] - prim_pos[j]) @ inv).astype(int) % np.array(supercell)
+        r = np.where((grid == cidx).all(axis=1))[0][0]
+        perm[r * n_uc + j] = a
+    return full_fc2[np.ix_(perm, perm)]
+
+
+# ---------------------------------------------------------------------------
+# B.3 — fc2 layout matches an INDEPENDENT hiphive oracle (highest-risk bug)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_fc2_layout_matches_hiphive_oracle(si_ph3):
+    """Direct fc2 mapping must equal the hiphive route element-wise.
+
+    The oracle is built entirely in the TEST: full phono3py fc2 -> reorder to
+    kaldo replication order -> hiphive ForceConstants.from_arrays -> kaldo's
+    own transform (transpose(0,2,1,3).reshape(...)[0][None]).  This exercises
+    the replica permutation, which Gamma-only checks cannot see.
+    """
+    from hiphive import ForceConstants as HFC
+    atoms, ph3 = si_ph3
+    n_uc = len(atoms)
+    n_rep = int(np.prod(_SC))
+
+    fc2_mine, _ = g.to_kaldo_layout(ph3, atoms, _SC, _SC)
+    assert fc2_mine.shape == (1, n_uc, 3, n_rep, n_uc, 3)
+    assert fc2_mine.dtype == np.float64
+
+    full = _full_fc2_phonopy(ph3)
+    fc2_kaldo_order = _reorder_fc2_to_kaldo(ph3, atoms, _SC, full)
+    ase_sc = _kaldo_supercell_order(atoms, _SC)
+    hfc = HFC.from_arrays(ase_sc, fc2_array=fc2_kaldo_order)
+    arr = hfc.get_fc_array(2).transpose(0, 2, 1, 3)
+    arr = arr.reshape((n_rep, n_uc, 3, n_rep, n_uc, 3))
+    fc2_oracle = arr[0][np.newaxis]
+
+    max_diff = np.abs(fc2_mine - fc2_oracle).max()
+    print(f"\nfc2 max abs diff vs hiphive oracle: {max_diff:.3e}")
+    np.testing.assert_allclose(fc2_mine, fc2_oracle, atol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# B.3 — fc3 layout sanity (shape/dtype, non-empty, acoustic sum residual)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_fc3_layout_shape_and_sum_rule(si_ph3):
+    """fc3 has kaldo shape/dtype, is non-empty, and obeys the acoustic sum."""
+    import sparse
+    atoms, ph3 = si_ph3
+    n_uc = len(atoms)
+    n_rep = int(np.prod(_SC))
+    _, fc3 = g.to_kaldo_layout(ph3, atoms, _SC, _SC)
+    assert isinstance(fc3, sparse.COO)
+    assert fc3.shape == (n_uc * 3, n_rep * n_uc * 3, n_rep * n_uc * 3)
+    assert fc3.data.dtype == np.float64
+    assert fc3.nnz > 0, "fc3 should be non-empty"
+
+    dense = fc3.todense().reshape(
+        (n_uc, 3, n_rep, n_uc, 3, n_rep, n_uc, 3))
+    # Sum over the third leg (l3, k, gamma) for each (i, alpha, l2, j, beta).
+    residual = np.abs(dense.sum(axis=(5, 6, 7))).max()
+    print(f"\nfc3 acoustic sum residual: {residual:.3e} eV/A^3")
+    # phono3py produce_fc3 default does NOT symmetrize, so allow a loose bound.
+    assert residual < 1e-2, f"fc3 acoustic sum residual too large: {residual:.3e}"
+
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_fc3_matches_hiphive_oracle(si_ph3, tmp_path):
+    """Strong fc3 oracle: element-wise match against hiphive read_phono3py.
+
+    Builds the oracle in the TEST by writing phono3py fc3 to hdf5, reading it
+    back through hiphive, reordering to kaldo replication order, and applying
+    kaldo's own fc3 transform.  Independent of the exporter's mapping.
+    """
+    from phono3py.file_IO import write_fc3_to_hdf5
+    from hiphive import ForceConstants as HFC
+    atoms, ph3 = si_ph3
+    n_uc = len(atoms)
+    n_rep = int(np.prod(_SC))
+
+    _, fc3_mine = g.to_kaldo_layout(ph3, atoms, _SC, _SC)
+
+    # Expand compact fc3 to full, then reorder to kaldo supercell order.
+    full3 = _full_fc3_phonopy(ph3)
+    full3 = _reorder_fc3_to_kaldo(ph3, atoms, _SC, full3)
+    h5 = tmp_path / 'fc3.hdf5'
+    write_fc3_to_hdf5(full3, filename=str(h5))
+    ase_sc = _kaldo_supercell_order(atoms, _SC)
+    hfc = HFC.read_phono3py(ase_sc, str(h5))
+    arr = hfc.get_fc_array(3).transpose(0, 3, 1, 4, 2, 5)
+    arr = arr.reshape((n_rep, n_uc, 3, n_rep, n_uc, 3, n_rep, n_uc, 3))
+    # kaldo fc3 logical layout: row=(i,alpha) at reference cell (rep 0),
+    # col1=(l2,j,beta), col2=(l3,k,gamma).
+    oracle = np.zeros((n_uc * 3, n_rep * n_uc * 3, n_rep * n_uc * 3),
+                      dtype=np.float64)
+    for i in range(n_uc):
+        for al in range(3):
+            for l2 in range(n_rep):
+                for j in range(n_uc):
+                    for be in range(3):
+                        for l3 in range(n_rep):
+                            for k in range(n_uc):
+                                block = arr[0, i, al, l2, j, be, l3, k, :]
+                                row = i * 3 + al
+                                c1 = (l2 * n_uc + j) * 3 + be
+                                base = (l3 * n_uc + k) * 3
+                                oracle[row, c1, base:base + 3] = block
+    mine = fc3_mine.todense()
+    max_diff = np.abs(mine - oracle).max()
+    print(f"\nfc3 max abs diff vs hiphive oracle: {max_diff:.3e}")
+    np.testing.assert_allclose(mine, oracle, atol=1e-8)
+
+
+def _full_fc3_phonopy(ph3):
+    """Expand a compact phono3py fc3 to full (N, N, N, 3, 3, 3). Test-only."""
+    import numpy as np
+    sc = ph3.supercell
+    s2u = np.array(sc.s2u_map)
+    p2s = list(np.array(ph3.primitive.p2s_map))
+    fc3 = np.array(ph3.fc3, dtype=np.float64)
+    n_satom = len(sc)
+    if fc3.shape[0] == n_satom:
+        return fc3
+    scaled = np.array(sc.scaled_positions)
+
+    def shifted_index(idx, shift):
+        target = scaled[idx] - shift
+        diff = scaled - target
+        diff -= np.rint(diff)
+        return int(np.argmin((diff ** 2).sum(axis=1)))
+
+    full = np.zeros((n_satom, n_satom, n_satom, 3, 3, 3), dtype=np.float64)
+    for a in range(n_satom):
+        prim_satom = s2u[a]
+        c = p2s.index(prim_satom)
+        shift = scaled[a] - scaled[prim_satom]
+        for b in range(n_satom):
+            bp = shifted_index(b, shift)
+            for cc in range(n_satom):
+                cp = shifted_index(cc, shift)
+                full[a, b, cc] = fc3[c, bp, cp]
+    return full
+
+
+def _reorder_fc3_to_kaldo(ph3, atoms, supercell, full_fc3):
+    """Reorder a phono3py-ordered full fc3 into kaldo supercell atom order."""
+    import numpy as np
+    from kaldo.grid import Grid
+    sc = ph3.supercell
+    n_uc = len(atoms)
+    n_rep = int(np.prod(supercell))
+    grid = Grid(tuple(supercell), order='C').grid(is_wrapping=False)
+    cell = np.array(atoms.cell)
+    inv = np.linalg.inv(cell)
+    prim_pos = atoms.get_positions()
+    sc_cart = np.array(sc.scaled_positions) @ np.array(sc.cell)
+    s2u = np.array(sc.s2u_map)
+    u2u = sc.u2u_map
+    perm = np.empty(n_rep * n_uc, dtype=int)
+    for a in range(len(sc_cart)):
+        j = u2u[s2u[a]]
+        cidx = np.rint((sc_cart[a] - prim_pos[j]) @ inv).astype(int) % np.array(supercell)
+        r = np.where((grid == cidx).all(axis=1))[0][0]
+        perm[r * n_uc + j] = a
+    return full_fc3[np.ix_(perm, perm, perm)]

--- a/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
@@ -59,3 +59,49 @@ def test_equilibrium_forces_small():
     assert f.shape == (2, 3)
     assert np.abs(f).max() < 1e-6, (
         f"Forces not near zero at relaxed a0={a0:.4f}: max|F|={np.abs(f).max():.2e}")
+
+
+# ---------------------------------------------------------------------------
+# B.2 — fc2 via phonopy, fc3 via phono3py
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_fc2_returns_phonopy():
+    """compute_fc2 returns a Phonopy object."""
+    from phonopy import Phonopy
+    a0 = g.relaxed_lattice_constant(NEP)
+    atoms = g.silicon_unitcell(a=a0)
+    ph = g.compute_fc2(atoms, NEP, supercell=(2, 2, 2), displacement=0.01)
+    assert isinstance(ph, Phonopy)
+
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_fc2_gamma_optical_frequency():
+    """Gamma-point optical frequency of Si is physical (~15.5 THz).
+
+    Uses the relaxed NEP lattice constant a0 so the acoustic sum rule is
+    not contaminated by residual stress.  The Fan-2022 Si NEP4 gives an
+    optical mode near 14.3 THz at the relaxed volume (accept 14.0–16.5 THz).
+    """
+    a0 = g.relaxed_lattice_constant(NEP)
+    atoms = g.silicon_unitcell(a=a0)
+    ph = g.compute_fc2(atoms, NEP, supercell=(3, 3, 3), displacement=0.01)
+    ph.run_mesh([1, 1, 1])  # Gamma only
+    freqs = ph.get_mesh_dict()['frequencies'][0]  # THz
+    print(f"\nGamma frequencies (THz): {freqs}")
+    # triply-degenerate optical mode near 15.5 THz for diamond Si
+    assert 14.0 < max(freqs) < 16.5, (
+        f"Max Gamma frequency {max(freqs):.2f} THz outside 14.0–16.5 THz window. "
+        f"Full list: {freqs}")
+
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_fc3_returns_phono3py():
+    """compute_fc3 returns a Phono3py object with fc2 and fc3 set."""
+    from phono3py import Phono3py
+    a0 = g.relaxed_lattice_constant(NEP)
+    atoms = g.silicon_unitcell(a=a0)
+    ph3 = g.compute_fc3(atoms, NEP, supercell=(2, 2, 2), displacement=0.03)
+    assert isinstance(ph3, Phono3py)
+    assert ph3.fc2 is not None, "fc2 should be set after compute_fc3"
+    assert ph3.fc3 is not None, "fc3 should be set after compute_fc3"

--- a/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
@@ -105,3 +105,5 @@ def test_fc3_returns_phono3py():
     assert isinstance(ph3, Phono3py)
     assert ph3.fc2 is not None, "fc2 should be set after compute_fc3"
     assert ph3.fc3 is not None, "fc3 should be set after compute_fc3"
+    assert ph3.fc2.ndim == 4, f"fc2 should be 4-D, got {ph3.fc2.ndim}-D"
+    assert ph3.fc3.ndim == 6, f"fc3 should be 6-D, got {ph3.fc3.ndim}-D"

--- a/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
@@ -1,4 +1,4 @@
-"""Tests for gpumd_to_kaldo.py — B.1 and B.2.
+"""Tests for gpumd_to_kaldo.py — B.1 through B.4.
 
 Run from this directory:
     conda run -n gpumd-kaldo python -m pytest test_gpumd_to_kaldo.py -v
@@ -225,6 +225,72 @@ def test_fc2_layout_matches_hiphive_oracle(si_ph3):
     max_diff = np.abs(fc2_mine - fc2_oracle).max()
     print(f"\nfc2 max abs diff vs hiphive oracle: {max_diff:.3e}")
     np.testing.assert_allclose(fc2_mine, fc2_oracle, atol=1e-8)
+
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_fc2_dispersion_matches_phonopy_nonGamma(si_ph3, tmp_path):
+    """Non-Gamma frequencies from the exported fc match phonopy's native ones.
+
+    This is an INDEPENDENT cross-check of the replica -> R-vector pairing in
+    ``to_kaldo_layout``.  The hiphive fc2 oracle and the Gamma frequency test
+    cannot catch a replica-permutation bug: the oracle reuses the exporter's own
+    C-grid formula, and D(Gamma) = sum_r phi_r is invariant under any permutation
+    of the replicas.  Phonopy, by contrast, builds the dynamical matrix from its
+    OWN real-space R-vectors (it never touches kaldo's C grid), so comparing
+    frequencies at non-Gamma q-points pins down whether each phi_r block sits on
+    the correct R-vector.  A wrong permutation shifts whole modes by several THz
+    (verified offline: rolling the replica axis by 1 drives the max diff to
+    ~24 THz), so the 2e-2 THz tolerance below is tight enough to expose it while
+    absorbing the small finite-displacement / ASR numerical noise (~7e-3 THz).
+
+    Both routes use the SAME primitive ``atoms`` and the SAME (2, 2, 2)
+    supercell, so reduced-coordinate q maps 1:1 between phonopy's reduced
+    q-points and kaldo's fractional-reciprocal ``q_point``.  The q-points are all
+    COMMENSURATE with the supercell (components in {0, 1/2}); at those points the
+    Fourier sum is exact and independent of the min-image R-vector choice, so the
+    comparison probes the replica mapping rather than interpolation conventions.
+    (Incommensurate points such as [0.25, 0.25, 0.25] legitimately differ between
+    the two codes because of differing real-space image conventions and are
+    therefore excluded.)
+    """
+    pytest.importorskip('kaldo')
+    from kaldo.forceconstants import ForceConstants
+    from kaldo.observables.harmonic_with_q import HarmonicWithQ
+    atoms, ph3 = si_ph3
+
+    # --- phonopy-native reference (its own R-vectors, no kaldo C grid) ---
+    ph = g.compute_fc2(atoms, NEP, supercell=_SC, displacement=0.01)
+    gamma = [0.0, 0.0, 0.0]
+    nongamma = [[0.5, 0.0, 0.0], [0.0, 0.5, 0.0], [0.0, 0.0, 0.5],
+                [0.5, 0.5, 0.0], [0.5, 0.0, 0.5], [0.0, 0.5, 0.5],
+                [0.5, 0.5, 0.5]]
+    qpoints = [gamma] + nongamma
+    ph.run_qpoints(qpoints)
+    phonopy_freqs = ph.get_qpoints_dict()['frequencies']  # (nq, n_modes) THz
+
+    # --- kaldo-from-exported (round-trips through to_kaldo_layout + writer) ---
+    fc2, fc3 = g.to_kaldo_layout(ph3, atoms, _SC, _SC)
+    fc2 = g.apply_acoustic_sum_rule(fc2)
+    g.write_gpumd_fc(str(tmp_path / 'gpumd_fc.npz'), atoms, _SC, _SC, fc2, fc3,
+                     nep_path=NEP, acoustic_sum_applied=True)
+    fc = ForceConstants.from_folder(folder=str(tmp_path), format='gpumd')
+
+    def kaldo_freqs(q):
+        hwq = HarmonicWithQ(q_point=np.array(q, dtype=float), second=fc.second,
+                            storage='numpy')
+        return hwq.frequency[0]  # (n_modes,) THz
+
+    # Sanity anchor: the two q-conventions must agree at Gamma first.
+    np.testing.assert_allclose(np.sort(kaldo_freqs(gamma)),
+                               np.sort(phonopy_freqs[0]), atol=2e-2)
+
+    max_diff = 0.0
+    for q, ph_f in zip(nongamma, phonopy_freqs[1:]):
+        k_sorted = np.sort(kaldo_freqs(q))
+        p_sorted = np.sort(ph_f)
+        max_diff = max(max_diff, float(np.abs(k_sorted - p_sorted).max()))
+        np.testing.assert_allclose(k_sorted, p_sorted, atol=2e-2)
+    print(f"\nnon-Gamma freq max abs diff (kaldo vs phonopy): {max_diff:.3e} THz")
 
 
 @pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')

--- a/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
@@ -1,0 +1,61 @@
+"""Tests for gpumd_to_kaldo.py — B.1 and B.2.
+
+Run from this directory:
+    conda run -n gpumd-kaldo python -m pytest test_gpumd_to_kaldo.py -v
+
+The SI_NEP env var (or the relative path default) must point to the
+Si_2022_NEP4_4body.txt potential file.
+"""
+import os
+
+import numpy as np
+import pytest
+
+import gpumd_to_kaldo as g
+
+NEP = os.environ.get(
+    'SI_NEP',
+    os.path.join(os.path.dirname(__file__), '..', '..', '..', 'potentials', 'nep',
+                 'Si_2022_NEP4_4body.txt'))
+
+_NEP_FOUND = os.path.isfile(NEP)
+
+
+# ---------------------------------------------------------------------------
+# B.1 — Si unit cell and NEP force helpers
+# ---------------------------------------------------------------------------
+
+def test_silicon_unitcell_shape():
+    """silicon_unitcell returns a 2-atom primitive cell."""
+    atoms = g.silicon_unitcell(a=5.43)
+    assert len(atoms) == 2
+    assert list(atoms.get_chemical_symbols()) == ['Si', 'Si']
+    assert atoms.cell.volume > 0
+    assert all(atoms.pbc)
+
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_nep_forces_shape():
+    """nep_forces returns an array of shape (n_atoms, 3)."""
+    atoms = g.silicon_unitcell(a=5.43)
+    f = g.nep_forces(atoms, NEP)
+    assert f.shape == (2, 3)
+
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_relaxed_lattice_constant():
+    """relaxed_lattice_constant returns an a0 near 5.45 Å for the Fan-2022 Si NEP."""
+    a0 = g.relaxed_lattice_constant(NEP)
+    # Fan-2022 Si NEP4 equilibrium is around 5.455 Å (not 5.43)
+    assert 5.43 < a0 < 5.47, f"a0={a0:.4f} out of expected range 5.43–5.47"
+
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_equilibrium_forces_small():
+    """Forces at the relaxed lattice constant are near machine zero."""
+    a0 = g.relaxed_lattice_constant(NEP)
+    atoms = g.silicon_unitcell(a=a0)
+    f = g.nep_forces(atoms, NEP)
+    assert f.shape == (2, 3)
+    assert np.abs(f).max() < 1e-6, (
+        f"Forces not near zero at relaxed a0={a0:.4f}: max|F|={np.abs(f).max():.2e}")

--- a/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
@@ -227,6 +227,21 @@ def test_fc2_layout_matches_hiphive_oracle(si_ph3):
     np.testing.assert_allclose(fc2_mine, fc2_oracle, atol=1e-8)
 
 
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_fc2_acoustic_sum_rule_zeroes_rows(si_ph3):
+    """After ASR, each reference atom's full fc2 row sums to ~0 (3x3 block)."""
+    atoms, ph3 = si_ph3
+    fc2, _ = g.to_kaldo_layout(ph3, atoms, _SC, _SC)
+    fc2_asr = g.apply_acoustic_sum_rule(fc2)
+    n_uc = fc2_asr.shape[1]
+    for i in range(n_uc):
+        row_sum = np.sum(fc2_asr[0, i, :, :, :, :], axis=(-2, -3))  # (3, 3)
+        assert np.abs(row_sum).max() < 1e-9, (
+            f"ASR residual for atom {i}: {np.abs(row_sum).max():.2e}")
+    # ASR must not mutate the input array
+    assert not np.shares_memory(fc2, fc2_asr)
+
+
 # ---------------------------------------------------------------------------
 # B.3 — fc3 layout sanity (shape/dtype, non-empty, acoustic sum residual)
 # ---------------------------------------------------------------------------
@@ -352,3 +367,80 @@ def _reorder_fc3_to_kaldo(ph3, atoms, supercell, full_fc3):
         r = np.where((grid == cidx).all(axis=1))[0][0]
         perm[r * n_uc + j] = a
     return full_fc3[np.ix_(perm, perm, perm)]
+
+
+# ---------------------------------------------------------------------------
+# B.4 — writer round-trips through the kaldo reader + end-to-end load
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_write_npz_roundtrips_through_kaldo_reader(si_ph3, tmp_path):
+    """write_gpumd_fc produces an npz the kaldo reader accepts byte-for-byte."""
+    pytest.importorskip('kaldo')
+    from kaldo.interfaces import gpumd_io
+    atoms, ph3 = si_ph3
+    fc2, fc3 = g.to_kaldo_layout(ph3, atoms, _SC, _SC)
+    out = tmp_path / 'gpumd_fc.npz'
+    g.write_gpumd_fc(str(out), atoms, _SC, _SC, fc2, fc3,
+                     nep_path=NEP, acoustic_sum_applied=False)
+    meta = gpumd_io.read_gpumd_fc(str(tmp_path))
+    assert meta['fc2'].shape == fc2.shape
+    np.testing.assert_allclose(meta['fc2'], fc2)
+    assert meta['fc3'].shape == fc3.shape
+    np.testing.assert_allclose(meta['fc3'].todense(), fc3.todense())
+    assert tuple(meta['supercell']) == _SC
+    assert tuple(meta['third_supercell']) == _SC
+    assert meta['acoustic_sum_applied'] is False
+
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_write_npz_records_nep_sha256(si_ph3, tmp_path):
+    """The npz embeds a sha256 of the NEP file in nep_potential."""
+    import hashlib
+    atoms, ph3 = si_ph3
+    fc2, fc3 = g.to_kaldo_layout(ph3, atoms, _SC, _SC)
+    out = tmp_path / 'gpumd_fc.npz'
+    g.write_gpumd_fc(str(out), atoms, _SC, _SC, fc2, fc3,
+                     nep_path=NEP, acoustic_sum_applied=True)
+    with open(NEP, 'rb') as fh:
+        sha = hashlib.sha256(fh.read()).hexdigest()
+    data = np.load(out, allow_pickle=False)
+    nep_field = str(data['nep_potential'])
+    assert sha in nep_field
+    assert bool(data['acoustic_sum_applied']) is True
+
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_end_to_end_force_constants_from_folder(si_ph3, tmp_path):
+    """ForceConstants.from_folder(format='gpumd') builds with correct shapes."""
+    pytest.importorskip('kaldo')
+    from kaldo.forceconstants import ForceConstants
+    atoms, ph3 = si_ph3
+    n_uc = len(atoms)
+    n_rep = int(np.prod(_SC))
+    fc2, fc3 = g.to_kaldo_layout(ph3, atoms, _SC, _SC)
+    fc2 = g.apply_acoustic_sum_rule(fc2)
+    g.write_gpumd_fc(str(tmp_path / 'gpumd_fc.npz'), atoms, _SC, _SC, fc2, fc3,
+                     nep_path=NEP, acoustic_sum_applied=True)
+    fc = ForceConstants.from_folder(folder=str(tmp_path), format='gpumd')
+    assert fc.second.value.shape == (1, n_uc, 3, n_rep, n_uc, 3)
+    assert fc.third.value.shape == (n_uc * 3, n_rep * n_uc * 3, n_rep * n_uc * 3)
+    assert tuple(fc.supercell) == _SC
+
+
+# ---------------------------------------------------------------------------
+# B.4 — CLI smoke test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_cli_writes_npz(tmp_path):
+    """main() wires compute -> layout -> ASR -> write and produces an npz."""
+    pytest.importorskip('kaldo')
+    from kaldo.interfaces import gpumd_io
+    out = tmp_path / 'gpumd_fc.npz'
+    g.main(['--nep', NEP, '--supercell', '2', '2', '2',
+            '--acoustic-sum', '--out', str(out)])
+    assert out.is_file()
+    meta = gpumd_io.read_gpumd_fc(str(tmp_path))
+    assert meta['acoustic_sum_applied'] is True
+    assert tuple(meta['supercell']) == (2, 2, 2)

--- a/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
+++ b/tools/Format_Conversion/gpumd_to_kaldo/test_gpumd_to_kaldo.py
@@ -205,6 +205,8 @@ def test_fc2_layout_matches_hiphive_oracle(si_ph3):
     own transform (transpose(0,2,1,3).reshape(...)[0][None]).  This exercises
     the replica permutation, which Gamma-only checks cannot see.
     """
+    pytest.importorskip('kaldo')
+    pytest.importorskip('hiphive')
     from hiphive import ForceConstants as HFC
     atoms, ph3 = si_ph3
     n_uc = len(atoms)
@@ -342,6 +344,8 @@ def test_fc3_matches_hiphive_oracle(si_ph3, tmp_path):
     back through hiphive, reordering to kaldo replication order, and applying
     kaldo's own fc3 transform.  Independent of the exporter's mapping.
     """
+    pytest.importorskip('kaldo')
+    pytest.importorskip('hiphive')
     from phono3py.file_IO import write_fc3_to_hdf5
     from hiphive import ForceConstants as HFC
     atoms, ph3 = si_ph3
@@ -510,3 +514,53 @@ def test_cli_writes_npz(tmp_path):
     meta = gpumd_io.read_gpumd_fc(str(tmp_path))
     assert meta['acoustic_sum_applied'] is True
     assert tuple(meta['supercell']) == (2, 2, 2)
+
+
+# ---------------------------------------------------------------------------
+# B.5 — CLI --structure option
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _NEP_FOUND, reason='Si NEP not found')
+def test_cli_structure_option(tmp_path):
+    """--structure PATH produces the same Gamma frequencies as the built-in Si path.
+
+    Writes the built-in Si cell to a POSCAR in tmp_path, then runs main() with
+    ``--structure``.  The resulting gpumd_fc.npz is loaded via kaldo
+    ``ForceConstants.from_folder(format='gpumd')`` and the Gamma-point
+    frequencies are compared against a reference run through the default
+    (built-in Si) path.  Both runs use ``--acoustic-sum`` and the same (2,2,2)
+    supercell so any index/unit bug would show as a large frequency discrepancy.
+    """
+    pytest.importorskip('kaldo')
+    from kaldo.forceconstants import ForceConstants
+    from kaldo.observables.harmonic_with_q import HarmonicWithQ
+
+    # --- reference: built-in Si path ---
+    ref_dir = tmp_path / 'ref'
+    ref_dir.mkdir()
+    g.main(['--nep', NEP, '--supercell', '2', '2', '2',
+            '--acoustic-sum', '--out', str(ref_dir / 'gpumd_fc.npz')])
+    fc_ref = ForceConstants.from_folder(folder=str(ref_dir), format='gpumd')
+    freqs_ref = np.sort(HarmonicWithQ(q_point=np.array([0.0, 0.0, 0.0]),
+                                      second=fc_ref.second,
+                                      storage='numpy').frequency[0])
+
+    # --- --structure path: write the built-in cell as a POSCAR ---
+    a0 = g.relaxed_lattice_constant(NEP)
+    atoms = g.silicon_unitcell(a=a0)
+    poscar = str(tmp_path / 'POSCAR')
+    import ase.io
+    ase.io.write(poscar, atoms, format='vasp')
+
+    struct_dir = tmp_path / 'struct'
+    struct_dir.mkdir()
+    g.main(['--nep', NEP, '--structure', poscar,
+            '--supercell', '2', '2', '2',
+            '--acoustic-sum', '--out', str(struct_dir / 'gpumd_fc.npz')])
+    fc_struct = ForceConstants.from_folder(folder=str(struct_dir), format='gpumd')
+    freqs_struct = np.sort(HarmonicWithQ(q_point=np.array([0.0, 0.0, 0.0]),
+                                         second=fc_struct.second,
+                                         storage='numpy').frequency[0])
+
+    np.testing.assert_allclose(freqs_struct, freqs_ref, atol=1e-6,
+                               err_msg='--structure Gamma freqs differ from built-in Si path')

--- a/tools/readme.md
+++ b/tools/readme.md
@@ -8,7 +8,7 @@ The tools are grouped into three categories for now:
 
 | **Category**            | **Tools**                                                    |
 | ----------------------- | ------------------------------------------------------------ |
-| Format Conversion       | abacus2xyz, castep2exyz, cp2k2xyz, dp2xyz, exyz2pdb, gmx2exyz, mtp2xyz, orca2xyz, runner2xyz, vasp2xyz, xtd2exyz, xyz2gro |
+| Format Conversion       | abacus2xyz, castep2exyz, cp2k2xyz, dp2xyz, exyz2pdb, gmx2exyz, gpumd_to_kaldo, mtp2xyz, orca2xyz, runner2xyz, vasp2xyz, xtd2exyz, xyz2gro |
 | Analysis and Processing | add_groups, energy-reference-aligner, get_max_rmse_xyz, hydrogen_bond_analysis, pbc_mol, pca_sampling, perturbed2poscar, rdf_adf, select_xyz_frames, shift_energy_to_zero, split_xyz, |
 | Miscellaneous           | doc_3.3.1, for_coding, md_tersoff, vim                       |
 


### PR DESCRIPTION
# Add `tools/Format_Conversion/gpumd_to_kaldo`: export NEP force constants to kaldo

## Motivation

[kaldo](https://github.com/nanotheorygroup/kaldo) solves the Boltzmann transport
equation / QHGK for phonon thermal transport. Users with a trained GPUMD **NEP**
potential currently have no turnkey way to feed it harmonic + anharmonic force
constants. GPUMD's engine does not serialize real-space interatomic force
constants (its `compute_phonon` output is a mass-weighted dynamical matrix on a
k-path, and there is no native third order), so the natural route is: evaluate
forces with the NEP via [calorine](https://gitlab.com/materials-modeling/calorine)
`CPUNEP`, build `fc2` (phonopy) and `fc3` (phono3py) by finite displacement, and
hand them to kaldo.

This tool does exactly that and writes a single compact `gpumd_fc.npz` that
kaldo reads through a new `format='gpumd'` loader (companion kaldo PR).

## What it does

`gpumd_to_kaldo.py` (library + CLI):
1. `CPUNEP` forces on phonopy/phono3py finite-displacement supercells → `fc2`, `fc3`.
2. Remaps phono3py's supercell/primitive indexing into kaldo's canonical
   C-grid replica layout (`fc2` dense `(1,n_uc,3,n_rep,n_uc,3)`; `fc3` sparse COO
   `(n_uc·3, n_rep·n_uc·3, n_rep·n_uc·3)`), handling phono3py's compact and full
   force-constant forms.
3. Optional acoustic sum rule; threshold + sparsify `fc3`.
4. Writes the self-describing `gpumd_fc.npz` (units, NEP sha256, grid order).

CLI: `python gpumd_to_kaldo.py --nep nep.txt --supercell 3 3 3 --acoustic-sum`
(defaults to a silicon cell; `--structure FILE` accepts any ASE-readable cell).

## Correctness — independently validated

The index remap is the load-bearing step, so it is checked three independent ways
(all in the committed test suite, `test_gpumd_to_kaldo.py`):
- **fc2 vs hiPhive** (`ForceConstants.from_arrays` → kaldo transform): max abs
  diff **8.9e-16**.
- **fc3 vs hiPhive `read_phono3py`**: **exact (0.0)**.
- **non-Γ dispersion vs phonopy-native** (the decisive replica-ordering check,
  since Γ alone is permutation-insensitive): agreement **7.5e-3 THz** across seven
  commensurate q-points; a deliberately corrupted replica axis breaks it by up to
  **23.9 THz**, proving the test has teeth.
- fc3 acoustic-sum residual **2.7e-13 eV/Å³**; Si Γ optical 14.33 THz (physical).

End-to-end on silicon (Fan-2022 NEP4, in-repo `potentials/nep/Si_2022_NEP4_4body.txt`):
the exported FCs load in kaldo and give a physical dispersion and a 300 K lattice
thermal conductivity in the expected range (see the companion kaldo PR / validation).

## Dependencies & footprint

`ase, calorine, phonopy, phono3py, numpy, scipy, sparse` for the exporter; `kaldo`
+ `hiphive` only for the cross-check tests (guarded with `pytest.importorskip`, so
the pure-NEP tests still run without them). New files only, under
`tools/Format_Conversion/gpumd_to_kaldo/`; no changes elsewhere in GPUMD.

## Notes

- The interchange format and the kaldo reader are a separate, decoupled PR to
  kaldo; the two agree only on the `gpumd_fc.npz` contract (documented in the
  tool's README).
