### PR TITLE
	modified:   src/force/neighbor.cu

### DIFF
--- a/src/force/neighbor.cu
+++ b/src/force/neighbor.cu
@@ -424,9 +424,9 @@ static __global__ void gpu_find_neighbor_ON1_ilp(
 
               bool different_layer = group_label[n1] != group_label[n2];
               if (different_layer && d2 < cutoff_square) {
-                NL[static_cast<size_t>(N) * count++ + n1] = n2;
+                NL[count++ * N + n1] = n2;
               } else if (!different_layer && d2 < big_ilp_cutoff_square) {
-                big_ilp_NL[static_cast<size_t>(N) * ilp_count++ + n1] = n2;
+                big_ilp_NL[ilp_count++ * N + n1] = n2;
               }
 
             }

--- a/src/force/neighbor.cu
+++ b/src/force/neighbor.cu
@@ -150,7 +150,7 @@ static __global__ void gpu_find_neighbor_ON1(
               const float d2 = x12 * x12 + y12 * y12 + z12 * z12;
 
               if (d2 < cutoff_square) {
-                NL[count++ * N + n1] = n2;
+                NL[static_cast<size_t>(N) * count++ + n1] = n2;
               }
             }
           }
@@ -424,9 +424,9 @@ static __global__ void gpu_find_neighbor_ON1_ilp(
 
               bool different_layer = group_label[n1] != group_label[n2];
               if (different_layer && d2 < cutoff_square) {
-                NL[count++ * N + n1] = n2;
+                NL[static_cast<size_t>(N) * count++ + n1] = n2;
               } else if (!different_layer && d2 < big_ilp_cutoff_square) {
-                big_ilp_NL[ilp_count++ * N + n1] = n2;
+                big_ilp_NL[static_cast<size_t>(N) * ilp_count++ + n1] = n2;
               }
 
             }
@@ -574,7 +574,7 @@ static __global__ void gpu_find_neighbor_ON1_SW(
               const double d2 = x12 * x12 + y12 * y12 + z12 * z12;
 
               if (d2 < cutoff_square && group_label[n1] ==  group_label[n2]) {
-                NL[count++ * N + n1] = n2;
+                NL[static_cast<size_t>(N) * count++ + n1] = n2;
               }
             }
           }
