### PR TITLE
Fix: correct PPPM per-atom virial handling for k=0 and virial-dependent outputs

### DIFF
--- a/src/force/pppm.cu
+++ b/src/force/pppm.cu
@@ -258,6 +258,15 @@ void __global__ find_mesh_virial(
       g_mesh_virial_yz[n] = {B * GSx, B * GSy};
       B = -alpha_k_factor * kz * kx;
       g_mesh_virial_zx[n] = {B * GSx, B * GSy};
+    } else {
+      // The k = 0 mode must be reset explicitly because mesh_virial is reused in-place
+      // across steps and later overwritten by inverse FFT output.
+      g_mesh_virial_xx[n] = {0.0f, 0.0f};
+      g_mesh_virial_yy[n] = {0.0f, 0.0f};
+      g_mesh_virial_zz[n] = {0.0f, 0.0f};
+      g_mesh_virial_xy[n] = {0.0f, 0.0f};
+      g_mesh_virial_yz[n] = {0.0f, 0.0f};
+      g_mesh_virial_zx[n] = {0.0f, 0.0f};
     }
   }
 }

--- a/src/utilities/read_file.cu
+++ b/src/utilities/read_file.cu
@@ -126,6 +126,28 @@ bool check_need_peratom_virial()
         need_peratom_virial = true;
         break;
       }
+      if (tokens[0] == "compute") {
+        for (const auto& token : tokens) {
+          if (token == "virial" || token == "jp") {
+            need_peratom_virial = true;
+            break;
+          }
+        }
+        if (need_peratom_virial) {
+          break;
+        }
+      }
+      if (tokens[0] == "dump_xyz") {
+        for (const auto& token : tokens) {
+          if (token == "virial") {
+            need_peratom_virial = true;
+            break;
+          }
+        }
+        if (need_peratom_virial) {
+          break;
+        }
+      }
     }
   }
   input_run.close();


### PR DESCRIPTION
**Summary**

This PR fixes two PPPM correctness issues in GPUMD while keeping all existing input syntax unchanged. It ensures that PPPM produces consistent per-atom virials for outputs that explicitly depend on them, such as compute ... virial, compute ... jp, and dump_xyz ... virial.

**Modification**

1. The k = 0 entry in the PPPM per-atom virial mesh is now explicitly reset to zero. This prevents stale data from previous steps from being reused when mesh_virial is updated in place and later overwritten by inverse FFT output.

2. The logic that decides whether PPPM must compute true per-atom virials has been extended. Previously, some commands that consume per-atom virials could still fall back to the simplified path that distributes the total virial evenly across atoms. This PR makes compute ... virial, compute ... jp, and dump_xyz ... virial correctly trigger the full per-atom PPPM virial path.

**Others**

Thermal conductivity calculations using qNEP models trained for BaTiO3 and AlAs have been tested. In PPPM mode with a mesh spacing of 1 Angstrom, BaTiO3 gives results that are in very good agreement with Ewald mode. For AlAs, the calculated thermal conductivity is also consistent with the BTE thermal conductivity obtained with Born effective charge corrections.