### PR TITLE
Fix/rendering of documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN pip3 install --break-system-packages --no-cache-dir \
       sphinx-rtd-theme \
       sphinx_sitemap \
       sphinxcontrib-bibtex \
+      sphinx-tabs \
       nbsphinx
 
 CMD ["/bin/bash"]

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -12,18 +12,51 @@ The source code is hosted on `github <https://github.com/brucefan1983/GPUMD>`_.
 Prerequisites
 =============
 
-To compile (and run) :program:`GPUMD` one requires an Nvidia GPU card with compute capability no less than 3.5 and CUDA toolkit 9.0 or newer.
-On Linux systems, one also needs a C++ compiler supporting at least the C++11 standard.
-On Windows systems, one also needs the ``cl.exe`` compiler from Microsoft Visual Studio and a `64-bit version of make.exe <http://www.equation.com/servlet/equation.cmd?fa=make>`_.
+.. tabs::
 
-Alternatively, :program:`GPUMD` can be built for AMD GPUs through ROCm/HIP (see :ref:`Building for AMD GPUs <build_amd_hip>` below); this requires a ROCm installation.
+   .. tab:: Make
 
+      To compile (and run) :program:`GPUMD` one requires an Nvidia GPU card with compute capability no less than 3.5 and CUDA toolkit 9.0 or newer.
+      On Linux systems, one also needs a C++ compiler supporting at least the C++11 standard.
+      On Windows systems, one also needs the ``cl.exe`` compiler from Microsoft Visual Studio and a `64-bit version of make.exe <http://www.equation.com/servlet/equation.cmd?fa=make>`_.
+
+      Alternatively, :program:`GPUMD` can be built for AMD GPUs through ROCm/HIP (see :ref:`Building for AMD GPUs <build_amd_hip>` below); this requires a ROCm installation.
+
+   .. tab:: CMake (pre-release)
+
+      To compile (and run) :program:`GPUMD` one requires an Nvidia GPU card and CUDA toolkit.
+      On Linux systems, one also needs a C++ compiler supporting the C++17 standard.
+      On Windows systems, one also needs the ``cl.exe`` compiler from Microsoft Visual Studio and CMake 3.24 or newer.
+
+.. _compilation:
 
 Compilation
 ===========
 
-In the ``src`` directory run ``make``, which generates two executables, ``nep`` and ``gpumd``.
-Please check the comments in the beginning of the makefile for some compiling options.
+.. tabs::
+
+   .. tab:: Make
+
+      In the ``src`` directory run ``make``, which generates two executables, ``nep`` and ``gpumd``.
+      Please check the comments in the beginning of the makefile for some compiling options.
+
+   .. tab:: CMake (pre-release)
+
+      Configure and compile from the project root:
+
+      .. code-block:: bash
+
+        cmake -S . -B build
+        cmake --build build --config Release --parallel
+
+      The executables (``gpumd`` and ``nep``) will be placed in the ``build`` directory.
+      Omit ``--parallel`` to fall back to serial compilation.
+
+      To target a specific GPU architecture, add ``-D`` at configure time:
+
+      .. code-block:: bash
+
+        -D CMAKE_CUDA_ARCHITECTURES=value   # 80, 90, ... (default native)
 
 
 .. _build_amd_hip:
@@ -31,13 +64,21 @@ Please check the comments in the beginning of the makefile for some compiling op
 Building for AMD GPUs (ROCm/HIP)
 ================================
 
-:program:`GPUMD` also runs on AMD GPUs through ROCm/HIP. In the ``src`` directory, build with the HIP makefile instead of the default one::
+.. tabs::
 
-  make -f makefile.hip
+   .. tab:: Make
 
-This uses ``hipcc`` and links rocThrust/rocPRIM, hipBLAS, hipSOLVER, and hipFFT, so it requires a ROCm installation. The target GPU architecture defaults to ``gfx90a``; build for another AMD GPU by setting ``HIP_ARCH``::
+      :program:`GPUMD` also runs on AMD GPUs through ROCm/HIP. In the ``src`` directory, build with the HIP makefile instead of the default one::
 