@@ -720,7 +720,7 @@ __global__ void gpu_find_local_neighbor_from_global(
   int count_local = 0;
 
   for (int i1 = 0; i1 < g_NN_global[n1]; ++i1) {
-    int n2 = g_NL_global[n1 + N * i1];
+    int n2 = g_NL_global[static_cast<size_t>(N) * i1 + n1];
     float x12 = g_x[n2] - x1;
     float y12 = g_y[n2] - y1;
     float z12 = g_z[n2] - z1;
@@ -730,7 +730,7 @@ __global__ void gpu_find_local_neighbor_from_global(
     if (d12_square >= rc_square) {
       continue;
     }
-    g_NL_local[count_local++ * N + n1] = n2;
+    g_NL_local[static_cast<size_t>(N) * count_local++ + n1] = n2;
   }
 
   g_NN_local[n1] = count_local;
@@ -826,7 +826,7 @@ void Neighbor::initialize(const double rc, const int num_atoms, const int num_ne
   const double rc_plus_skin = rc + skin;
   const int MN = num_neighbors * rc_plus_skin * rc_plus_skin * rc_plus_skin / (rc * rc * rc);
   NN.resize(num_atoms);
-  NL.resize(num_atoms * MN);
+  NL.resize(static_cast<size_t>(num_atoms) * MN);
   cell_count.resize(num_atoms);
   cell_count_sum.resize(num_atoms);
   cell_contents.resize(num_atoms);

--- a/src/force/neighbor.cuh
+++ b/src/force/neighbor.cuh
@@ -118,7 +118,7 @@ static __global__ void gpu_sort_neighbor_list(const int N, const int* NN, int* N
   extern __shared__ int atom_index_copy[];
 
   if (tid < neighbor_number) {
-    atom_index = NL[bid + tid * N];
+    atom_index = NL[static_cast<size_t>(N) * tid + bid];
     atom_index_copy[tid] = atom_index;
   }
   int count = 0;
@@ -131,7 +131,7 @@ static __global__ void gpu_sort_neighbor_list(const int N, const int* NN, int* N
   }
 
   if (tid < neighbor_number) {
-    NL[bid + count * N] = atom_index;
+    NL[static_cast<size_t>(N) * count + bid] = atom_index;
   }
 }
 
@@ -146,13 +146,13 @@ static __global__ void gpu_sort_neighbor_list_ilp(const int N, const int* NN, in
 
   if (neighbor_number <= 1024) {
     if (tid < neighbor_number) {
-      atom_index = NL[bid + tid * N];
+      atom_index = NL[static_cast<size_t>(N) * tid + bid];
       atom_index_copy[tid] = atom_index;
     }
   } else {
     int tid_plus = tid;
     for (int i = 0; tid_plus < neighbor_number; ++i) {
-      atom_index = NL[bid + tid_plus * N];
+      atom_index = NL[static_cast<size_t>(N) * tid_plus + bid];
       atom_index_copy[tid_plus] = atom_index;
       atom_index_hold[i] = atom_index;
       tid_plus += 1024;
@@ -169,7 +169,7 @@ static __global__ void gpu_sort_neighbor_list_ilp(const int N, const int* NN, in
     }
 
     if (tid < neighbor_number) {
-      NL[bid + count * N] = atom_index;
+      NL[static_cast<size_t>(N) * count + bid] = atom_index;
     }
   } else {
     int tid_plus = tid;
@@ -184,7 +184,7 @@ static __global__ void gpu_sort_neighbor_list_ilp(const int N, const int* NN, in
       }
 
       if (tid_plus < neighbor_number) {
-        NL[bid + count * N] = atom_index;
+        NL[static_cast<size_t>(N) * count + bid] = atom_index;
       }
       tid_plus += 1024;
     }

--- a/src/force/neighbor.cuh
+++ b/src/force/neighbor.cuh
@@ -146,13 +146,13 @@ static __global__ void gpu_sort_neighbor_list_ilp(const int N, const int* NN, in
 
   if (neighbor_number <= 1024) {
     if (tid < neighbor_number) {
-      atom_index = NL[static_cast<size_t>(N) * tid + bid];
+      atom_index = NL[bid + tid * N];
       atom_index_copy[tid] = atom_index;
     }
   } else {
     int tid_plus = tid;
     for (int i = 0; tid_plus < neighbor_number; ++i) {
-      atom_index = NL[static_cast<size_t>(N) * tid_plus + bid];
+      atom_index = NL[bid + tid_plus * N];
       atom_index_copy[tid_plus] = atom_index;
       atom_index_hold[i] = atom_index;
       tid_plus += 1024;
@@ -169,7 +169,7 @@ static __global__ void gpu_sort_neighbor_list_ilp(const int N, const int* NN, in
     }
 
     if (tid < neighbor_number) {
-      NL[static_cast<size_t>(N) * count + bid] = atom_index;
+      NL[bid + count * N] = atom_index;
     }
   } else {
     int tid_plus = tid;
@@ -184,7 +184,7 @@ static __global__ void gpu_sort_neighbor_list_ilp(const int N, const int* NN, in
       }
 
       if (tid_plus < neighbor_number) {
-        NL[static_cast<size_t>(N) * count + bid] = atom_index;
+        NL[bid + count * N] = atom_index;
       }
       tid_plus += 1024;
     }

--- a/src/force/nep.cu
+++ b/src/force/nep.cu
@@ -345,14 +345,14 @@ NEP::NEP(const char* file_potential, const int num_atoms)
     zbl.num_types = paramb.num_types;
   }
 
-  nep_data.f12x.resize(static_cast<size_t>(num_atoms) * paramb.MN_angular);
-  nep_data.f12y.resize(static_cast<size_t>(num_atoms) * paramb.MN_angular);
-  nep_data.f12z.resize(static_cast<size_t>(num_atoms) * paramb.MN_angular);
+  nep_data.f12x.resize(num_atoms * paramb.MN_angular);
+  nep_data.f12y.resize(num_atoms * paramb.MN_angular);
+  nep_data.f12z.resize(num_atoms * paramb.MN_angular);
   neighbor.initialize(rc, num_atoms, paramb.MN_radial);
   nep_data.NN_radial.resize(num_atoms);
   nep_data.NL_radial.resize(static_cast<size_t>(num_atoms) * paramb.MN_radial);
   nep_data.NN_angular.resize(num_atoms);
-  nep_data.NL_angular.resize(static_cast<size_t>(num_atoms) * paramb.MN_angular);
+  nep_data.NL_angular.resize(num_atoms * paramb.MN_angular);
   nep_data.Fp.resize(static_cast<size_t>(num_atoms) * annmb.dim);
   nep_data.sum_fxyz.resize(
     static_cast<size_t>(num_atoms) * (paramb.n_max_angular + 1) * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1));
@@ -446,7 +446,7 @@ static __global__ void find_neighbor_list_large_box(
     }
     g_NL_radial[static_cast<size_t>(N) * count_radial++ + n1] = n2;
     if (d12_square < rc_angular * rc_angular) {
-      g_NL_angular[static_cast<size_t>(N) * count_angular++ + n1] = n2;
+      g_NL_angular[count_angular++ * N + n1] = n2;
     }
   }
 
@@ -517,7 +517,7 @@ static __global__ void find_descriptor(
     for (int n = 0; n <= paramb.n_max_angular; ++n) {
       float s[NUM_OF_ABC] = {0.0f};
       for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
-        int n2 = g_NL_angular[static_cast<size_t>(N) * i1 + n1];
+        int n2 = g_NL_angular[n1 + N * i1];
         float x12 = g_x[n2] - x1;
         float y12 = g_y[n2] - y1;
         float z12 = g_z[n2] - z1;
@@ -775,8 +775,8 @@ static __global__ void find_partial_force_angular(
     double y1 = g_y[n1];
     double z1 = g_z[n1];
     for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
-      size_t index = static_cast<size_t>(N) * i1 + n1;
-      int n2 = g_NL_angular[index];
+      int index = i1 * N + n1;
+      int n2 = g_NL_angular[n1 + N * i1];
       float x12 = g_x[n2] - x1;
       float y12 = g_y[n2] - y1;
       float z12 = g_z[n2] - z1;
@@ -864,7 +864,7 @@ static __global__ void find_force_ZBL(
     int zi = zbl.atomic_numbers[type1];
     float pow_zi = pow(float(zi), 0.23f);
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
-      int n2 = g_NL[static_cast<size_t>(N) * i1 + n1];
+      int n2 = g_NL[n1 + N * i1];
       float x12 = g_x[n2] - x1;
       float y12 = g_y[n2] - y1;
       float z12 = g_z[n2] - z1;
@@ -1113,8 +1113,8 @@ void NEP::compute_small_box(
   const int N = type.size();
   const int grid_size = (N2 - N1 - 1) / BLOCK_SIZE + 1;
 
-  const size_t big_neighbor_size = 2000;
-  const size_t size_x12 = type.size() * big_neighbor_size;
+  const int big_neighbor_size = 2000;
+  const int size_x12 = type.size() * big_neighbor_size;
 
   find_neighbor_list_small_box<<<grid_size, BLOCK_SIZE>>>(
     paramb,
@@ -1327,10 +1327,10 @@ void NEP::compute(
   const bool is_small_box = get_expanded_box(paramb.rc_radial_max, box, ebox);
   if (is_small_box) {
     // update small_box_data
-    const size_t current_num_atoms = type.size();
+    const int current_num_atoms = type.size();
     if (small_box_data.NN_radial.size() != current_num_atoms) {
-        const size_t big_neighbor_size = 2000;
-        const size_t size_x12 = current_num_atoms * big_neighbor_size;
+        const int big_neighbor_size = 2000;
+        const int size_x12 = current_num_atoms * big_neighbor_size;
 
         small_box_data.NN_radial.resize(current_num_atoms);
         small_box_data.NL_radial.resize(size_x12);
@@ -1410,7 +1410,7 @@ static __global__ void find_descriptor(
     for (int n = 0; n <= paramb.n_max_angular; ++n) {
       float s[NUM_OF_ABC] = {0.0f};
       for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
-        int n2 = g_NL_angular[static_cast<size_t>(N) * i1 + n1];
+        int n2 = g_NL_angular[n1 + N * i1];
         float x12 = g_x[n2] - x1;
         float y12 = g_y[n2] - y1;
         float z12 = g_z[n2] - z1;
@@ -1631,8 +1631,8 @@ void NEP::compute_small_box(
   const int N = type.size();
   const int grid_size = (N2 - N1 - 1) / BLOCK_SIZE + 1;
 
-  const size_t big_neighbor_size = 2000;
-  const size_t size_x12 = type.size() * big_neighbor_size;
+  const int big_neighbor_size = 2000;
+  const int size_x12 = type.size() * big_neighbor_size;
 
   find_neighbor_list_small_box<<<grid_size, BLOCK_SIZE>>>(
     paramb,
@@ -1782,10 +1782,10 @@ void NEP::compute(
 
   if (is_small_box) {
     // update small_box_data
-    const size_t current_num_atoms = type.size();
+    const int current_num_atoms = type.size();
     if (small_box_data.NN_radial.size() != current_num_atoms) {
-        const size_t big_neighbor_size = 2000;
-        const size_t size_x12 = current_num_atoms * big_neighbor_size;
+        const int big_neighbor_size = 2000;
+        const int size_x12 = current_num_atoms * big_neighbor_size;
 
         small_box_data.NN_radial.resize(current_num_atoms);
         small_box_data.NL_radial.resize(size_x12);

--- a/src/force/nep.cu
+++ b/src/force/nep.cu
@@ -30,6 +30,7 @@ heat transport, Phys. Rev. B. 104, 104309 (2021).
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -344,17 +345,18 @@ NEP::NEP(const char* file_potential, const int num_atoms)
     zbl.num_types = paramb.num_types;
   }
 
-  nep_data.f12x.resize(num_atoms * paramb.MN_angular);
-  nep_data.f12y.resize(num_atoms * paramb.MN_angular);
-  nep_data.f12z.resize(num_atoms * paramb.MN_angular);
+  nep_data.f12x.resize(static_cast<size_t>(num_atoms) * paramb.MN_angular);
+  nep_data.f12y.resize(static_cast<size_t>(num_atoms) * paramb.MN_angular);
+  nep_data.f12z.resize(static_cast<size_t>(num_atoms) * paramb.MN_angular);
   neighbor.initialize(rc, num_atoms, paramb.MN_radial);
   nep_data.NN_radial.resize(num_atoms);
-  nep_data.NL_radial.resize(num_atoms * paramb.MN_radial);
+  nep_data.NL_radial.resize(static_cast<size_t>(num_atoms) * paramb.MN_radial);
   nep_data.NN_angular.resize(num_atoms);
-  nep_data.NL_angular.resize(num_atoms * paramb.MN_angular);
-  nep_data.Fp.resize(num_atoms * annmb.dim);
+  nep_data.NL_angular.resize(static_cast<size_t>(num_atoms) * paramb.MN_angular);
+  nep_data.Fp.resize(static_cast<size_t>(num_atoms) * annmb.dim);
   nep_data.sum_fxyz.resize(
-    num_atoms * (paramb.n_max_angular + 1) * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1));
+    static_cast<size_t>(num_atoms) * (paramb.n_max_angular + 1) *
+    ((paramb.L_max + 1) * (paramb.L_max + 1) - 1));
   nep_data.cpu_NN_radial.resize(num_atoms);
   nep_data.cpu_NN_angular.resize(num_atoms);
 
@@ -431,7 +433,7 @@ static __global__ void find_neighbor_list_large_box(
   int count_angular = 0;
 
   for (int i1 = 0; i1 < g_NN_global[n1]; ++i1) {
-    int n2 = g_NL_global[n1 + N * i1];
+    int n2 = g_NL_global[static_cast<size_t>(N) * i1 + n1];
     float x12 = g_x[n2] - x1;
     float y12 = g_y[n2] - y1;
     float z12 = g_z[n2] - z1;
@@ -443,9 +445,9 @@ static __global__ void find_neighbor_list_large_box(
     if (d12_square >= rc_radial * rc_radial) {
       continue;
     }
-    g_NL_radial[count_radial++ * N + n1] = n2;
+    g_NL_radial[static_cast<size_t>(N) * count_radial++ + n1] = n2;
     if (d12_square < rc_angular * rc_angular) {
-      g_NL_angular[count_angular++ * N + n1] = n2;
+      g_NL_angular[static_cast<size_t>(N) * count_angular++ + n1] = n2;
     }
   }
 
@@ -487,7 +489,7 @@ static __global__ void find_descriptor(
 
     // get radial descriptors
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
-      int n2 = g_NL[n1 + N * i1];
+      int n2 = g_NL[static_cast<size_t>(N) * i1 + n1];
       float x12 = g_x[n2] - x1;
       float y12 = g_y[n2] - y1;
       float z12 = g_z[n2] - z1;
@@ -516,7 +518,7 @@ static __global__ void find_descriptor(
     for (int n = 0; n <= paramb.n_max_angular; ++n) {
       float s[NUM_OF_ABC] = {0.0f};
       for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
-        int n2 = g_NL_angular[n1 + N * i1];
+        int n2 = g_NL_angular[static_cast<size_t>(N) * i1 + n1];
         float x12 = g_x[n2] - x1;
         float y12 = g_y[n2] - y1;
         float z12 = g_z[n2] - z1;
@@ -541,7 +543,8 @@ static __global__ void find_descriptor(
         paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
-        g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
+        g_sum_fxyz[static_cast<size_t>(N) *
+          (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
       }
     }
 
@@ -618,7 +621,7 @@ static __global__ void find_descriptor(
     g_pe[n1] += F;
 
     for (int d = 0; d < annmb.dim; ++d) {
-      g_Fp[d * N + n1] = Fp[d] * annmb.q_scaler[d];
+      g_Fp[static_cast<size_t>(N) * d + n1] = Fp[d] * annmb.q_scaler[d];
     }
   }
 }
@@ -662,7 +665,7 @@ static __global__ void find_force_radial(
     double y1 = g_y[n1];
     double z1 = g_z[n1];
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
-      int n2 = g_NL[n1 + N * i1];
+      int n2 = g_NL[static_cast<size_t>(N) * i1 + n1];
       int t2 = g_type[n2];
       float x12 = g_x[n2] - x1;
       float y12 = g_y[n2] - y1;
@@ -688,8 +691,8 @@ static __global__ void find_force_radial(
           gnp12 += fnp12[k] * annmb.c[c_index + t1 * paramb.num_types + t2];
           gnp21 += fnp12[k] * annmb.c[c_index + t2 * paramb.num_types + t1];
         }
-        float tmp12 = g_Fp[n1 + n * N] * gnp12 * d12inv;
-        float tmp21 = g_Fp[n2 + n * N] * gnp21 * d12inv;
+        float tmp12 = g_Fp[static_cast<size_t>(N) * n + n1] * gnp12 * d12inv;
+        float tmp21 = g_Fp[static_cast<size_t>(N) * n + n2] * gnp21 * d12inv;
         for (int d = 0; d < 3; ++d) {
           f12[d] += tmp12 * r12[d];
           f21[d] -= tmp21 * r12[d];
@@ -760,12 +763,13 @@ static __global__ void find_partial_force_angular(
     float Fp[MAX_DIM_ANGULAR] = {0.0f};
     float sum_fxyz[NUM_OF_ABC * MAX_NUM_N];
     for (int d = 0; d < paramb.dim_angular; ++d) {
-      Fp[d] = g_Fp[(paramb.n_max_radial + 1 + d) * N + n1];
+      Fp[d] = g_Fp[static_cast<size_t>(N) * (paramb.n_max_radial + 1 + d) + n1];
     }
     for (int n = 0; n < paramb.n_max_angular + 1; ++n) {
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         sum_fxyz[n * NUM_OF_ABC + abc] =
-          g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1];
+          g_sum_fxyz[static_cast<size_t>(N) *
+            (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1];
       }
     }
 
@@ -774,8 +778,8 @@ static __global__ void find_partial_force_angular(
     double y1 = g_y[n1];
     double z1 = g_z[n1];
     for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
-      int index = i1 * N + n1;
-      int n2 = g_NL_angular[n1 + N * i1];
+      size_t index = static_cast<size_t>(N) * i1 + n1;
+      int n2 = g_NL_angular[index];
       float x12 = g_x[n2] - x1;
       float y12 = g_y[n2] - y1;
       float z12 = g_z[n2] - z1;
@@ -863,7 +867,7 @@ static __global__ void find_force_ZBL(
     int zi = zbl.atomic_numbers[type1];
     float pow_zi = pow(float(zi), 0.23f);
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
-      int n2 = g_NL[n1 + N * i1];
+      int n2 = g_NL[static_cast<size_t>(N) * i1 + n1];
       float x12 = g_x[n2] - x1;
       float y12 = g_y[n2] - y1;
       float z12 = g_z[n2] - z1;
@@ -1112,8 +1116,8 @@ void NEP::compute_small_box(
   const int N = type.size();
   const int grid_size = (N2 - N1 - 1) / BLOCK_SIZE + 1;
 
-  const int big_neighbor_size = 2000;
-  const int size_x12 = type.size() * big_neighbor_size;
+  const size_t big_neighbor_size = 2000;
+  const size_t size_x12 = type.size() * big_neighbor_size;
 
   find_neighbor_list_small_box<<<grid_size, BLOCK_SIZE>>>(
     paramb,
@@ -1326,10 +1330,10 @@ void NEP::compute(
   const bool is_small_box = get_expanded_box(paramb.rc_radial_max, box, ebox);
   if (is_small_box) {
     // update small_box_data
-    const int current_num_atoms = type.size();
+    const size_t current_num_atoms = type.size();
     if (small_box_data.NN_radial.size() != current_num_atoms) {
-        const int big_neighbor_size = 2000;
-        const int size_x12 = current_num_atoms * big_neighbor_size;
+        const size_t big_neighbor_size = 2000;
+        const size_t size_x12 = current_num_atoms * big_neighbor_size;
 
         small_box_data.NN_radial.resize(current_num_atoms);
         small_box_data.NL_radial.resize(size_x12);
@@ -1381,7 +1385,7 @@ static __global__ void find_descriptor(
 
     // get radial descriptors
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
-      int n2 = g_NL[n1 + N * i1];
+      int n2 = g_NL[static_cast<size_t>(N) * i1 + n1];
       float x12 = g_x[n2] - x1;
       float y12 = g_y[n2] - y1;
       float z12 = g_z[n2] - z1;
@@ -1409,7 +1413,7 @@ static __global__ void find_descriptor(
     for (int n = 0; n <= paramb.n_max_angular; ++n) {
       float s[NUM_OF_ABC] = {0.0f};
       for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
-        int n2 = g_NL_angular[n1 + N * i1];
+        int n2 = g_NL_angular[static_cast<size_t>(N) * i1 + n1];
         float x12 = g_x[n2] - x1;
         float y12 = g_y[n2] - y1;
         float z12 = g_z[n2] - z1;
@@ -1434,7 +1438,8 @@ static __global__ void find_descriptor(
         paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
-        g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
+        g_sum_fxyz[static_cast<size_t>(N) *
+          (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
       }
     }
 
@@ -1452,7 +1457,7 @@ static __global__ void find_descriptor(
     g_pe[n1] += F;
 
     for (int d = 0; d < annmb.dim; ++d) {
-      g_Fp[d * N + n1] = Fp[d] * annmb.q_scaler[d];
+      g_Fp[static_cast<size_t>(N) * d + n1] = Fp[d] * annmb.q_scaler[d];
     }
   }
 }
@@ -1630,8 +1635,8 @@ void NEP::compute_small_box(
   const int N = type.size();
   const int grid_size = (N2 - N1 - 1) / BLOCK_SIZE + 1;
 
-  const int big_neighbor_size = 2000;
-  const int size_x12 = type.size() * big_neighbor_size;
+  const size_t big_neighbor_size = 2000;
+  const size_t size_x12 = type.size() * big_neighbor_size;
 
   find_neighbor_list_small_box<<<grid_size, BLOCK_SIZE>>>(
     paramb,
@@ -1781,10 +1786,10 @@ void NEP::compute(
 
   if (is_small_box) {
     // update small_box_data
-    const int current_num_atoms = type.size();
+    const size_t current_num_atoms = type.size();
     if (small_box_data.NN_radial.size() != current_num_atoms) {
-        const int big_neighbor_size = 2000;
-        const int size_x12 = current_num_atoms * big_neighbor_size;
+        const size_t big_neighbor_size = 2000;
+        const size_t size_x12 = current_num_atoms * big_neighbor_size;
 
         small_box_data.NN_radial.resize(current_num_atoms);
         small_box_data.NL_radial.resize(size_x12);

--- a/src/force/nep.cu
+++ b/src/force/nep.cu
@@ -355,8 +355,7 @@ NEP::NEP(const char* file_potential, const int num_atoms)
   nep_data.NL_angular.resize(static_cast<size_t>(num_atoms) * paramb.MN_angular);
   nep_data.Fp.resize(static_cast<size_t>(num_atoms) * annmb.dim);
   nep_data.sum_fxyz.resize(
-    static_cast<size_t>(num_atoms) * (paramb.n_max_angular + 1) *
-    ((paramb.L_max + 1) * (paramb.L_max + 1) - 1));
+    static_cast<size_t>(num_atoms) * (paramb.n_max_angular + 1) * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1));
   nep_data.cpu_NN_radial.resize(num_atoms);
   nep_data.cpu_NN_angular.resize(num_atoms);
 
@@ -543,8 +542,7 @@ static __global__ void find_descriptor(
         paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
-        g_sum_fxyz[static_cast<size_t>(N) *
-          (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
+        g_sum_fxyz[static_cast<size_t>(N) * (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
       }
     }
 
@@ -768,8 +766,7 @@ static __global__ void find_partial_force_angular(
     for (int n = 0; n < paramb.n_max_angular + 1; ++n) {
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         sum_fxyz[n * NUM_OF_ABC + abc] =
-          g_sum_fxyz[static_cast<size_t>(N) *
-            (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1];
+          g_sum_fxyz[static_cast<size_t>(N) * (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1];
       }
     }
 
@@ -1438,8 +1435,7 @@ static __global__ void find_descriptor(
         paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
-        g_sum_fxyz[static_cast<size_t>(N) *
-          (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
+        g_sum_fxyz[static_cast<size_t>(N) * (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
       }
     }
 

--- a/src/force/nep_multigpu.cu
+++ b/src/force/nep_multigpu.cu
@@ -28,6 +28,7 @@ when there is NVlink, but is also not very bad when there is only PCI-E.
 #include "utilities/error.cuh"
 #include "utilities/gpu_macro.cuh"
 #include "utilities/nep_utilities.cuh"
+#include <cstddef>
 #include <iostream>
 #include <string>
 #include <thrust/execution_policy.h>
@@ -396,11 +397,11 @@ void NEP_MULTIGPU::allocate_memory()
     nep_data[gpu].f12y.resize(nep_temp_data.num_atoms_per_gpu * paramb.MN_angular);
     nep_data[gpu].f12z.resize(nep_temp_data.num_atoms_per_gpu * paramb.MN_angular);
     nep_data[gpu].NN_radial.resize(nep_temp_data.num_atoms_per_gpu);
-    nep_data[gpu].NL_radial.resize(nep_temp_data.num_atoms_per_gpu * paramb.MN_radial);
+    nep_data[gpu].NL_radial.resize(static_cast<size_t>(nep_temp_data.num_atoms_per_gpu) * paramb.MN_radial);
     nep_data[gpu].NN_angular.resize(nep_temp_data.num_atoms_per_gpu);
     nep_data[gpu].NL_angular.resize(nep_temp_data.num_atoms_per_gpu * paramb.MN_angular);
-    nep_data[gpu].Fp.resize(nep_temp_data.num_atoms_per_gpu * annmb[gpu].dim);
-    nep_data[gpu].sum_fxyz.resize(nep_temp_data.num_atoms_per_gpu * (paramb.n_max_angular + 1) * 
+    nep_data[gpu].Fp.resize(static_cast<size_t>(nep_temp_data.num_atoms_per_gpu) * annmb[gpu].dim);
+    nep_data[gpu].sum_fxyz.resize(static_cast<size_t>(nep_temp_data.num_atoms_per_gpu) * (paramb.n_max_angular + 1) *
       ((paramb.L_max + 1) * (paramb.L_max + 1) - 1));
     nep_data[gpu].type.resize(nep_temp_data.num_atoms_per_gpu);
     nep_data[gpu].position.resize(nep_temp_data.num_atoms_per_gpu * 3);
@@ -778,7 +779,7 @@ static __global__ void find_neighbor_list_large_box(
             continue;
           }
 
-          g_NL_radial[count_radial++ * N + n1] = n2;
+          g_NL_radial[static_cast<size_t>(N) * count_radial++ + n1] = n2;
 
           if (d12_square < rc_angular * rc_angular) {
             g_NL_angular[count_angular++ * N + n1] = n2;
@@ -823,7 +824,7 @@ static __global__ void find_descriptor(
 
     // get radial descriptors
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
-      int n2 = g_NL[n1 + N * i1];
+      int n2 = g_NL[static_cast<size_t>(N) * i1 + n1];
       double x12double = g_x[n2] - x1;
       double y12double = g_y[n2] - y1;
       double z12double = g_z[n2] - z1;
@@ -877,7 +878,7 @@ static __global__ void find_descriptor(
       find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
-        g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
+        g_sum_fxyz[static_cast<size_t>(N) * (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
       }
     }
 
@@ -938,7 +939,7 @@ static __global__ void find_descriptor(
     g_pe[n1] = F;
 
     for (int d = 0; d < annmb.dim; ++d) {
-      g_Fp[d * N + n1] = Fp[d] * annmb.q_scaler[d];
+      g_Fp[static_cast<size_t>(N) * d + n1] = Fp[d] * annmb.q_scaler[d];
     }
   }
 }
@@ -982,7 +983,7 @@ static __global__ void find_force_radial(
     double y1 = g_y[n1];
     double z1 = g_z[n1];
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
-      int n2 = g_NL[n1 + N * i1];
+      int n2 = g_NL[static_cast<size_t>(N) * i1 + n1];
       int t2 = g_type[n2];
       double x12double = g_x[n2] - x1;
       double y12double = g_y[n2] - y1;
@@ -1008,8 +1009,8 @@ static __global__ void find_force_radial(
           gnp12 += fnp12[k] * annmb.c[c_index + t1 * paramb.num_types + t2];
           gnp21 += fnp12[k] * annmb.c[c_index + t2 * paramb.num_types + t1];
         }
-        float tmp12 = g_Fp[n1 + n * N] * gnp12 * d12inv;
-        float tmp21 = g_Fp[n2 + n * N] * gnp21 * d12inv;
+        float tmp12 = g_Fp[static_cast<size_t>(N) * n + n1] * gnp12 * d12inv;
+        float tmp21 = g_Fp[static_cast<size_t>(N) * n + n2] * gnp21 * d12inv;
         for (int d = 0; d < 3; ++d) {
           f12[d] += tmp12 * r12[d];
           f21[d] -= tmp21 * r12[d];
@@ -1080,12 +1081,12 @@ static __global__ void find_partial_force_angular(
     float Fp[MAX_DIM_ANGULAR] = {0.0f};
     float sum_fxyz[NUM_OF_ABC * MAX_NUM_N];
     for (int d = 0; d < paramb.dim_angular; ++d) {
-      Fp[d] = g_Fp[(paramb.n_max_radial + 1 + d) * N + n1];
+      Fp[d] = g_Fp[static_cast<size_t>(N) * (paramb.n_max_radial + 1 + d) + n1];
     }
     for (int n = 0; n < paramb.n_max_angular + 1; ++n) {
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         sum_fxyz[n * NUM_OF_ABC + abc] = 
-          g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1];
+          g_sum_fxyz[static_cast<size_t>(N) * (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1];
       }
     }
 
@@ -1832,7 +1833,7 @@ static __global__ void find_descriptor(
 
     // get radial descriptors
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
-      int n2 = g_NL[n1 + N * i1];
+      int n2 = g_NL[static_cast<size_t>(N) * i1 + n1];
       double x12double = g_x[n2] - x1;
       double y12double = g_y[n2] - y1;
       double z12double = g_z[n2] - z1;
@@ -1886,7 +1887,7 @@ static __global__ void find_descriptor(
       find_q(paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
-        g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
+        g_sum_fxyz[static_cast<size_t>(N) * (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
       }
     }
 
@@ -1904,7 +1905,7 @@ static __global__ void find_descriptor(
     g_pe[n1] = F;
 
     for (int d = 0; d < annmb.dim; ++d) {
-      g_Fp[d * N + n1] = Fp[d] * annmb.q_scaler[d];
+      g_Fp[static_cast<size_t>(N) * d + n1] = Fp[d] * annmb.q_scaler[d];
     }
   }
 }

--- a/src/force/nep_small_box.cuh
+++ b/src/force/nep_small_box.cuh
@@ -109,17 +109,19 @@ static __global__ void find_neighbor_list_small_box(
             float rc_angular = (paramb.rc_angular[t1] + paramb.rc_angular[t2]) * 0.5f;
 
             if (distance_square < rc_radial * rc_radial) {
-              g_NL_radial[count_radial * N + n1] = n2;
-              g_x12_radial[count_radial * N + n1] = x12;
-              g_y12_radial[count_radial * N + n1] = y12;
-              g_z12_radial[count_radial * N + n1] = z12;
+              const size_t index = static_cast<size_t>(N) * count_radial + n1;
+              g_NL_radial[index] = n2;
+              g_x12_radial[index] = x12;
+              g_y12_radial[index] = y12;
+              g_z12_radial[index] = z12;
               count_radial++;
             }
             if (distance_square < rc_angular * rc_angular) {
-              g_NL_angular[count_angular * N + n1] = n2;
-              g_x12_angular[count_angular * N + n1] = x12;
-              g_y12_angular[count_angular * N + n1] = y12;
-              g_z12_angular[count_angular * N + n1] = z12;
+              const size_t index = static_cast<size_t>(N) * count_angular + n1;
+              g_NL_angular[index] = n2;
+              g_x12_angular[index] = x12;
+              g_y12_angular[index] = y12;
+              g_z12_angular[index] = z12;
               count_angular++;
             }
           }
@@ -164,7 +166,7 @@ static __global__ void find_descriptor_small_box(
 
     // get radial descriptors
     for (int i1 = 0; i1 < g_NN_radial[n1]; ++i1) {
-      int index = i1 * N + n1;
+      size_t index = static_cast<size_t>(N) * i1 + n1;
       int n2 = g_NL_radial[index];
       float r12[3] = {g_x12_radial[index], g_y12_radial[index], g_z12_radial[index]};
       float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
@@ -190,7 +192,7 @@ static __global__ void find_descriptor_small_box(
     for (int n = 0; n <= paramb.n_max_angular; ++n) {
       float s[NUM_OF_ABC] = {0.0f};
       for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
-        int index = i1 * N + n1;
+        size_t index = static_cast<size_t>(N) * i1 + n1;
         int n2 = g_NL_angular[index];
         float r12[3] = {g_x12_angular[index], g_y12_angular[index], g_z12_angular[index]};
         float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
@@ -213,7 +215,8 @@ static __global__ void find_descriptor_small_box(
         paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
-        g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
+        g_sum_fxyz[static_cast<size_t>(N) *
+          (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
       }
     }
 
@@ -286,7 +289,7 @@ static __global__ void find_descriptor_small_box(
     g_pe[n1] += F;
 
     for (int d = 0; d < annmb.dim; ++d) {
-      g_Fp[d * N + n1] = Fp[d] * annmb.q_scaler[d];
+      g_Fp[static_cast<size_t>(N) * d + n1] = Fp[d] * annmb.q_scaler[d];
     }
   }
 }
@@ -321,7 +324,7 @@ static __global__ void find_descriptor_small_box(
 
     // get radial descriptors
     for (int i1 = 0; i1 < g_NN_radial[n1]; ++i1) {
-      int index = i1 * N + n1;
+      size_t index = static_cast<size_t>(N) * i1 + n1;
       int n2 = g_NL_radial[index];
       float r12[3] = {g_x12_radial[index], g_y12_radial[index], g_z12_radial[index]};
       float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
@@ -347,7 +350,7 @@ static __global__ void find_descriptor_small_box(
     for (int n = 0; n <= paramb.n_max_angular; ++n) {
       float s[NUM_OF_ABC] = {0.0f};
       for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
-        int index = i1 * N + n1;
+        size_t index = static_cast<size_t>(N) * i1 + n1;
         int n2 = g_NL_angular[index];
         float r12[3] = {g_x12_angular[index], g_y12_angular[index], g_z12_angular[index]};
         float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
@@ -370,7 +373,8 @@ static __global__ void find_descriptor_small_box(
         paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
-        g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
+        g_sum_fxyz[static_cast<size_t>(N) *
+          (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
       }
     }
 
@@ -388,7 +392,7 @@ static __global__ void find_descriptor_small_box(
     g_pe[n1] += F;
 
     for (int d = 0; d < annmb.dim; ++d) {
-      g_Fp[d * N + n1] = Fp[d] * annmb.q_scaler[d];
+      g_Fp[static_cast<size_t>(N) * d + n1] = Fp[d] * annmb.q_scaler[d];
     }
   }
 }
@@ -416,7 +420,7 @@ static __global__ void find_force_radial_small_box(
   if (n1 < N2) {
     int t1 = g_type[n1];
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
-      int index = i1 * N + n1;
+      size_t index = static_cast<size_t>(N) * i1 + n1;
       int n2 = g_NL[index];
       int t2 = g_type[n2];
       float r12[3] = {g_x12[index], g_y12[index], g_z12[index]};
@@ -437,7 +441,7 @@ static __global__ void find_force_radial_small_box(
           c_index += t1 * paramb.num_types + t2;
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
-        float tmp12 = g_Fp[n1 + n * N] * gnp12 * d12inv;
+        float tmp12 = g_Fp[static_cast<size_t>(N) * n + n1] * gnp12 * d12inv;
         for (int d = 0; d < 3; ++d) {
           f12[d] += tmp12 * r12[d];
         }
@@ -517,20 +521,21 @@ static __global__ void find_force_angular_small_box(
     float Fp[MAX_DIM_ANGULAR] = {0.0f};
     float sum_fxyz[NUM_OF_ABC * MAX_NUM_N];
     for (int d = 0; d < paramb.dim_angular; ++d) {
-      Fp[d] = g_Fp[(paramb.n_max_radial + 1 + d) * N + n1];
+      Fp[d] = g_Fp[static_cast<size_t>(N) * (paramb.n_max_radial + 1 + d) + n1];
     }
     for (int n = 0; n < paramb.n_max_angular + 1; ++n) {
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         sum_fxyz[n * NUM_OF_ABC + abc] = 
-          g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1];
+          g_sum_fxyz[static_cast<size_t>(N) *
+            (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1];
       }
     }
 
     int t1 = g_type[n1];
 
     for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
-      int index = i1 * N + n1;
-      int n2 = g_NL_angular[n1 + N * i1];
+      size_t index = static_cast<size_t>(N) * i1 + n1;
+      int n2 = g_NL_angular[index];
       float r12[3] = {g_x12[index], g_y12[index], g_z12[index]};
       float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
       float f12[3] = {0.0f};
@@ -639,7 +644,7 @@ static __global__ void find_force_ZBL_small_box(
     int zi = zbl.atomic_numbers[type1];
     float pow_zi = pow(float(zi), 0.23f);
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
-      int index = i1 * N + n1;
+      size_t index = static_cast<size_t>(N) * i1 + n1;
       int n2 = g_NL[index];
       float r12[3] = {g_x12[index], g_y12[index], g_z12[index]};
       float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);

--- a/src/force/nep_small_box.cuh
+++ b/src/force/nep_small_box.cuh
@@ -109,19 +109,17 @@ static __global__ void find_neighbor_list_small_box(
             float rc_angular = (paramb.rc_angular[t1] + paramb.rc_angular[t2]) * 0.5f;
 
             if (distance_square < rc_radial * rc_radial) {
-              const size_t index = static_cast<size_t>(N) * count_radial + n1;
-              g_NL_radial[index] = n2;
-              g_x12_radial[index] = x12;
-              g_y12_radial[index] = y12;
-              g_z12_radial[index] = z12;
+              g_NL_radial[static_cast<size_t>(N) * count_radial + n1] = n2;
+              g_x12_radial[static_cast<size_t>(N) * count_radial + n1] = x12;
+              g_y12_radial[static_cast<size_t>(N) * count_radial + n1] = y12;
+              g_z12_radial[static_cast<size_t>(N) * count_radial + n1] = z12;
               count_radial++;
             }
             if (distance_square < rc_angular * rc_angular) {
-              const size_t index = static_cast<size_t>(N) * count_angular + n1;
-              g_NL_angular[index] = n2;
-              g_x12_angular[index] = x12;
-              g_y12_angular[index] = y12;
-              g_z12_angular[index] = z12;
+              g_NL_angular[static_cast<size_t>(N) * count_angular + n1] = n2;
+              g_x12_angular[static_cast<size_t>(N) * count_angular + n1] = x12;
+              g_y12_angular[static_cast<size_t>(N) * count_angular + n1] = y12;
+              g_z12_angular[static_cast<size_t>(N) * count_angular + n1] = z12;
               count_angular++;
             }
           }
@@ -215,8 +213,7 @@ static __global__ void find_descriptor_small_box(
         paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
-        g_sum_fxyz[static_cast<size_t>(N) *
-          (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
+        g_sum_fxyz[static_cast<size_t>(N) * (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
       }
     }
 
@@ -373,8 +370,7 @@ static __global__ void find_descriptor_small_box(
         paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
-        g_sum_fxyz[static_cast<size_t>(N) *
-          (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
+        g_sum_fxyz[static_cast<size_t>(N) * (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
       }
     }
 
@@ -526,8 +522,7 @@ static __global__ void find_force_angular_small_box(
     for (int n = 0; n < paramb.n_max_angular + 1; ++n) {
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         sum_fxyz[n * NUM_OF_ABC + abc] = 
-          g_sum_fxyz[static_cast<size_t>(N) *
-            (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1];
+          g_sum_fxyz[static_cast<size_t>(N) * (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1];
       }
     }
 

--- a/src/force/nep_small_box.cuh
+++ b/src/force/nep_small_box.cuh
@@ -109,17 +109,17 @@ static __global__ void find_neighbor_list_small_box(
             float rc_angular = (paramb.rc_angular[t1] + paramb.rc_angular[t2]) * 0.5f;
 
             if (distance_square < rc_radial * rc_radial) {
-              g_NL_radial[static_cast<size_t>(N) * count_radial + n1] = n2;
-              g_x12_radial[static_cast<size_t>(N) * count_radial + n1] = x12;
-              g_y12_radial[static_cast<size_t>(N) * count_radial + n1] = y12;
-              g_z12_radial[static_cast<size_t>(N) * count_radial + n1] = z12;
+              g_NL_radial[count_radial * N + n1] = n2;
+              g_x12_radial[count_radial * N + n1] = x12;
+              g_y12_radial[count_radial * N + n1] = y12;
+              g_z12_radial[count_radial * N + n1] = z12;
               count_radial++;
             }
             if (distance_square < rc_angular * rc_angular) {
-              g_NL_angular[static_cast<size_t>(N) * count_angular + n1] = n2;
-              g_x12_angular[static_cast<size_t>(N) * count_angular + n1] = x12;
-              g_y12_angular[static_cast<size_t>(N) * count_angular + n1] = y12;
-              g_z12_angular[static_cast<size_t>(N) * count_angular + n1] = z12;
+              g_NL_angular[count_angular * N + n1] = n2;
+              g_x12_angular[count_angular * N + n1] = x12;
+              g_y12_angular[count_angular * N + n1] = y12;
+              g_z12_angular[count_angular * N + n1] = z12;
               count_angular++;
             }
           }
@@ -164,7 +164,7 @@ static __global__ void find_descriptor_small_box(
 
     // get radial descriptors
     for (int i1 = 0; i1 < g_NN_radial[n1]; ++i1) {
-      size_t index = static_cast<size_t>(N) * i1 + n1;
+      int index = i1 * N + n1;
       int n2 = g_NL_radial[index];
       float r12[3] = {g_x12_radial[index], g_y12_radial[index], g_z12_radial[index]};
       float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
@@ -190,7 +190,7 @@ static __global__ void find_descriptor_small_box(
     for (int n = 0; n <= paramb.n_max_angular; ++n) {
       float s[NUM_OF_ABC] = {0.0f};
       for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
-        size_t index = static_cast<size_t>(N) * i1 + n1;
+        int index = i1 * N + n1;
         int n2 = g_NL_angular[index];
         float r12[3] = {g_x12_angular[index], g_y12_angular[index], g_z12_angular[index]};
         float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
@@ -213,7 +213,7 @@ static __global__ void find_descriptor_small_box(
         paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
-        g_sum_fxyz[static_cast<size_t>(N) * (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
+        g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
       }
     }
 
@@ -286,7 +286,7 @@ static __global__ void find_descriptor_small_box(
     g_pe[n1] += F;
 
     for (int d = 0; d < annmb.dim; ++d) {
-      g_Fp[static_cast<size_t>(N) * d + n1] = Fp[d] * annmb.q_scaler[d];
+      g_Fp[d * N + n1] = Fp[d] * annmb.q_scaler[d];
     }
   }
 }
@@ -321,7 +321,7 @@ static __global__ void find_descriptor_small_box(
 
     // get radial descriptors
     for (int i1 = 0; i1 < g_NN_radial[n1]; ++i1) {
-      size_t index = static_cast<size_t>(N) * i1 + n1;
+      int index = i1 * N + n1;
       int n2 = g_NL_radial[index];
       float r12[3] = {g_x12_radial[index], g_y12_radial[index], g_z12_radial[index]};
       float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
@@ -347,7 +347,7 @@ static __global__ void find_descriptor_small_box(
     for (int n = 0; n <= paramb.n_max_angular; ++n) {
       float s[NUM_OF_ABC] = {0.0f};
       for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
-        size_t index = static_cast<size_t>(N) * i1 + n1;
+        int index = i1 * N + n1;
         int n2 = g_NL_angular[index];
         float r12[3] = {g_x12_angular[index], g_y12_angular[index], g_z12_angular[index]};
         float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
@@ -370,7 +370,7 @@ static __global__ void find_descriptor_small_box(
         paramb.L_max, paramb.has_q_222, paramb.has_q_1111, paramb.has_q_112, paramb.has_q_123, paramb.has_q_233, paramb.has_q_134,
         paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
-        g_sum_fxyz[static_cast<size_t>(N) * (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1] = s[abc];
+        g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1] = s[abc];
       }
     }
 
@@ -388,7 +388,7 @@ static __global__ void find_descriptor_small_box(
     g_pe[n1] += F;
 
     for (int d = 0; d < annmb.dim; ++d) {
-      g_Fp[static_cast<size_t>(N) * d + n1] = Fp[d] * annmb.q_scaler[d];
+      g_Fp[d * N + n1] = Fp[d] * annmb.q_scaler[d];
     }
   }
 }
@@ -416,7 +416,7 @@ static __global__ void find_force_radial_small_box(
   if (n1 < N2) {
     int t1 = g_type[n1];
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
-      size_t index = static_cast<size_t>(N) * i1 + n1;
+      int index = i1 * N + n1;
       int n2 = g_NL[index];
       int t2 = g_type[n2];
       float r12[3] = {g_x12[index], g_y12[index], g_z12[index]};
@@ -437,7 +437,7 @@ static __global__ void find_force_radial_small_box(
           c_index += t1 * paramb.num_types + t2;
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
-        float tmp12 = g_Fp[static_cast<size_t>(N) * n + n1] * gnp12 * d12inv;
+        float tmp12 = g_Fp[n1 + n * N] * gnp12 * d12inv;
         for (int d = 0; d < 3; ++d) {
           f12[d] += tmp12 * r12[d];
         }
@@ -517,20 +517,20 @@ static __global__ void find_force_angular_small_box(
     float Fp[MAX_DIM_ANGULAR] = {0.0f};
     float sum_fxyz[NUM_OF_ABC * MAX_NUM_N];
     for (int d = 0; d < paramb.dim_angular; ++d) {
-      Fp[d] = g_Fp[static_cast<size_t>(N) * (paramb.n_max_radial + 1 + d) + n1];
+      Fp[d] = g_Fp[(paramb.n_max_radial + 1 + d) * N + n1];
     }
     for (int n = 0; n < paramb.n_max_angular + 1; ++n) {
       for (int abc = 0; abc < (paramb.L_max + 1) * (paramb.L_max + 1) - 1; ++abc) {
         sum_fxyz[n * NUM_OF_ABC + abc] = 
-          g_sum_fxyz[static_cast<size_t>(N) * (n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) + n1];
+          g_sum_fxyz[(n * ((paramb.L_max + 1) * (paramb.L_max + 1) - 1) + abc) * N + n1];
       }
     }
 
     int t1 = g_type[n1];
 
     for (int i1 = 0; i1 < g_NN_angular[n1]; ++i1) {
-      size_t index = static_cast<size_t>(N) * i1 + n1;
-      int n2 = g_NL_angular[index];
+      int index = i1 * N + n1;
+      int n2 = g_NL_angular[n1 + N * i1];
       float r12[3] = {g_x12[index], g_y12[index], g_z12[index]};
       float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
       float f12[3] = {0.0f};
@@ -639,7 +639,7 @@ static __global__ void find_force_ZBL_small_box(
     int zi = zbl.atomic_numbers[type1];
     float pow_zi = pow(float(zi), 0.23f);
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
-      size_t index = static_cast<size_t>(N) * i1 + n1;
+      int index = i1 * N + n1;
       int n2 = g_NL[index];
       float r12[3] = {g_x12[index], g_y12[index], g_z12[index]};
       float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);


### PR DESCRIPTION
**Summary**
This PR adds local `size_t` casts to large NEP array size calculations and flattened neighbor-list/descriptor offsets that can exceed 32-bit integer range in large-system GPU runs.

**Modification**
- Cast large `GPU_Vector::resize()` products to `size_t` in `NEP::NEP()`:
  - `nep_data.NL_radial`
  - `nep_data.Fp`
  - `nep_data.sum_fxyz`

- Cast per-GPU `GPU_Vector::resize()` products to `size_t` in `NEP_MULTIGPU::allocate_memory()`:
  - `nep_data[gpu].NL_radial`
  - `nep_data[gpu].Fp`
  - `nep_data[gpu].sum_fxyz`

- Cast flattened NEP large-box offsets to `size_t` for:
  - global neighbor-list reads before building NEP radial lists
  - `NL_radial` writes and reads
  - `Fp` writes and reads
  - `sum_fxyz` writes and reads

- Cast the global neighbor-list allocation size in `Neighbor::initialize()`.

- Cast flattened global/local neighbor-list offsets in non-ILP global neighbor-list kernels.

- Cast flattened read/write offsets in the ordinary neighbor-list sort kernel in `neighbor.cuh`.


**Validation**
<img width="3505" height="1375" alt="A100_nve_new_old_speed_memory" src="https://github.com/user-attachments/assets/b2c47b8f-d55a-4e08-95e3-2dba79b28483" />
<img width="3531" height="1375" alt="2V100_nve_new_old_speed_memory" src="https://github.com/user-attachments/assets/22ce50b8-11cb-4cba-b789-cf5cbe3ce5a7" />

The x-axis is the number of atoms, shown on a logarithmic scale. The speed panel reports throughput in units of `10^7 atom step s^-1`. The memory panel reports peak GPU memory used in GiB. Blue circles represent the old version; orange squares represent the new version. Dashed vertical lines in the memory panel mark the first failed point for each version. The A100 speed panel includes an inset that zooms in on the high-atom-count region of the new version.

Compared with the old version, the new version reaches about 3.62x more atoms on A100 and about 1.47x more atoms on 2V100. The corresponding peak GPU memory usage increases from 22.50 to 77.69 GiB on A100, and from 39.54 to 57.22 GiB on 2V100.