### PR TITLE
fix(dp): pass gpu_rank=0 instead of num_gpus to DeepPot::init()

### DIFF
--- a/src/force/dp.cu
+++ b/src/force/dp.cu
@@ -68,7 +68,7 @@ void DP::initialize_dp(const char* filename_dp)
   int num_gpus;
   CHECK(gpuGetDeviceCount(&num_gpus));
   printf("\nInitialize deep potential by the file: %s and %d gpu(s).\n\n", filename_dp, num_gpus);
-  deep_pot.init(filename_dp, num_gpus);
+  deep_pot.init(filename_dp, 0);
   rc = deep_pot.cutoff();
   int numb_types = deep_pot.numb_types();
   int numb_types_spin = deep_pot.numb_types_spin();


### PR DESCRIPTION
## Bug

`src/force/dp.cu` passes `gpuGetDeviceCount()` (number of GPUs) as the second argument to `deep_pot.init()`:

```cpp
deep_pot.init(filename_dp, num_gpus); // num_gpus = gpuGetDeviceCount()
```

But `DeepPot::init(const std::string& model, const int& gpu_rank = 0, ...)` expects a **0-based device index**, not a count.

## Impact

| Machine | num_gpus | gpu_rank passed | Result |
|---------|----------|-----------------|--------|
| 1× GPU  | 1        | 1               | Works by luck (most backends tolerate it) |
| 2× GPU  | 2        | 2               | Out of bounds; pt2 backend interprets as multi-rank → crash |
| 4× GPU  | 4        | 4               | Out of bounds |

The error on multi-GPU nodes with `.pt2` (DPA4/SeZM) models:
```
DeePMD-kit Error: Multi-rank LAMMPS .pt2 inference requires the model
to be exported with use_loc_mapping=False ...
```

## Fix

```diff
-  deep_pot.init(filename_dp, num_gpus);
+  deep_pot.init(filename_dp, 0);
```

Hard-code `gpu_rank=0`. GPUMD always runs DP on a single GPU (multi-GPU is only for NEP via `NEP_MULTIGPU`). Users select the physical GPU via `CUDA_VISIBLE_DEVICES`.

> Note: `gpuGetDevice()` was considered but is not abstracted in `gpu_macro.cuh` (which covers both CUDA and HIP paths), and adding it is unnecessary since the DP device is always 0.

## Testing

Tested on 2× A800 node with a DPA4 water box (192 atoms, NVT 300K, 7000 steps):
- Before fix: crashes with multi-rank error
- After fix: runs successfully (164s, 8182 atom·step/s)
- O-O RDF matches ASE+DPA4 reference (first peak: 2.75 Å)