-  make -f makefile.hip HIP_ARCH=gfx1100
+        make -f makefile.hip
+
+      This uses ``hipcc`` and links rocThrust/rocPRIM, hipBLAS, hipSOLVER, and hipFFT, so it requires a ROCm installation. The target GPU architecture defaults to ``gfx90a``; build for another AMD GPU by setting ``HIP_ARCH``::
+
+        make -f makefile.hip HIP_ARCH=gfx1100
+
+   .. tab:: CMake (pre-release)
+
+      CMake build for AMD GPUs is not yet supported.
 
 
 Examples
@@ -56,7 +97,19 @@ GNEP setup
 GNEP stands for a method of training NEP models using analytical Gradients (G stands for Gradients).
 See the `implementation paper <https://doi.org/10.1016/j.cpc.2025.109994/>`_ for details.
 
-To compile the ``gnep`` executable, one can run ``make gnep`` in the ``src`` directory.
+.. tabs::
+
+   .. tab:: Make
+
+      To compile the ``gnep`` executable, run ``make gnep`` in the ``src`` directory.
+
+   .. tab:: CMake (pre-release)
+
+      To compile the ``gnep`` executable, configure with CMake as described in the :ref:`compilation` section above, then run:
+
+      .. code-block:: bash
+
+        cmake --build build --target gnep
 
 The usage of the ``gnep`` executable is similar to that of the ``nep`` executable.
 The major difference is that training hyperparameters are written in ``gnep.in`` instead of ``nep.in``'
@@ -438,6 +491,7 @@ References
    single: NNAP Potential
 
 NNAP support
+============
 
 Program introduction
 --------------------

--- a/doc/publications.bib
+++ b/doc/publications.bib
@@ -29,6 +29,7 @@ journal = {Advanced Electronic Materials},
 volume = {11},
 pages = {2400944},
 year = {2025},
+number = {11},
 doi = {10.1002/aelm.202400944}
 }
 
@@ -37,6 +38,9 @@ author = {Bao, Yu and Song, Keke and Liu, Jiahui and Wang, Yanzhou and Ning, Yif
 title = {Atomistic understanding of hydrogen bubble-induced embrittlement in tungsten enabled by machine learning molecular dynamics},
 journal = {npj Computational Materials},
 year = {2026},
+volume = {12},
+pages = {108},
+number = {1},
 doi = {10.1038/s41524-026-01986-2}
 }
 
@@ -192,6 +196,9 @@ author = {Xitai Cai and Yuxun Wu and Libo Li and Lijun Liao and Penghua Ying and
 title = {{HULU}: {A} unified Monte Carlo framework for adsorption simulations with machine learning potentials},
 year = {2026},
 journal = {Nano Research},
+volume = {19},
+number = {4},
+pages = {94908548},
 doi = {10.26599/NR.2026.94908548}
 }
 
@@ -216,6 +223,17 @@ pages = {125359},
 doi = {10.1016/j.ijheatmasstransfer.2024.125359}
 }
 
+@article{CaoCheLiu26,
+title = {Interfacial engineering of core-shell {Cu@Zn} nanoclusters enables methane selective {CO₂} electroreduction via accelerated water dissociation},
+journal = {Chemical Engineering Journal},
+volume = {541},
+pages = {177779},
+year = {2026},
+issn = {1385-8947},
+doi = {10.1016/j.cej.2026.177779},
+author = {Wenlong Cao and Caiyu Chen and Hai Liu and Lei Yang and Tianlong Tan and Ruiyang Xu and Chengjian Ma and Tianyu Wang and Daniel Hedman and Shigeo Maruyama and Rong Xiang and Jue Wang and Qinfang Zhang}
+}
+
 @article{CaoJiaLi26,
 title = {Efficient Molecular Dynamics of Primary Radiation Damage in Vanadium Using Neuroevolution Potential},
 journal = {Journal of Nuclear Materials},
@@ -223,6 +241,7 @@ pages = {156726},
 year = {2026},
 issn = {0022-3115},
 doi = {10.1016/j.jnucmat.2026.156726},
+volume = {630},
 author = {Chenyang Cao and Xinfang Jia and Hongfei Li and Shuo Cao and Yanzhou Wang and Ping Qian}
 }
 
