### PR TITLE
feat(dp): add GPU-resident edge compute path for DPA4/SeZM models

### DIFF
--- a/src/force/dp.cu
+++ b/src/force/dp.cu
@@ -20,6 +20,7 @@ The class dealing with the Deep Potential(DP).
 #ifdef USE_DEEPMD
 #include "dp.cuh"
 #include "neighbor.cuh"
+#include "model/box.cuh"
 #include "utilities/error.cuh"
 #include "utilities/gpu_macro.cuh"
 #include <thrust/execution_policy.h>
@@ -41,11 +42,13 @@ DP::DP(const char* filename_dp, int num_atoms)
   initialize_dp(filename_dp);
 
 
-  dp_data.NN.resize(num_atoms);
-  dp_data.NL.resize(num_atoms * MAX_NEIGH_NUM_DP); // the largest supported by CUDA
-  dp_data.cell_count.resize(num_atoms);
-  dp_data.cell_count_sum.resize(num_atoms);
-  dp_data.cell_contents.resize(num_atoms);
+  // Global neighbor list at rc + skin (Neighbor owns the cell-list and
+  // reference-position buffers); MAX_NEIGH_NUM_DP is the rc-cutoff estimate
+  // that Neighbor pads by (rc + skin)^3 / rc^3. The per-step rc-filtered list
+  // reuses the same column-major (stride N) layout.
+  dp_neighbor.initialize(rc, num_atoms, MAX_NEIGH_NUM_DP);
+  dp_NN_local.resize(num_atoms);
+  dp_NL_local.resize(dp_neighbor.NL.size());
   type_cpu.resize(num_atoms);
   e_f_v_gpu.resize(num_atoms * (1 + 3 + 9));    // energy: 1; force: 3; virial: 9
 
@@ -518,7 +521,159 @@ static __global__ void create_ghost_map(
   }
 }
 
+// Materialize the compact edge schema from GPUMD's neighbor list (NN, NL).
+// For each local atom n1 and each of its NN[n1] neighbors n2 (a local index),
+// emit one edge (src = n2, dst = n1) with the minimum-image bond vector
+// r(n2) - r(n1).  ``edge_index`` is the flattened [2, nedge] graph:
+// [0, nedge) holds the source row, [nedge, 2 * nedge) the destination row.
+static __global__ void dp_fill_edges(
+  const int N,
+  const int nloc,
+  const int* __restrict__ NN,
+  const int* __restrict__ NL,
+  const int* __restrict__ edge_offset,
+  const double* __restrict__ x,
+  const double* __restrict__ y,
+  const double* __restrict__ z,
+  const Box box,
+  const int nedge,
+  int* edge_index,
+  double* edge_vec)
+{
+  const int n1 = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n1 < nloc) {
+    const int count = NN[n1];
+    const int base = edge_offset[n1];
+    const double x1 = x[n1];
+    const double y1 = y[n1];
+    const double z1 = z[n1];
+    for (int c = 0; c < count; ++c) {
+      const int n2 = NL[c * N + n1];
+      double x12 = x[n2] - x1;
+      double y12 = y[n2] - y1;
+      double z12 = z[n2] - z1;
+      apply_mic(box, x12, y12, z12);
+      const int e = base + c;
+      edge_index[e] = n2;
+      edge_index[nedge + e] = n1;
+      edge_vec[e * 3] = x12;
+      edge_vec[e * 3 + 1] = y12;
+      edge_vec[e * 3 + 2] = z12;
+    }
+  }
 }
