### PR TITLE
fix compute_viscosity

### DIFF
--- a/src/measure/viscosity.cu
+++ b/src/measure/viscosity.cu
@@ -18,8 +18,10 @@ Calculate the stress autocorrelation function and viscosity.
 ------------------------------------------------------------------------------*/
 
 #include "utilities/common.cuh"
+#include "utilities/error.cuh"
 #include "utilities/gpu_macro.cuh"
 #include "utilities/read_file.cuh"
+#include "integrate/integrate.cuh"
 #include "viscosity.cuh"
 #include <vector>
 #include <cstring>
@@ -38,6 +40,8 @@ void Viscosity::preprocess(
   if (compute) {
     int number_of_frames = number_of_steps / sample_interval;
     stress_all.resize(NUM_OF_COMPONENTS * number_of_frames);
+    accumulated_kinetic_temperature_ = 0.0;
+    kinetic_temperature_sample_count_ = 0;
   }
 }
 
@@ -109,6 +113,17 @@ void Viscosity::process(
   gpu_sum_stress<<<NUM_OF_COMPONENTS, 1024>>>(
     N, Nd, nd, atom.mass.data(), atom.velocity_per_atom.data(), atom.virial_per_atom.data(), stress_all.data());
   GPU_CHECK_KERNEL
+
+  double thermo_cpu[1];
+  thermo.copy_to_host(thermo_cpu, 1);
+  double kinetic_temperature = thermo_cpu[0];
+  if (integrate.type >= 31) {
+    kinetic_temperature = temperature;
+  }
+  if (kinetic_temperature > 0.0) {
+    accumulated_kinetic_temperature_ += kinetic_temperature;
+    kinetic_temperature_sample_count_ += 1;
+  }
 }
 
 static __global__ void gpu_correct_stress(const int Nd, double* g_stress_all)
@@ -223,7 +238,23 @@ void Viscosity::postprocess(
 
   correlation_gpu.copy_to_host(correlation_cpu.data());
 
-  double factor = dt * 0.5 / (K_B * temperature * box.get_volume());
+  double temperature_for_green_kubo = temperature;
+  if (kinetic_temperature_sample_count_ > 0) {
+    temperature_for_green_kubo =
+      accumulated_kinetic_temperature_ / kinetic_temperature_sample_count_;
+    if (integrate.type == 0) {
+      printf(
+        "Use averaged kinetic temperature %g K for viscosity Green-Kubo prefactor "
+        "(NVE has no thermostat target temperature).\n",
+        temperature_for_green_kubo);
+    }
+  } else if (temperature_for_green_kubo <= 0.0) {
+    PRINT_INPUT_ERROR(
+      "Invalid temperature for compute_viscosity. Use NVT/NPT equilibration before "
+      "NVE production, or ensure kinetic temperature can be sampled from thermo.\n");
+  }
+
+  double factor = dt * 0.5 / (K_B * temperature_for_green_kubo * box.get_volume());
   factor *= PRESSURE_UNIT_CONVERSION * TIME_UNIT_CONVERSION * 1.0e-6; // Pa s
 
   find_viscosity(Nc, factor, correlation_cpu.data(), viscosity.data());

--- a/src/measure/viscosity.cuh
+++ b/src/measure/viscosity.cuh
@@ -60,4 +60,6 @@ public:
 
 private:
   GPU_Vector<double> stress_all;
+  double accumulated_kinetic_temperature_ = 0.0;
+  int kinetic_temperature_sample_count_ = 0;
 };


### PR DESCRIPTION
**Summary**

Improve #1582 `compute_viscosity` handling when NVE production is run without a thermostatted ensemble in the same `run.in`.

This edge case was found in GPUMD 5.3 during Green-Kubo viscosity work and remains on current `master`. GPUMD’s expected workflow is NVT/NPT equilibration (temperature defined) followed by NVE production. In our case, a continuation run used NVE-only input—including a short NVE re-equilibration stage—without any NVT/NPT block in that file. Although the structure was equilibrated in a prior job, `Viscosity::postprocess()` still uses `integrate.temperature2`, which is zero for NVE-only inputs, causing division by zero and `inf` in `viscosity.out` columns 11-19.

This PR makes the Green-Kubo prefactor use the time-averaged kinetic temperature sampled during production, so continuation and NVE-only workflows behave correctly without changing the standard NVT → NVE path.

**Modification**

- `src/measure/viscosity.cuh`: Add accumulators for kinetic temperature during stress sampling.
- `src/measure/viscosity.cu`:
  - Accumulate kinetic temperature from `thermo[0]` in `process()`.
  - Use the averaged kinetic temperature in `postprocess()` for the Green-Kubo prefactor.
  - For PIMD (`integrate.type >= 31`), keep using the passed thermostat temperature.
  - Emit a diagnostic when NVE production relies on kinetic rather than thermostat target temperature.
  - Error if no valid temperature is available.

**Others**

- Scope: Primarily affects NVE-only / continuation workflows. Single-file NVT → NVE runs are largely unchanged.
- Validation: NVE-only `compute_viscosity 20 4000` run — unfixed code gives `inf` in columns 11-19; with this fix, all columns are finite and match re-integration from columns 2-10.
- Design note: NVE is a poor choice for equilibration; this fix does not endorse that workflow, but prevents silent failure when users run `compute_viscosity` without a thermostat-defined temperature in the current input.
- Output format: Unchanged; only numerical values of columns 11-19 are corrected in affected cases.

**Discussion**

We originally hit this while running long Green–Kubo viscosity calculations on a molten system with GPUMD 5.3. Our main equilibration path follows the usual GPUMD workflow (NVT/NPT before production), but for a continuation job we used an NVE-only `run.in`—including a short NVE re-equilibration stage—without a thermostatted block in that same input file. In that setup, `viscosity.out` columns 2–10 looked fine, while columns 11–19 overflowed to `inf`, which traced back to the Green–Kubo prefactor relying on a thermostat-defined temperature that NVE does not provide in the current run context. We understand this is an uncommon boundary case rather than the primary intended path, and we are not suggesting a change to the recommended NVT/NPT → NVE workflow; we simply thought it would be helpful to fail gracefully here by using the sampled kinetic temperature during production. We would be happy to adjust the implementation or wording if you prefer a different behavior for continuation runs. Thank you for maintaining GPUMD and for considering this small robustness improvement.

Files used to test.
[share.tar.gz](https://github.com/user-attachments/files/29538374/share.tar.gz)