@@ -230,6 +249,7 @@ author = {Chenyang Cao and Xinfang Jia and Hongfei Li and Shuo Cao and Yanzhou W
 title = {Temperature-stable thermal transport in graphene antidot lattices: {Phonon} scattering regulation},
 journal = {Chemical Physics Letters},
 pages = {142740},
+volume = {890},
 year = {2026},
 issn = {0009-2614},
 doi = {10.1016/j.cplett.2026.142740},
@@ -284,10 +304,12 @@ doi = {10.1021/acs.jced.3c00561}
 
 @article{CheCaoBao26,
 author={Chen, Yuanyuan and Cao, Shuo and Bao, Yu and Song, KeKe and Qian, Ping and Su, Yanjing},
-title={Machine learning potential-assisted design of thermoelectricvperformance in anharmonic {CsPbBr₃} and {CsPbI₃}},
+title={Machine learning potential-assisted design for thermoelectric performance in anharmonic {CsPbBr₃} and {CsPbI₃}},
 journal={J. Mater. Chem. C},
 year={2026},
 publisher={The Royal Society of Chemistry},
+volume = {14},
+pages = {8701-8714},
 doi={10.1039/D6TC00498A}
 }
 
@@ -414,6 +436,19 @@ doi = {10.1016/j.cpc.2025.109859},
 author = {Chengbing Chen and Yutong Li and Rui Zhao and Zhoulin Liu and Zheyong Fan and Gang Tang and Zhiyong Wang}
 }
 
+@article{CheRenWan26,
+    author = {Che, Junwei and Ren, Guoliang and Wang, Xuezhi and Zhang, Shengli},
+    title = {Revisiting phonon thermal transport in perovskite {CsPbBr₃} crystals: {Critical} role of temperature-dependent quartic anharmonicity},
+    journal = {Applied Physics Letters},
+    volume = {128},
+    number = {24},
+    pages = {241904},
+    year = {2026},
+    month = {06},
+    issn = {0003-6951},
+    doi = {10.1063/5.0324950}
+}
+
 @article{CheSheKlo23,
   title = {Lattice dynamics and thermal transport of PbTe under high pressure},
   author = {Cheng, Ruihuan and Shen, Xingchen and Klotz, Stefan and Zeng, Zezhu and Li, Zehua and Ivanov, Alexandre and Xiao, Yu and Zhao, Li-Dong and Weber, Frank and Chen, Yue},
@@ -434,7 +469,7 @@ year = {2025},
 doi = {10.1016/j.commatsci.2025.114015}
 }
 
-@article{CheTaoLi26,
+@article{CheTaoLi26a,
 title = {Sequential transformation mediated twinning in a low stacking-fault energy {Cu}-{Sn}-{P} alloy: {The} essential precursor role of the 9{R} phase},
 journal = {Journal of Alloys and Compounds},
 volume = {1062},
@@ -442,6 +477,17 @@ pages = {187653},
 year = {2026},
 issn = {0925-8388},
 doi = {10.1016/j.jallcom.2026.187653},
+author = {Hao Chen and Yang Tao and Cheng Xin Li and Han Xiao}
+}
+
+@article{CheTaoLi26b,
+title = {Atomistic origin of faulting, twinning, and work hardening in {CuSn10P1} phosphor bronze revealed by in-situ characterization and machine-learning molecular dynamics},
+journal = {Journal of Alloys and Compounds},
+volume = {1074},
+pages = {189180},
+year = {2026},
+issn = {0925-8388},
+doi = {10.1016/j.jallcom.2026.189180},
 author = {Hao Chen and Yang Tao and Cheng Xin Li and Han Xiao}
 }
 
@@ -510,6 +556,7 @@ pages = {156704},
 year = {2026},
 issn = {0022-3115},
 doi = {10.1016/j.jnucmat.2026.156704},
+volume = {630},
 author = {Ming Chen and Yihao Wang and Junjie Yang and Yuchi Cui and Shengyi Zhong and Zhe Chen}
 }
 
@@ -556,6 +603,7 @@ pages = {121845},
 year = {2025},
 issn = {1359-6454},
 doi = {10.1016/j.actamat.2025.121845},
+volume = {305},
 author = {Ming Chen and Linfu Zhang and Kang Liu and Qiang Zhu and Jie Xu and Bin Guo and Debin Shan and Hushan Li and Guohua Fan and Tao Yang and Yinghao Zhou and Peng Zhang}
 }
 
@@ -862,6 +910,9 @@ author = {Fang, Yilin and Li, Weiyi and Hang, Guiyun and Wang, Jintao and Yun, X
 title = {New Insights into Thermal Transport in {ε}-{CL}-20 Revealed by Machine-Learned Potentials and Mode-Projection Analysis},
 journal = {The Journal of Physical Chemistry A},
 year = {2026},
+volume = {130},
+number = {22},
+pages = {4120-4135},
 doi = {10.1021/acs.jpca.6c00862}
 }
 
