### PR TITLE
Added header information to output files or easier parsing

### DIFF
--- a/src/measure/compute_dpdt.cu
+++ b/src/measure/compute_dpdt.cu
@@ -92,6 +92,10 @@ void Compute_dpdt::preprocess(
   Force& force)
 {
   fid = fopen("dpdt.out", "a");
+  fprintf(fid, "# compute_dpdt %d\n", sample_interval);
+  fprintf(fid, "# format_version 1\n");
+  fprintf(fid, "# dt_output %.10e fs\n", time_step * sample_interval * TIME_UNIT_CONVERSION);
+  fprintf(fid, "# columns time_fs dpdt_x dpdt_y dpdt_z P_x P_y P_z\n");
   gpu_dpdt_per_atom.resize(3 * atom.number_of_atoms);
   gpu_dpdt_total.resize(3);
   cpu_dpdt_total.resize(3);

--- a/src/measure/compute_dpdt.cu
+++ b/src/measure/compute_dpdt.cu
@@ -94,6 +94,13 @@ void Compute_dpdt::preprocess(
   fid = fopen("dpdt.out", "a");
   fprintf(fid, "# compute_dpdt %d\n", sample_interval);
   fprintf(fid, "# format_version 1\n");
+  fprintf(fid, "# num_atoms %d\n", atom.number_of_atoms);
+  fprintf(
+    fid,
+    "# cell %.10e %.10e %.10e %.10e %.10e %.10e %.10e %.10e %.10e\n",
+    box.cpu_h[0], box.cpu_h[3], box.cpu_h[6],
+    box.cpu_h[1], box.cpu_h[4], box.cpu_h[7],
+    box.cpu_h[2], box.cpu_h[5], box.cpu_h[8]);
   fprintf(fid, "# dt_output %.10e fs\n", time_step * sample_interval * TIME_UNIT_CONVERSION);
   fprintf(fid, "# columns time_fs dpdt_x dpdt_y dpdt_z P_x P_y P_z\n");
   gpu_dpdt_per_atom.resize(3 * atom.number_of_atoms);

--- a/src/measure/dump_dipole.cu
+++ b/src/measure/dump_dipole.cu
@@ -135,6 +135,13 @@ void Dump_Dipole::preprocess(
     file_ = my_fopen(filename_.c_str(), "a");
     fprintf(file_, "# dump_dipole %d\n", dump_interval_);
     fprintf(file_, "# format_version 1\n");
+    fprintf(file_, "# num_atoms %d\n", atom.number_of_atoms);
+    fprintf(
+      file_,
+      "# cell %.10e %.10e %.10e %.10e %.10e %.10e %.10e %.10e %.10e\n",
+      box.cpu_h[0], box.cpu_h[3], box.cpu_h[6],
+      box.cpu_h[1], box.cpu_h[4], box.cpu_h[7],
+      box.cpu_h[2], box.cpu_h[5], box.cpu_h[8]);
     fprintf(file_, "# dt_output %.10e fs\n", time_step * dump_interval_ * TIME_UNIT_CONVERSION);
     fprintf(file_, "# columns step dipole_x dipole_y dipole_z\n");
     gpu_dipole_.resize(3);

--- a/src/measure/dump_dipole.cu
+++ b/src/measure/dump_dipole.cu
@@ -133,6 +133,10 @@ void Dump_Dipole::preprocess(
   if (dump_) {
     std::string filename_ = "dipole.out";
     file_ = my_fopen(filename_.c_str(), "a");
+    fprintf(file_, "# dump_dipole %d\n", dump_interval_);
+    fprintf(file_, "# format_version 1\n");
+    fprintf(file_, "# dt_output %.10e fs\n", time_step * dump_interval_ * TIME_UNIT_CONVERSION);
+    fprintf(file_, "# columns step dipole_x dipole_y dipole_z\n");
     gpu_dipole_.resize(3);
     cpu_dipole_.resize(3);
 

--- a/src/measure/dump_polarizability.cu
+++ b/src/measure/dump_polarizability.cu
@@ -136,6 +136,13 @@ void Dump_Polarizability::preprocess(
     file_ = my_fopen(filename_.c_str(), "a");
     fprintf(file_, "# dump_polarizability %d\n", dump_interval_);
     fprintf(file_, "# format_version 1\n");
+    fprintf(file_, "# num_atoms %d\n", atom.number_of_atoms);
+    fprintf(
+      file_,
+      "# cell %.10e %.10e %.10e %.10e %.10e %.10e %.10e %.10e %.10e\n",
+      box.cpu_h[0], box.cpu_h[3], box.cpu_h[6],
+      box.cpu_h[1], box.cpu_h[4], box.cpu_h[7],
+      box.cpu_h[2], box.cpu_h[5], box.cpu_h[8]);
     fprintf(file_, "# dt_output %.10e fs\n", time_step * dump_interval_ * TIME_UNIT_CONVERSION);
     fprintf(file_, "# columns step pol_xx pol_yy pol_zz pol_xy pol_yz pol_zx\n");
     gpu_pol_.resize(6);

--- a/src/measure/dump_polarizability.cu
+++ b/src/measure/dump_polarizability.cu
@@ -134,6 +134,10 @@ void Dump_Polarizability::preprocess(
   if (dump_) {
     std::string filename_ = "polarizability.out";
     file_ = my_fopen(filename_.c_str(), "a");
+    fprintf(file_, "# dump_polarizability %d\n", dump_interval_);
+    fprintf(file_, "# format_version 1\n");
+    fprintf(file_, "# dt_output %.10e fs\n", time_step * dump_interval_ * TIME_UNIT_CONVERSION);
+    fprintf(file_, "# columns step pol_xx pol_yy pol_zz pol_xy pol_yz pol_zx\n");
     gpu_pol_.resize(6);
     cpu_pol_.resize(6);
 


### PR DESCRIPTION
This PR adds a small header to the output files written by `dump_dipole`, `dump_polarizability`, and `dump_dpdt`. The header includes information that makes it (much) easier to parse these files for processing.

The header is written as a number of comment lines prepended by a hash mark (`#`) to minimize interfering with existing parsers.

This PR does not touch the output columns. In the future one could, however, consider dropping the `step`/`time` columns as they contain redundant information that still consumes (disk) space. 

If the change proposed in this PR is found generally useful, one could easily add similar headers to other output files.