### PR TITLE
Update MTTK ensemble's documentation

### DIFF
--- a/doc/gpumd/input_parameters/ensemble_mttk.rst
+++ b/doc/gpumd/input_parameters/ensemble_mttk.rst
@@ -1,6 +1,7 @@
 .. _mttk:
 .. _kw_ensemble_mttk:
 .. index::
+   single: nvt_mttk (keyword in run.in)
    single: npt_mttk (keyword in run.in)
    single: nph_mttk (keyword in run.in)
    single: MTTK integrator
@@ -10,10 +11,10 @@
 
 The variants of the :attr:`ensemble` keyword described on this page implement the Nosé-Hoover thermostat [Hoover1996]_ and the Parrinello-Rahman barostat [Parrinello1981]_.
 Both the thermostat and barostat are enhanced by the :ref:`Nosé-Hoover chain method <nose_hoover_chain_thermostat>` as recommended in [Martyna1994]_. 
-The resulting so-called Martyna-Tuckerman-Tobias-Klein (:term:`MTTK`) integrators enable one to perform simulations in the isothermal-isobaric (NPT) or isenthalpic (NPH) ensembles.
+The resulting so-called Martyna-Tuckerman-Tobias-Klein (:term:`MTTK`) integrators enable one to perform simulations in the canonical (NVT), isothermal-isobaric (NPT), or isenthalpic (NPH) ensembles.
 
 This implementation of the :term:`MTTK` integrator provides more fine-grained control than :ref:`"standard" ensembles <kw_ensemble_standard>`.
-The style of the :attr:`npt_mttk` and :attr:`nph_mttk` keywords is therefore slightly different.
+The style of the :attr:`nvt_mttk`, :attr:`npt_mttk`, and :attr:`nph_mttk` keywords is therefore slightly different.
 
 Syntax
 ------
@@ -40,7 +41,11 @@ It determines how strongly the system is coupled to the barostat and should be :
 
 The :attr:`nph_mttk` keyword can be used in analoguous fashion to run simulations in the isenthalpic (NPH) ensemble::
 
-    ensemble nph_mttk <direction> <p_1> <p_2> <tau_press>
+    ensemble nph_mttk <direction> <p_1> <p_2> pperiod <tau_press>
+
+The :attr:`nvt_mttk` keyword can be used to run simulations in the canonical (NVT) ensemble::
+
+    ensemble nvt_mttk temp <T_1> <T_2> tperiod <tau_temp>
 
 
 Examples
@@ -102,3 +107,20 @@ NPH Ensemble
     ensemble nph_mttk iso 10 10
 
 When using this command one performs a NPH simulation at 10 GPa, allowing only changes in the volume but not the cell shape.
+
+
+NVT Ensemble
+^^^^^^^^^^^^
+
+.. code-block:: rst
+
+    ensemble nvt_mttk temp 300 300
+
+This command sets the target temperature to 300 K using the Nosé-Hoover chain thermostat.
+No barostat is used, so the simulation cell is fixed.
+
+.. code-block:: rst
+
+    ensemble nvt_mttk temp 300 1000 tperiod 100
+
+This command ramps the temperature from 300 K to 1000 K and explicitly sets the period of the thermostat to 100 timesteps.


### PR DESCRIPTION
**Summary**
Fix #1588 

**Modification**
- Update `nvt_mttk` ensemble's documentation and related example;
- Correct `nph_mttk` ensemble's documentation, the original: 
```
ensemble nph_mttk <direction> <p_1> <p_2> <tau_press>
```

The correct one should be:
```
ensemble nph_mttk <direction> <p_1> <p_2> pperiod <tau_press>
```