@@ -906,6 +957,9 @@ doi = {10.1021/acs.jpca.6c00862}
   title = {{qNEP}: {A} Highly Efficient Neuroevolution Potential with Dynamic Charges for Large-Scale Atomistic Simulations},
   journal = {Journal of Chemical Theory and Computation},
   year = {2026},
+  volume = {22},
+  number = {9},
+  pages = {4787-4801},
   doi = {10.1021/acs.jctc.6c00146},
   issn = {1549-9618},
   publisher = {American Chemical Society}
@@ -1279,6 +1333,19 @@ doi = {10.1016/j.jpowsour.2025.239008},
 author = {Sanqi Guo and Dinggen Li and Bo Xu}
 }
 
+@article{GuoWanQi26,
+    author = {Guo, Shijie and Wang, Qijun and Qi, Zijun and Sun, Zhanpeng and Ni, Jingyuan and Chen, Bingkun and Li, Rui and Shen, Wei and Wu, Gai},
+    title = {Shear-strain-dependent thermal conductivity of diamond explored via a machine learning potential},
+    journal = {Applied Physics Letters},
+    volume = {128},
+    number = {23},
+    pages = {231905},
+    year = {2026},
+    month = {06},
+    issn = {0003-6951},
+    doi = {10.1063/5.0336299}
+}
+
 @article{HaiFraDut25,
 author = {Hainer, Tobias and Fransson, Erik and Dutta, Sangita and Wiktor, Julia and Erhart, Paul},
 title = {A morphotropic phase boundary in {MA₁₋ₓFAₓPbI₃}: linking structure, dynamics, and electronic properties},
@@ -1453,6 +1520,7 @@ pages = {166672},
 year = {2026},
 issn = {0169-4332},
 doi = {10.1016/j.apsusc.2026.166672},
+volume = {735},
 author = {Dian Huang and Jun Lyu and Zhe Wu and Guihua Tang and Lin Yang}
 }
 
@@ -1518,6 +1586,7 @@ doi = {10.1016/j.mtphys.2025.101669}
 title = {Structures of iron and cobalt bimetallic clusters for optimized chemical vapor deposition growth of single-walled carbon nanotubes},
 journal = {Carbon},
 pages = {121679},
+volume = {257},
 year = {2026},
 issn = {0008-6223},
 doi = {10.1016/j.carbon.2026.121679},
@@ -1586,6 +1655,9 @@ author = {Ji, Shengnan and Ai, Qing and Chen, Jialong and Wang, Minyu and Liu, M
 title = {Interfacial Mechanical Properties and Optimization of {GaN}/Diamond Heterostructures via Machine Learning Potential},
 journal = {The Journal of Physical Chemistry C},
 year = {2026},
+volume = {130},
+number = {18},
+pages = {6663-6673},
 doi = {10.1021/acs.jpcc.6c00699}
 }
 
@@ -1605,6 +1677,9 @@ doi = {10.1021/acsami.5c06264}
 	title={Multi-fidelity, active-learning assisted design of {TaNbMoVW} refractory high-entropy alloys with superior mechanical properties},
 	journal={Journal of Physics: Materials},
 	year={2026},
+  volume = {9},
+  number = {2},
+  pages = {025003},
   doi={10.1088/2515-7639/ae44d1}
 }
 
@@ -1614,6 +1689,9 @@ doi = {10.1021/acsami.5c06264}
   journal={npj Computational Materials},
   year={2026},
   publisher={Nature Publishing Group UK London},
+  volume = {12},
+  number = {1},
+  pages = {132},
   doi = {10.1038/s41524-026-02012-1}
 }
 
@@ -1642,6 +1720,9 @@ doi={10.1088/1674-1056/ae039a}
 	title={Improve thermoelectric properties of Graphene nanoribbons based on resonant structure engineering},
 	journal={Chinese Physics B},
   doi = {10.1088/1674-1056/ae1950},
+  volume = {35},
+  number = {3},
+  pages = {037301},
 	year={2025}
 }
 
