### PR TITLE
Add more information to several output files

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -15,7 +15,7 @@
 # some flags
 ###########################################################
 CC = nvcc
-CUDA_ARCH=-arch=sm_60
+CUDA_ARCH=-arch=sm_80
 WARN_FLAGS = -Wall -Wextra
 WARN_FLAGS += -Wno-sign-compare -Wno-unused-parameter
 WARN_FLAGS += -Wnull-dereference -Wstringop-overflow -Wstringop-truncation -Wrestrict
@@ -26,11 +26,11 @@ WARN_FLAGS += -Wformat -Wformat-security -Wformat-overflow -Wformat-truncation
 ifdef OS # For Windows with the cl.exe compiler
 CFLAGS = -O3 $(CUDA_ARCH)
 else # For linux
-CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)"
+CFLAGS = -std=c++17 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)"
 endif
-INC = -I./
-LDFLAGS = 
-LIBS = -lcublas -lcusolver -lcufft
+INC = -I./ -I${HOME}/repos/netcdf/include
+LDFLAGS = -L${HOME}/repos/netcdf/lib
+LIBS = -lcublas -lcusolver -lcufft -l:libnetcdf.a
 
 
 ###########################################################

--- a/src/makefile
+++ b/src/makefile
@@ -15,7 +15,7 @@
 # some flags
 ###########################################################
 CC = nvcc
-CUDA_ARCH=-arch=sm_80
+CUDA_ARCH=-arch=sm_60
 WARN_FLAGS = -Wall -Wextra
 WARN_FLAGS += -Wno-sign-compare -Wno-unused-parameter
 WARN_FLAGS += -Wnull-dereference -Wstringop-overflow -Wstringop-truncation -Wrestrict
@@ -26,11 +26,11 @@ WARN_FLAGS += -Wformat -Wformat-security -Wformat-overflow -Wformat-truncation
 ifdef OS # For Windows with the cl.exe compiler
 CFLAGS = -O3 $(CUDA_ARCH)
 else # For linux
-CFLAGS = -std=c++17 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)"
+CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)"
 endif
-INC = -I./ -I${HOME}/repos/netcdf/include
-LDFLAGS = -L${HOME}/repos/netcdf/lib
-LIBS = -lcublas -lcusolver -lcufft -l:libnetcdf.a
+INC = -I./
+LDFLAGS = 
+LIBS = -lcublas -lcusolver -lcufft
 
 
 ###########################################################

