### PR TITLE
	modified:   src/main_gpumd/electron_stop.cu

### DIFF
--- a/src/main_gpumd/electron_stop.cu
+++ b/src/main_gpumd/electron_stop.cu
@@ -54,6 +54,7 @@ static void __global__ find_stopping_force(
       g_force[0 * num_atoms + i] = 0.0;
       g_force[1 * num_atoms + i] = 0.0;
       g_force[2 * num_atoms + i] = 0.0;
+      g_power_loss[i] = 0.0;
       return;
     }
 


### PR DESCRIPTION
The loss of the total energy in NVE ensemble:
<img width="1539" height="1077" alt="2f98ab35-1ce9-4ca7-9fe2-6da55da7d679" src="https://github.com/user-attachments/assets/1b426bdf-9343-4d47-a504-4aff8b870184" />
Before:
<img width="657" height="63" alt="1" src="https://github.com/user-attachments/assets/3234c4f2-5324-4ab3-8eba-e134e33a6204" />
Now:
<img width="642" height="47" alt="2" src="https://github.com/user-attachments/assets/3a9fe0ee-00ee-49d0-9b10-5568c5058815" />