@@ -1711,6 +1792,9 @@ doi = {10.1021/acs.jpclett.4c03517}
   journal = {Nature},
   year = {2026},
   doi = {10.1038/s41586-026-10212-4},
+  volume = {651},
+  number = {8106},
+  pages = {621--625},
   issn = {1476-4687}
 }
 
@@ -1719,6 +1803,9 @@ author = {Laurila, Ossi and Jacklin, Tiia and Zakary, Ouail and Lantto, Perttu},
 title = {Machine Learning-Accelerated Path Integral Molecular Dynamics and {¹³C} {NMR} Simulations Unlock New Insights into Quantum Effects in {C₆₀} Fullerene},
 journal = {The Journal of Physical Chemistry A},
 year = {2026},
+volume = {130},
+number = {10},
+pages = {2169-2181},
 doi = {10.1021/acs.jpca.6c00238}
 }
 
@@ -1730,6 +1817,14 @@ volume = {16},
 year = {2025},
 pages = {4812--4818},
 doi = {10.1021/acs.jpclett.5c00778}
+}
+
+@article{LiaCaoWan26,
+author = {Liao, Wenkai and Cao, Wei and Wang, Ziyu and Miao, Ling and Shi, Jing and Xiong, Rui},
+title = {Theoretical Investigation of Grain-Boundary Engineering for Thermal Transport Control in Janus {2D} Transition Metal Dichalcogenides: {Implications} for Nanoscale Thermal Management},
+journal = {ACS Applied Nano Materials},
+year = {2026},
+doi = {10.1021/acsanm.6c00566}
 }
 
 @article{LiaFioSon25,
@@ -1772,6 +1867,9 @@ author = {Liao, Yujie and Suo, Pengfei and Wang, Changhao and Zhang, Jincang and
 title = {Advanced Machine Learning Interatomic Potential for Accelerated Atomistic Simulations of Lithiation Dynamics in Large-Scale {Si@C} Core-Shell Anodes},
 journal = {ACS Applied Materials \& Interfaces},
 year = {2025},
+volume = {18},
+number = {1},
+pages = {2996-3006},
 doi = {10.1021/acsami.5c18142}
 }
 
@@ -1792,6 +1890,9 @@ doi = {10.1021/acsami.5c18142}
   month = {Dec},
   issn = {2057-3960},
   journal = {npj Computational Materials},
+  volume = {12},
+  number = {1},
+  pages = {11},
   doi = {10.1038/s41524-025-01885-y}
 }
 
@@ -1800,6 +1901,9 @@ author = {Liang, Chenjia and Yao, Jun and Hou, Xiaoxia and Li, Liang and Gao, Ni
 title = {Dynamic Vibration-Coupled Energy Transfer for Boosting {ORR} Catalysts in Fuel Cells},
 journal = {Journal of the American Chemical Society},
 year = {2026},
+volume = {148},
+number = {5},
+pages = {5115-5124},
 doi = {10.1021/jacs.5c15936}
 }
 
@@ -2368,6 +2472,14 @@ issn = {2057-3960},
 doi = {10.1038/s41524-025-01849-2}
 }
 
+@article{LiWanZhe26,
+author = {Li, Mingqian and Wang, Lifeng and Zheng, Zhuoqun},
+title = {Virial-Matching in Machine Learning Coarse-Grained Potential for Multilayer {hBN}},
+journal = {The Journal of Physical Chemistry C},
+year = {2026},
+doi = {10.1021/acs.jpcc.6c01847}
+}
+
 @article{LiZhaCha25,
   author = {Li, Jianxin and Zhang, Hongwei and Chang, Tienchong},
   title = {Mechanical properties of twin graphene nanotube},
@@ -2457,6 +2569,19 @@ doi = {10.1002/smll.202409092}
   number = {2},
   pages = {024204},
   doi = {10.1103/PhysRevB.103.024204}
+}
+
+@article{LuoHuZha26,
+    author = {Luo, Jian and Hu, Yinglong and Zhang, Xinran and Ma, Hao},
+    title = {Unraveling the microscopic mechanism of thermal conductivity in {2D COF-C₆₀} assemblies via machine-learning potentials},
+    journal = {Applied Physics Letters},
+    volume = {128},
+    number = {24},
+    pages = {242202},
+    year = {2026},
+    month = {06},
+    issn = {0003-6951},
+    doi = {10.1063/5.0335720}
 }
 
 @article{LuoYinWan25,
@@ -2804,6 +2929,17 @@ volume = {258},
 pages = {114535},
 year = {2025},
 doi = {10.1016/j.matdes.2025.114535}
+}
+
+@article{QinZhaSun26,
+title = {{AI}-driven insight of interfacial evolution and {SEI} formation in {Br}-doped sulfide solid electrolyte/{Li} metal anode},
+journal = {Computational Materials Science},
+volume = {272},
+pages = {114868},
+year = {2026},
+issn = {0927-0256},
+doi = {10.1016/j.commatsci.2026.114868},
+author = {Yihan Qin and Pingyang Zhang and Haoze Sun and Ziqi Zuo and Qiyuan Song and Xujiang Wang}
 }
 
 @article{QiZhaMa26,
@@ -3188,6 +3324,14 @@ doi = {10.1016/j.jnucmat.2026.156475},
 author = {R.S. Stroud and C. Reynolds and T. Melichar and J. Haley and M. Carter and M. Moody and C. Hardie and D. Bowden and D. Nguyen-Manh and M.R. Wenman}
 }
 