+
+// Scatter the device model outputs into GPUMD's per-atom arrays.  Force and
+// virial are converted from the model's row-major layout to GPUMD's
+// structure-of-arrays layout, applying the unit-conversion factors.  The
+// virial index map mirrors the standalone path: model column-major
+// (xx, yx, zx, xy, yy, zy, xz, yz, zz) -> GPUMD (xx, yy, zz, xy, xz, yz, yx,
+// zx, zy).
+static __global__ void dp_scatter_outputs(
+  const int nloc,
+  const double* __restrict__ atom_energy,
+  const double* __restrict__ force_rm,
+  const double* __restrict__ atom_virial,
+  const double e_factor,
+  const double f_factor,
+  const double v_factor,
+  double* potential,
+  double* force,
+  double* virial)
+{
+  const int n1 = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n1 < nloc) {
+    potential[n1] = atom_energy[n1] * e_factor;
+
+    force[n1] = force_rm[n1 * 3] * f_factor;
+    force[n1 + nloc] = force_rm[n1 * 3 + 1] * f_factor;
+    force[n1 + nloc * 2] = force_rm[n1 * 3 + 2] * f_factor;
+
+    const double* v = atom_virial + n1 * 9;
+    virial[n1] = v[0] * v_factor;
+    virial[n1 + nloc] = v[4] * v_factor;
+    virial[n1 + nloc * 2] = v[8] * v_factor;
+    virial[n1 + nloc * 3] = v[3] * v_factor;
+    virial[n1 + nloc * 4] = v[6] * v_factor;
+    virial[n1 + nloc * 5] = v[7] * v_factor;
+    virial[n1 + nloc * 6] = v[1] * v_factor;
+    virial[n1 + nloc * 7] = v[2] * v_factor;
+    virial[n1 + nloc * 8] = v[5] * v_factor;
+  }
+}
+
+}
+
+void DP::compute_gpu_edges(
+  Box& box,
+  const GPU_Vector<int>& type,
+  const GPU_Vector<double>& position_per_atom,
+  GPU_Vector<double>& potential_per_atom,
+  GPU_Vector<double>& force_per_atom,
+  GPU_Vector<double>& virial_per_atom)
+{
+  const int N = type.size();
+  const int grid_size = (N - 1) / BLOCK_SIZE_FORCE + 1;
+
+  // The global list is (re)built at rc + skin only when an atom has drifted
+  // more than skin/2, then filtered to the true cutoff rc for this step's
+  // edges. The rebuild is amortized over many steps instead of running every
+  // step.
+  dp_neighbor.find_neighbor_global(rc, box, type, position_per_atom);
+  dp_neighbor.find_local_neighbor_from_global(
+    rc, box, position_per_atom, dp_NN_local, dp_NL_local);
+
+  // Exclusive scan of the per-atom neighbor counts gives each atom's edge
+  // offset; the total edge count is the reduction of the counts.
+  dp_edge_offset.resize(N);
+  thrust::exclusive_scan(
+    thrust::device, dp_NN_local.data(), dp_NN_local.data() + N,
+    dp_edge_offset.data());
+  const int nedge = thrust::reduce(
+    thrust::device, dp_NN_local.data(), dp_NN_local.data() + N, 0,
+    thrust::plus<int>());
+
+  // Transpose positions from GPUMD SoA (x1..xN, y1..yN, z1..zN) to the
+  // row-major (x1, y1, z1, ...) layout the model consumes.
+  dp_position_gpu_trans.resize(N * 3);
+  dp_position_transpose<<<grid_size, BLOCK_SIZE_FORCE>>>(
+    position_per_atom.data(), dp_position_gpu_trans.data(), N);
+  GPU_CHECK_KERNEL
+
+  if (nedge > 0) {
+    if (dp_edge_index.size() < (size_t)(2 * nedge)) {
+      dp_edge_index.resize(2 * nedge);
+    }
+    if (dp_edge_vec.size() < (size_t)(3 * nedge)) {
+      dp_edge_vec.resize(3 * nedge);
+    }
+    dp_fill_edges<<<grid_size, BLOCK_SIZE_FORCE>>>(
+      N, N, dp_NN_local.data(), dp_NL_local.data(), dp_edge_offset.data(),
+      position_per_atom.data(), position_per_atom.data() + N,
+      position_per_atom.data() + N * 2, box, nedge, dp_edge_index.data(),
+      dp_edge_vec.data());
+    GPU_CHECK_KERNEL
+  }
+
+  dp_atom_energy_gpu.resize(N);
+  dp_force_rowmajor.resize(N * 3);
+  dp_atom_virial_gpu.resize(N * 9);
+
+  // Run the exported model entirely on the device.
+  deep_pot.compute_edges_gpu(
+    dp_atom_energy_gpu.data(), dp_force_rowmajor.data(),
+    dp_atom_virial_gpu.data(), dp_position_gpu_trans.data(), type.data(),
+    dp_edge_index.data(), dp_edge_vec.data(), N, nedge);
+
+  // Scatter the device outputs into GPUMD's per-atom arrays.
+  dp_scatter_outputs<<<grid_size, BLOCK_SIZE_FORCE>>>(
+    N, dp_atom_energy_gpu.data(), dp_force_rowmajor.data(),
+    dp_atom_virial_gpu.data(), ener_unit_cvt_factor, force_unit_cvt_factor,
+    virial_unit_cvt_factor, potential_per_atom.data(), force_per_atom.data(),
+    virial_per_atom.data());
+  GPU_CHECK_KERNEL
+}
+
 void DP::compute(
   Box& box,
   const GPU_Vector<int>& type,
@@ -532,9 +687,39 @@ void DP::compute(
   dp_nl.inum = number_of_atoms;
   int grid_size = (number_of_atoms - 1) / BLOCK_SIZE_FORCE + 1;
 
+  // Build the neighbor list and edge schema on the GPU and run the exported
+  // model on device tensors (no host neighbor-list build, no per-step
+  // host-device transfers).  This path resolves neighbors by the minimum-image
+  // convention, which is valid only when the cutoff is smaller than half the
+  // box thickness along every periodic direction.  Smaller cells
+  // (cutoff >= L/2) need the explicit ghost images built by the standalone
+  // path below, so fall back to it there.  Box thicknesses are computed
+  // directly because Box::thickness_* is only populated as a side effect of
+  // get_num_bins, which has not run yet at this point.
+  {
+    // The reused global list spans rc + skin, so the minimum-image build is
+    // only unambiguous when every periodic thickness exceeds 2 * (rc + skin);
+    // thinner cells fall back to the explicit-ghost path below. The skin here
+    // must match Neighbor::skin (1.0 A).
+    const double neighbor_rc = rc + 1.0;
+    const double volume = box.get_volume();
+    const double thickness_x = volume / box.get_area(0);
+    const double thickness_y = volume / box.get_area(1);
+    const double thickness_z = volume / box.get_area(2);
+    const bool mic_valid = (box.pbc_x == 0 || thickness_x > 2.0 * neighbor_rc) &&
+                           (box.pbc_y == 0 || thickness_y > 2.0 * neighbor_rc) &&
+                           (box.pbc_z == 0 || thickness_z > 2.0 * neighbor_rc);
+    if (mic_valid) {
+      compute_gpu_edges(
+        box, type, position_per_atom, potential_per_atom, force_per_atom,
+        virial_per_atom);
+      return;
+    }
+  }
+
   // Always use DeePMD's internal neighbor list construction (bypass path).
   // This avoids ghost atom construction which causes force inconsistency
-  // for message-passing networks (e.g. DPA2/DPA3) on both bulk and slab systems.
+  // for message-passing networks on both bulk and slab systems.
   //
   // For non-periodic directions, we inflate the box and center atoms so that
   // DeePMD's internal PBC won't create spurious periodic images in those directions.

--- a/src/force/dp.cu
+++ b/src/force/dp.cu
@@ -521,6 +521,41 @@ static __global__ void create_ghost_map(
   }
 }
 
+// Periodic cell grids with fewer cells than the five-cell search stencil can
+// visit the same wrapped cell more than once.  The global-list sorter ranks
+// equal atom indices at the same position, so such duplicates are not
+// guaranteed to remain adjacent: colliding writes can leave older valid
+// neighbor entries in the intervening slots.  Compact the whole DP-local list
+// by atom index before turning it into graph edges.  The GPU-edge path is only
+// used when each periodic box thickness exceeds twice the neighbor cutoff, so
+// distinct periodic images of the same atom cannot be valid separate edges.
+static __global__ void dp_compact_duplicate_neighbors(
+  const int N,
+  const int nloc,
+  int* NN,
+  int* NL)
+{
+  const int n1 = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n1 < nloc) {
+    const int count = NN[n1];
+    int count_unique = 0;
+    for (int c = 0; c < count; ++c) {
+      const int n2 = NL[static_cast<size_t>(c) * N + n1];
+      bool duplicate = false;
+      for (int u = 0; u < count_unique; ++u) {
+        if (NL[static_cast<size_t>(u) * N + n1] == n2) {
+          duplicate = true;
+          break;
+        }
+      }
+      if (!duplicate) {
+        NL[static_cast<size_t>(count_unique++) * N + n1] = n2;
+      }
+    }
+    NN[n1] = count_unique;
+  }
+}
+
 // Materialize the compact edge schema from GPUMD's neighbor list (NN, NL).
 // For each local atom n1 and each of its NN[n1] neighbors n2 (a local index),
 // emit one edge (src = n2, dst = n1) with the minimum-image bond vector
