### PR TITLE
Bumped arch to sm_86 in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ before_script:
   script:
   - mkdir $INSTDIR
   - cd src
-  - make CFLAGS="-std=c++14 -O3 -arch=sm_72 -DDEBUG" -j4
+  - make CFLAGS="-std=c++14 -O3 -arch=sm_86 -DDEBUG" -j4
   - mv gpumd nep ../$INSTDIR/
 
 build:linux:


### PR DESCRIPTION
Bumped GPU arch used during CI to sm_86 (Ampere) to work with more recent CUDA versions (13.1.1).