+@article{SubHopGir26,
+author = {Subedi, Achyut and Hopkins, Patrick E. and Giri, Ashutosh},
+title = {Topology-Driven Node-Linker Coupling Enables Exceptional Thermal and Mechanical Performance in Covalent Organic Frameworks},
+journal = {ACS Nano},
+year = {2026},
+doi = {10.1021/acsnano.6c04527}
+}
+
 @article{SuCheWan23,
   title = {Origin of low lattice thermal conductivity and mobility of lead-free halide double perovskites},
   author = {Ye Su and Yuan-Yuan Chen and Hao Wang and Hai-Kuan Dong and Shuo Cao and Li-Bin Shi and Ping Qian},  
@@ -3521,6 +3665,17 @@ issn = {0021-8979},
 doi = {10.1063/5.0253919}
 }
 
+@article{WanDuaSha26,
+title = {Shear-coupled migration governed by misorientation angles and atomistic structures in {[1 1 0]} symmetric tilt grain boundaries of face-centered-cubic {Pt}},
+journal = {Acta Materialia},
+volume = {315},
+pages = {122408},
+year = {2026},
+issn = {1359-6454},
+doi = {10.1016/j.actamat.2026.122408},
+author = {Zhenduo Wang and Junwen Duan and Xuecheng Shao and Bo Gao}
+}
+
 @article{WanFanQia23,
   title = {Quantum-Corrected Thickness-Dependent Thermal Conductivity in Amorphous Silicon Predicted by Machine Learning Molecular Dynamics Simulations},
   author = {Wang, Yanzhou and Fan, Zheyong and Qian, Ping and Caro, Miguel A. and {Ala-Nissila}, Tapio},
@@ -3640,6 +3795,18 @@ volume = {16},
 number = {1},
 pages = {5504},
 doi = {10.1038/s41467-025-61390-0} 
+}
+
+@article{WanShiWan26,
+author = {Wang, Zhaoming and Shi, Guanghui and Wang, Guanghui and Wang, Man and Ding, Feng and Wang, Xiao},
+title = {Unveiling sodium storage mechanisms in hard carbon via machine learning-driven simulations integrated with accurate site occupation identification},
+journal = {Chem. Sci.},
+year = {2026},
+volume = {17},
+issue = {5},
+pages = {2547-2558},
+publisher = {The Royal Society of Chemistry},
+doi = {10.1039/D5SC07068F}
 }
 
 @article{WanShiYin25,
@@ -4633,6 +4800,17 @@ month = {02},
 doi = {10.1063/5.0241006}
 }
 
+@article{YouJinHan26,
+title = {Understanding the pressure-induced structural evolution and thermophysical response of {Mg-Zn} intermetallics via a neuroevolution potential},
+journal = {Journal of Materials Research and Technology},
+volume = {43},
+pages = {1002-1012},
+year = {2026},
+issn = {2238-7854},
+doi = {10.1016/j.jmrt.2026.06.105},
+author = {Zhiyong You and Shuaishuai Jin and Peide Han and Xiaofeng Niu and Hang Li}
+}
+
 @article{YuaGuoYi25,
   title = {Consistency between the {Green}-{Kubo} formula and the Lorentz model for predicting the infrared dielectric function of polar materials},
   author = {Yuan, Wei-Zhe and Guo, Yangyu and Yi, Hong-Liang},
@@ -4646,7 +4824,7 @@ doi = {10.1063/5.0241006}
   doi = {10.1103/PhysRevB.111.184310}
 }
 