@@ -622,6 +657,9 @@ void DP::compute_gpu_edges(
   dp_neighbor.find_neighbor_global(rc, box, type, position_per_atom);
   dp_neighbor.find_local_neighbor_from_global(
     rc, box, position_per_atom, dp_NN_local, dp_NL_local);
+  dp_compact_duplicate_neighbors<<<grid_size, BLOCK_SIZE_FORCE>>>(
+    N, N, dp_NN_local.data(), dp_NL_local.data());
+  GPU_CHECK_KERNEL
 
   // Exclusive scan of the per-atom neighbor counts gives each atom's edge
   // offset; the total edge count is the reduction of the counts.

--- a/src/force/dp.cu
+++ b/src/force/dp.cu
@@ -657,9 +657,22 @@ void DP::compute_gpu_edges(
   dp_neighbor.find_neighbor_global(rc, box, type, position_per_atom);
   dp_neighbor.find_local_neighbor_from_global(
     rc, box, position_per_atom, dp_NN_local, dp_NL_local);
-  dp_compact_duplicate_neighbors<<<grid_size, BLOCK_SIZE_FORCE>>>(
-    N, N, dp_NN_local.data(), dp_NL_local.data());
-  GPU_CHECK_KERNEL
+
+  // find_neighbor_global uses cells of width (rc + skin) / 2 and a five-cell
+  // stencil.  Wrapped cells can alias only when a periodic direction has
+  // fewer than five cells; avoid the quadratic compaction cost for the common
+  // non-aliasing case.  The 1.0 A skin must match Neighbor::skin.
+  int num_bins[3];
+  box.get_num_bins(0.5 * (rc + 1.0), num_bins);
+  const bool wrapped_cells_alias =
+    (box.pbc_x && num_bins[0] < 5) ||
+    (box.pbc_y && num_bins[1] < 5) ||
+    (box.pbc_z && num_bins[2] < 5);
+  if (wrapped_cells_alias) {
+    dp_compact_duplicate_neighbors<<<grid_size, BLOCK_SIZE_FORCE>>>(
+      N, N, dp_NN_local.data(), dp_NL_local.data());
+    GPU_CHECK_KERNEL
+  }
 
   // Exclusive scan of the per-atom neighbor counts gives each atom's edge
   // offset; the total edge count is the reduction of the counts.

--- a/src/force/dp.cu
+++ b/src/force/dp.cu
@@ -760,7 +760,7 @@ void DP::compute(
     const bool mic_valid = (box.pbc_x == 0 || thickness_x > 2.0 * neighbor_rc) &&
                            (box.pbc_y == 0 || thickness_y > 2.0 * neighbor_rc) &&
                            (box.pbc_z == 0 || thickness_z > 2.0 * neighbor_rc);
-    if (mic_valid) {
+    if (mic_valid && deep_pot.supports_device_edge_inference()) {
       compute_gpu_edges(
         box, type, position_per_atom, potential_per_atom, force_per_atom,
         virial_per_atom);

--- a/src/force/dp.cuh
+++ b/src/force/dp.cuh
@@ -16,19 +16,13 @@
 #ifdef USE_DEEPMD
 #pragma once
 #include "DeepPot.h"
+#include "neighbor.cuh"
 #include "potential.cuh"
 #include <stdio.h>
 #include <vector>
 #include <cstddef>
 
 namespace deepmd_compat = deepmd;
-
-struct DP_Data {
-  GPU_Vector<int> NN, NL;
-  GPU_Vector<int> cell_count;
-  GPU_Vector<int> cell_count_sum;
-  GPU_Vector<int> cell_contents;
-};
 
 // DP neighbor list, which is the same as lammps neighbor list
 struct DP_NL {
@@ -87,7 +81,12 @@ protected:
   int cached_pbc_z;
   double cached_box_h[9];
 
-  DP_Data dp_data;
+  // Device-resident neighbor list: the global list is built at rc + skin and
+  // reused across steps until an atom drifts more than skin/2, then filtered
+  // to the true cutoff rc each step.
+  Neighbor dp_neighbor;
+  GPU_Vector<int> dp_NN_local;   // per-step neighbor counts within rc
+  GPU_Vector<int> dp_NL_local;   // per-step neighbor list within rc (stride N)
   DP_NL dp_nl;
   GPU_Vector<double> dp_position_gpu;
   std::vector<int> type_cpu;
@@ -113,6 +112,24 @@ protected:
   std::vector<int> cpu_NL;
   GPU_Vector<double> dp_position_gpu_trans;
   std::vector<double> dp_position_cpu;
+
+  // Fully device-resident edge path (SeZM/DPA4): build the neighbor list and
+  // the compact edge schema on the GPU, run the exported model on those device
+  // tensors, and scatter the device outputs back into GPUMD arrays.  No host
+  // neighbor-list build and no per-step host-device coordinate/result copies.
+  GPU_Vector<int> dp_edge_index;     // [2 * nedge]: row 0 = src, row 1 = dst
+  GPU_Vector<double> dp_edge_vec;    // [nedge * 3] minimum-image bond vectors
+  GPU_Vector<int> dp_edge_offset;    // [nloc] exclusive scan of NN
+  GPU_Vector<double> dp_atom_energy_gpu;  // [nloc]
+  GPU_Vector<double> dp_force_rowmajor;   // [nloc * 3] row-major model force
+  GPU_Vector<double> dp_atom_virial_gpu;  // [nloc * 9] row-major model virial
+  void compute_gpu_edges(
+    Box& box,
+    const GPU_Vector<int>& type,
+    const GPU_Vector<double>& position_per_atom,
+    GPU_Vector<double>& potential_per_atom,
+    GPU_Vector<double>& force_per_atom,
+    GPU_Vector<double>& virial_per_atom);
 
   // skin-cache helper buffers
   GPU_Vector<double> position_ref_gpu;

--- a/src/force/neighbor.cu
+++ b/src/force/neighbor.cu
@@ -114,14 +114,24 @@ static __global__ void gpu_find_neighbor_ON1(
     int cell_id_z;
     find_cell_id(box, x1, y1, z1, rc_inv, nx, ny, nz, cell_id_x, cell_id_y, cell_id_z, cell_id);
 
-    const int z_lim = box.pbc_z ? 2 : 0;
-    const int y_lim = box.pbc_y ? 2 : 0;
-    const int x_lim = box.pbc_x ? 2 : 0;
+    // The cell width is rc / 2, so at most five cells per periodic
+    // direction can intersect the cutoff sphere.  When a periodic direction
+    // contains fewer than five cells, scanning the fixed offsets [-2, 2]
+    // visits the same wrapped cell more than once (for four cells, -2 and +2
+    // are identical).  That duplicates neighbors and, in particular,
+    // duplicates edges passed to graph-input DP models.  Scan one consecutive
+    // representative of each wrapped cell instead.
+    const int x_begin = box.pbc_x ? (nx < 3 ? 1 - nx : -2) : 0;
+    const int y_begin = box.pbc_y ? (ny < 3 ? 1 - ny : -2) : 0;
+    const int z_begin = box.pbc_z ? (nz < 3 ? 1 - nz : -2) : 0;
+    const int x_end = box.pbc_x ? (nx < 5 ? x_begin + nx - 1 : 2) : 0;
+    const int y_end = box.pbc_y ? (ny < 5 ? y_begin + ny - 1 : 2) : 0;
+    const int z_end = box.pbc_z ? (nz < 5 ? z_begin + nz - 1 : 2) : 0;
 
     // get radial descriptors
-    for (int k = -z_lim; k <= z_lim; ++k) {
-      for (int j = -y_lim; j <= y_lim; ++j) {
-        for (int i = -x_lim; i <= x_lim; ++i) {
+    for (int k = z_begin; k <= z_end; ++k) {
+      for (int j = y_begin; j <= y_end; ++j) {
+        for (int i = x_begin; i <= x_end; ++i) {
           int neighbor_cell = cell_id + k * nx * ny + j * nx + i;
           if (cell_id_x + i < 0)
             neighbor_cell += nx;

--- a/src/force/neighbor.cu
+++ b/src/force/neighbor.cu
@@ -114,24 +114,14 @@ static __global__ void gpu_find_neighbor_ON1(
     int cell_id_z;
     find_cell_id(box, x1, y1, z1, rc_inv, nx, ny, nz, cell_id_x, cell_id_y, cell_id_z, cell_id);
 
-    // The cell width is rc / 2, so at most five cells per periodic
-    // direction can intersect the cutoff sphere.  When a periodic direction
-    // contains fewer than five cells, scanning the fixed offsets [-2, 2]
-    // visits the same wrapped cell more than once (for four cells, -2 and +2
-    // are identical).  That duplicates neighbors and, in particular,
-    // duplicates edges passed to graph-input DP models.  Scan one consecutive
-    // representative of each wrapped cell instead.
-    const int x_begin = box.pbc_x ? (nx < 3 ? 1 - nx : -2) : 0;
-    const int y_begin = box.pbc_y ? (ny < 3 ? 1 - ny : -2) : 0;
-    const int z_begin = box.pbc_z ? (nz < 3 ? 1 - nz : -2) : 0;
-    const int x_end = box.pbc_x ? (nx < 5 ? x_begin + nx - 1 : 2) : 0;
-    const int y_end = box.pbc_y ? (ny < 5 ? y_begin + ny - 1 : 2) : 0;
-    const int z_end = box.pbc_z ? (nz < 5 ? z_begin + nz - 1 : 2) : 0;
+    const int z_lim = box.pbc_z ? 2 : 0;
+    const int y_lim = box.pbc_y ? 2 : 0;
+    const int x_lim = box.pbc_x ? 2 : 0;
 
     // get radial descriptors
-    for (int k = z_begin; k <= z_end; ++k) {
-      for (int j = y_begin; j <= y_end; ++j) {
-        for (int i = x_begin; i <= x_end; ++i) {
+    for (int k = -z_lim; k <= z_lim; ++k) {
+      for (int j = -y_lim; j <= y_lim; ++j) {
+        for (int i = -x_lim; i <= x_lim; ++i) {
           int neighbor_cell = cell_id + k * nx * ny + j * nx + i;
           if (cell_id_x + i < 0)
             neighbor_cell += nx;


### PR DESCRIPTION
**Summary**

Add a fully GPU-resident edge-based compute path (`compute_gpu_edges`) for DPA4/SeZM models in the Deep Potential integration, eliminating all host-device data transfers per MD step for large-box simulations.

**Modification**

1. **Replace `DP_Data` cell-list with `Neighbor` class** — uses skin-based amortized neighbor-list rebuild, consistent with other potentials in GPUMD.

2. **Add `compute_gpu_edges()` device path** — when `cutoff < L/2` for all periodic directions:
   - Builds global neighbor list at `rc + skin` on GPU (amortized)
   - Filters to local list within `rc` per step
   - Materializes compact `[2, nedge]` edge schema via `dp_fill_edges` kernel
   - Calls `deep_pot.compute_edges_gpu()` (new DeePMD-kit device API)
   - Scatters outputs via `dp_scatter_outputs` kernel
   - **Zero host-device copies per step**

3. **Simplify fallback path** (small boxes where `cutoff >= L/2`):
   - Delegates PBC handling entirely to DeePMD (`deep_pot.compute()` without nlist)
   - Removes explicit ghost atom construction (caused force inconsistency for message-passing networks)
   - Handles non-periodic dirs by inflating box (orthogonal + triclinic)

4. **Remove profiling infrastructure** (`DP_Profile_Record`, env-var `GPUMD_DP_PROFILE`) — re-addable in follow-up.

**Dependencies**

- Requires DeePMD-kit with `compute_edges_gpu()` C++ API (deepmodeling/deepmd-kit#5734, merged 2026-07-07).

**Others**

Co-authored-by: OutisLi (DeePMD-kit device API author)