--- a/src/measure/dump_thermo.cu
+++ b/src/measure/dump_thermo.cu
@@ -57,6 +57,17 @@ void Dump_Thermo::preprocess(
   Force& force)
 {
   fid_ = my_fopen("thermo.out", "a");
+  fprintf(fid_, "# dump_thermo %d\n", dump_interval_);
+  fprintf(fid_, "# format_version 1\n");
+  fprintf(fid_, "# num_atoms %d\n", atom.number_of_atoms);
+  fprintf(fid_, "# dt_output %.10e fs\n", time_step * dump_interval_ * TIME_UNIT_CONVERSION);
+  if (integrate.type >= 31) {
+    fprintf(
+      fid_,
+      "# columns T_target KE_quantum PE sxx syy szz syz sxz sxy ax ay az bx by bz cx cy cz\n");
+  } else {
+    fprintf(fid_, "# columns T KE PE sxx syy szz syz sxz sxy ax ay az bx by bz cx cy cz\n");
+  }
 }
 
 void Dump_Thermo::process(

--- a/src/measure/msd.cu
+++ b/src/measure/msd.cu
@@ -251,6 +251,8 @@ void MSD::preprocess(
   
   dt_in_natural_units_ = time_step * sample_interval_;
   dt_in_ps_ = dt_in_natural_units_ * TIME_UNIT_CONVERSION / 1000.0;
+  for (int i = 0; i < 9; ++i)
+    cpu_h_[i] = box.cpu_h[i];
   x_.resize(num_atoms_ * num_correlation_steps_);
   y_.resize(num_atoms_ * num_correlation_steps_);
   z_.resize(num_atoms_ * num_correlation_steps_);
@@ -397,6 +399,35 @@ void MSD::write(const char* filename)
   const double sdc_unit_conversion = 1.0e3 / TIME_UNIT_CONVERSION;
 
   FILE* fid = fopen(filename, "a");
+  fprintf(fid, "# compute_msd %d %d", sample_interval_, num_correlation_steps_);
+  if (msd_over_all_groups_)
+    fprintf(fid, " all_groups %d", grouping_method_);
+  else if (grouping_method_ >= 0)
+    fprintf(fid, " group %d %d", grouping_method_, group_id_);
+  if (save_output_every_ > 0)
+    fprintf(fid, " save_every %d", save_output_every_);
+  fprintf(fid, "\n");
+  fprintf(fid, "# format_version 1\n");
+  fprintf(fid, "# num_atoms %d\n", num_atoms_);
+  fprintf(fid, "# num_groups %d\n", num_groups_);
+  fprintf(fid, "# num_atoms_per_group");
+  for (int g = 0; g < num_groups_; ++g)
+    fprintf(fid, " %d", num_atoms_per_group_[g]);
+  fprintf(fid, "\n");
+  fprintf(fid,
+    "# cell %.10e %.10e %.10e %.10e %.10e %.10e %.10e %.10e %.10e\n",
+    cpu_h_[0], cpu_h_[3], cpu_h_[6],
+    cpu_h_[1], cpu_h_[4], cpu_h_[7],
+    cpu_h_[2], cpu_h_[5], cpu_h_[8]);
+  fprintf(fid, "# dt_output %.10e ps\n", dt_in_ps_);
+  fprintf(fid, "# columns time_ps");
+  if (!msd_over_all_groups_) {
+    fprintf(fid, " msdx msdy msdz sdcx sdcy sdcz");
+  } else {
+    for (int g = 0; g < num_groups_; ++g)
+      fprintf(fid, " msdx_%d msdy_%d msdz_%d sdcx_%d sdcy_%d sdcz_%d", g, g, g, g, g, g);
+  }
+  fprintf(fid, "\n");
   for (int nc = 0; nc < num_correlation_steps_; nc++) {
     fprintf(fid, "%g", nc * dt_in_ps_);
     for (int group_id = 0; group_id < num_groups_; group_id++) {

--- a/src/measure/msd.cuh
+++ b/src/measure/msd.cuh
@@ -79,4 +79,5 @@ private:
   GPU_Vector<double> msdx_, msdy_, msdz_;
   GPU_Vector<double> msdx_out_, msdy_out_, msdz_out_;  // holds output for writing
   GPU_Vector<int> group_per_atom_gpu_;
+  double cpu_h_[9];
 };

--- a/src/measure/sdc.cu
+++ b/src/measure/sdc.cu
@@ -258,6 +258,20 @@ void SDC::postprocess(
   const double vac_unit_conversion = sdc_unit_conversion * sdc_unit_conversion;
 
   FILE* fid = fopen("sdc.out", "a");
+  fprintf(fid, "# compute_sdc %d %d", sample_interval_, num_correlation_steps_);
+  if (grouping_method_ >= 0)
+    fprintf(fid, " group %d %d", grouping_method_, group_id_);
+  fprintf(fid, "\n");
+  fprintf(fid, "# format_version 1\n");
+  fprintf(fid, "# num_atoms %d\n", num_atoms_);
+  fprintf(
+    fid,
+    "# cell %.10e %.10e %.10e %.10e %.10e %.10e %.10e %.10e %.10e\n",
+    box.cpu_h[0], box.cpu_h[3], box.cpu_h[6],
+    box.cpu_h[1], box.cpu_h[4], box.cpu_h[7],
+    box.cpu_h[2], box.cpu_h[5], box.cpu_h[8]);
+  fprintf(fid, "# dt_output %.10e ps\n", dt_in_ps_);
+  fprintf(fid, "# columns time_ps vacx vacy vacz sdcx sdcy sdcz\n");
   for (int nc = 0; nc < num_correlation_steps_; nc++) {
     fprintf(
       fid,

--- a/src/measure/viscosity.cu
+++ b/src/measure/viscosity.cu
@@ -229,6 +229,20 @@ void Viscosity::postprocess(
   find_viscosity(Nc, factor, correlation_cpu.data(), viscosity.data());
 
   FILE* fid = fopen("viscosity.out", "a");
+  fprintf(fid, "# compute_viscosity %d %d\n", sample_interval, Nc);
+  fprintf(fid, "# format_version 1\n");
+  fprintf(fid, "# num_atoms %d\n", atom.number_of_atoms);
+  fprintf(fid,
+    "# cell %.10e %.10e %.10e %.10e %.10e %.10e %.10e %.10e %.10e\n",
+    box.cpu_h[0], box.cpu_h[3], box.cpu_h[6],
+    box.cpu_h[1], box.cpu_h[4], box.cpu_h[7],
+    box.cpu_h[2], box.cpu_h[5], box.cpu_h[8]);
+  fprintf(fid, "# dt_output %.10e ps\n", dt_in_ps);
+  fprintf(
+    fid,
+    "# columns time_ps"
+    " sacf_xx sacf_yy sacf_zz sacf_xy sacf_xz sacf_yz sacf_yx sacf_zx sacf_zy"
+    " visc_xx visc_yy visc_zz visc_xy visc_xz visc_yz visc_yx visc_zx visc_zy\n");
   for (int nc = 0; nc < Nc; nc++) {
     fprintf(fid, "%25.15e", nc * dt_in_ps);
     for (int m = 0; m < NUM_OF_COMPONENTS; m++) {


### PR DESCRIPTION
This PR adds headers to several output files analogously to #1552, specifically including
* `thermo.out` (`dump_thermo`)
* `msd.out` (`compute_msd`)
* `viscosity.out` (`compute_viscosity`)
* `sdc.out` (`compute_sdc`)

This makes parsing these files simpler and much less error prone since information such as the number of atoms, the cell metric, and the time step or dump frequency are included in the file and do not have to provided externally.

Each header records the originating command and its call signature, `format_version`, `num_atoms`, cell metric (where not already in every data row), the time spacing between output rows, and column names.
The headers are compatible with numpy/pandas comment-skipping parsers.