-@article{YuaGuoYi26,
+@article{YuaGuoYi26a,
     author = {Yuan, Wei-Zhe and Guo, Yangyu and Yi, Hong-Liang},
     title = {Atomistic effect on infrared dielectric response of {GaN}/{AlN} superlattices},
     journal = {Applied Physics Reviews},
@@ -4657,6 +4835,19 @@ doi = {10.1063/5.0241006}
     month = {May},
     issn = {1931-9401},
     doi = {10.1063/5.0316648}
+}
+
+@article{YuaGuoYi26b,
+    author = {Yuan, Wei-Zhe and Guo, Yangyu and Yi, Hong-Liang},
+    title = {Dynamic charges effect on infrared dielectric response of polar materials},
+    journal = {Journal of Applied Physics},
+    volume = {139},
+    number = {22},
+    pages = {223104},
+    year = {2026},
+    month = {06},
+    issn = {0021-8979},
+    doi = {10.1063/5.0337379}
 }
 
 @article{YuBiLiu26,
@@ -5035,6 +5226,20 @@ year = {2025},
 doi = {10.1126/sciadv.adx5007}
 }
 
+@article{ZhaOuyFan26,
+  title = {Microscopic Mechanisms of Low Lattice Thermal Conductivity in {AlₓGa₁₋ₓN} Alloys Revealed by Neuroevolution Machine-Learning Potential},
+  author = {Zhang, Yuwen and Ouyang, Tao and Fan, Zheyong and Li, Wu},
+  journal = {PRX Energy},
+  volume = {5},
+  issue = {2},
+  pages = {023013},
+  numpages = {18},
+  year = {2026},
+  month = {Jun},
+  publisher = {American Physical Society},
+  doi = {10.1103/df1n-9bll}
+}
+
 @article{ZhaQinLiu25,
 author = {Guoqiang Zhang and Huasong Qin and Yilun Liu},
 title = {Strength of 2D materials with multiple defects},
@@ -5112,6 +5317,14 @@ doi = {10.1016/j.actamat.2026.121976},
 author = {Jiajun Zhang and Jiajun Wang and Yu Yan and Fei Wang and Jian Wang and Jianjiang Zhao and Yunmin Chen and Yang Ju and Hua Wei}
 }
 
+@article{ZhaWuTon26,
+	author={Zhai, Xin-Yue and Wu, Cheng-Wei and Tong, Hua and Zeng, Yu-Jia and Guo, Yan and Zhou, Wu-Xing},
+	title={Role of interfacial bonding and phonon spectral overlap in thermal transport across {GaN}/{c-BN} interfaces},
+	journal={Chinese Physics B},
+	doi={10.1088/1674-1056/ae7e71},
+	year={2026}
+}
+
 @article{ZhaWuWan26,
   author = {Zhang, Wentao and Wu, Xingxing and Wang, Chen and Hu, Siyu and Liu, Yueyang and Wang, Lin-Wang},
   title = {Constructing machine learning interatomic potentials with minimum amount of ab initio data},
@@ -5119,6 +5332,17 @@ author = {Jiajun Zhang and Jiajun Wang and Yu Yan and Fei Wang and Jian Wang and
   year = {2026},
   doi = {10.1038/s41524-026-02023-y},
   issn = {2057-3960}
+}
+
+@article{ZhaXiaQia26,
+title = {Strain-gradient-driven decoupling of thermal suppression from anisotropy in {β-Ga₂O₃}},
+journal = {Acta Materialia},
+volume = {307},
+pages = {121973},
+year = {2026},
+issn = {1359-6454},
+doi = {10.1016/j.actamat.2026.121973},
+author = {Guangwu Zhang and Xing Xiang and Ziyan Qian and Yixin Xu and Shengying Yue and Hyejin Jang and Lin Yang and Yanguang Zhou and Xinyu Wang and Qiye Zheng}
 }
 
 @article{ZhaXieTao25,

--- a/src/makefile
+++ b/src/makefile
@@ -15,15 +15,16 @@
 # some flags
 ###########################################################
 CC = nvcc
-CUDA_ARCH=-arch=sm_80
+CUDA_ARCH=-arch=sm_60
 ifdef OS # For Windows with the cl.exe compiler
 CFLAGS = -O3 $(CUDA_ARCH)
 else # For linux
-CFLAGS = -std=c++17 -O3 $(CUDA_ARCH) -DUSE_NETCDF
+CFLAGS = -std=c++14 -O3 $(CUDA_ARCH)
 endif
-INC = -I./ -I${HOME}/repos/netcdf/include
-LDFLAGS = -L${HOME}/repos/netcdf/lib
-LIBS = -lcublas -lcusolver -lcufft -l:libnetcdf.a
+INC = -I./
+LDFLAGS = 
+LIBS = -lcublas -lcusolver -lcufft
+
 
 ###########################################################
 # source files
@@ -41,6 +42,9 @@ SOURCES_GPUMD =                   \
 SOURCES_NEP =                     \
 	$(wildcard main_nep/*.cu)     \
 	$(wildcard utilities/*.cu)
+SOURCES_GNEP =                     \
+	$(wildcard main_gnep/*.cu)     \
+	$(wildcard utilities/*.cu)
 
 
 ###########################################################
@@ -49,9 +53,11 @@ SOURCES_NEP =                     \
 ifdef OS # For Windows with the cl.exe compiler
 OBJ_GPUMD = $(SOURCES_GPUMD:.cu=.obj)
 OBJ_NEP = $(SOURCES_NEP:.cu=.obj)
+OBJ_GNEP = $(SOURCES_GNEP:.cu=.obj)
 else
 OBJ_GPUMD = $(SOURCES_GPUMD:.cu=.o)
 OBJ_NEP = $(SOURCES_NEP:.cu=.o)
+OBJ_GNEP = $(SOURCES_GNEP:.cu=.o)
 endif
 
 
@@ -68,13 +74,14 @@ HEADERS =                         \
 	$(wildcard measure/*.cuh)     \
 	$(wildcard model/*.cuh)       \
 	$(wildcard phonon/*.cuh)      \
-	$(wildcard main_nep/*.cuh)
+	$(wildcard main_nep/*.cuh)    \
+	$(wildcard main_gnep/*.cuh)
 
 
 ###########################################################
 # executables
 ###########################################################
-all: gpumd nep
+all: gpumd nep 
 gpumd: $(OBJ_GPUMD)
 	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
 	@echo =================================================
@@ -84,6 +91,11 @@ nep: $(OBJ_NEP)
 	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
 	@echo =================================================
 	@echo The nep executable is successfully compiled!
+	@echo =================================================
+gnep: $(OBJ_GNEP)
+	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
+	@echo =================================================
+	@echo The gnep executable is successfully compiled!
 	@echo =================================================
 
 
@@ -111,6 +123,8 @@ phonon/%.obj: phonon/%.cu $(HEADERS)
 	$(CC) $(CFLAGS) $(INC) -c $< -o $@
 main_nep/%.obj: main_nep/%.cu $(HEADERS)
 	$(CC) $(CFLAGS) $(INC) -c $< -o $@
+main_gnep/%.obj: main_gnep/%.cu $(HEADERS)
+	$(CC) $(CFLAGS) $(INC) -c $< -o $@
 else # for Linux
 integrate/%.o: integrate/%.cu $(HEADERS)
 	$(CC) $(CFLAGS) $(INC) -c $< -o $@
@@ -132,6 +146,8 @@ phonon/%.o: phonon/%.cu $(HEADERS)
 	$(CC) $(CFLAGS) $(INC) -c $< -o $@
 main_nep/%.o: main_nep/%.cu $(HEADERS)
 	$(CC) $(CFLAGS) $(INC) -c $< -o $@
+main_gnep/%.o: main_gnep/%.cu $(HEADERS)
+	$(CC) $(CFLAGS) $(INC) -c $< -o $@
 endif
 
 
@@ -142,6 +158,6 @@ clean:
 ifdef OS
 	del /s *.obj *.exp *.lib *.exe
 else
-	rm -f */*.o gpumd nep
+	rm -f */*.o gpumd nep gnep
 endif
 


### PR DESCRIPTION
This PR addresses several issues that currently cause errors and warning during the deployment of the documentation. This includes
- adding `sphinx-tabs` to the Docker image
- fixing a broken reference on the installation page
- fixing duplicated reference keys in the publications file