### PR TITLE
Allow user to override the q-scaler reset

### DIFF
--- a/doc/nep/input_parameters/import_q_scaler.rst
+++ b/doc/nep/input_parameters/import_q_scaler.rst
@@ -1,0 +1,20 @@
+.. _kw_import_q_scaler:
+.. index::
+   single: import_q_scaler (keyword in nep.in)
+
+:attr:`import_q_scaler`
+========================
+
+By default, when training or resuming a NEP potential without :attr:`fine_tune`, :program:`nep` computes :attr:`q_scaler`, the per-descriptor-component normalization used by the neural network, from the training structures of the current run at generation 0.
+This keyword instead tells :program:`nep` to read :attr:`q_scaler` from the :attr:`nep.txt` file present in the run directory, skipping that computation.
+This naturally requires such a file to be present.
+The syntax is::
+
+  import_q_scaler <0 or 1>
+
+with a default value of 0.
+
+This is intended for resuming training from a restart state (:attr:`nep.restart`) that was transplanted from a different model, e.g. a foundation model restricted to a subset of species via a species-selection tool.
+In that case, the transplanted network weights were tuned under the :attr:`q_scaler` of the original model, and recomputing a different one from a smaller or less diverse training set can force the weights to spend part of the optimization readapting to the new descriptor scale, rather than only to the new training data.
+Unlike :attr:`fine_tune`, this keyword does not perform any species extraction: the :attr:`nep.txt` file it reads from is expected to already have the exact same architecture and species as the current run (:program:`nep` validates this and raises an error on a mismatch), which is why the file is referred to implicitly rather than by a path argument, matching the way :attr:`nep.restart` is referred to.
+The mean/standard-deviation restart state (:attr:`mu`/:attr:`sigma`) is unaffected by this keyword: it is unconditionally read from :attr:`nep.restart`, exactly as in any other non-:attr:`fine_tune` run.

--- a/doc/nep/input_parameters/index.rst
+++ b/doc/nep/input_parameters/index.rst
@@ -39,4 +39,5 @@ Below you can find a listing of keywords for the ``nep.in`` input file.
    save_potential
    output_descriptor
    fine_tune
+   import_q_scaler
    charge_mode

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -166,7 +166,7 @@ void Fitness::compute(
         para,
         dummy_solution.data(),
         train_set[n],
-        (para.fine_tune ? false : true),
+        (para.fine_tune || para.import_q_scaler) ? false : true,
         deviceCount);
     }
   } else {

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -280,6 +280,25 @@ void Parameters::calculate_parameters()
       q_scaler_cpu[n] = get_double_from_token(tokens[0], __FILE__, __LINE__);
     }
     input.close();
+  } else if (import_q_scaler) {
+    std::ifstream input("nep.txt");
+    if (!input.is_open()) {
+      PRINT_INPUT_ERROR("Failed to open nep.txt for q_scaler import.");
+    }
+    std::vector<std::string> tokens;
+    // Unlike the fine_tune case above, the imported nep.txt is assumed (and validated by
+    // check_foundation_model, called from report_inputs) to already have the exact same
+    // architecture and species count as the current run, so no species-count-specific
+    // offset arithmetic is needed here: just skip the 7 header lines and this run's own
+    // number_of_variables parameter lines, then read the trailing dim-line q_scaler block.
+    for (int n = 0; n < 7 + number_of_variables; ++n) {
+      tokens = get_tokens(input); // not used
+    }
+    for (int n = 0; n < q_scaler_cpu.size(); ++n) {
+      tokens = get_tokens(input);
+      q_scaler_cpu[n] = get_double_from_token(tokens[0], __FILE__, __LINE__);
+    }
+    input.close();
   }
 
   int deviceCount;
@@ -298,9 +317,9 @@ void Parameters::calculate_parameters()
   }
 }
 
-void Parameters::check_foundation_model()
+void Parameters::check_foundation_model(const std::string& filename)
 {
-  std::ifstream input(fine_tune_nep_txt);
+  std::ifstream input(filename);
   if (!input.is_open()) {
     PRINT_INPUT_ERROR("Failed to open foundation model file.");
   }
@@ -394,7 +413,11 @@ void Parameters::report_inputs()
   }
 
   if (fine_tune) {
-    check_foundation_model();
+    check_foundation_model(fine_tune_nep_txt);
+  }
+
+  if (import_q_scaler) {
+    check_foundation_model("nep.txt");
   }
 
   printf("Input or default parameters:\n");
@@ -690,6 +713,8 @@ void Parameters::parse_one_keyword(std::vector<std::string>& tokens)
     parse_save_potential(param, num_param);
   } else if (strcmp(param[0], "q_scaler") == 0) {
     parse_q_scaler(param, num_param);
+  } else if (strcmp(param[0], "import_q_scaler") == 0) {
+    parse_import_q_scaler(param, num_param);
   } else {
     PRINT_KEYWORD_ERROR(param[0]);
   }
@@ -1458,4 +1483,20 @@ void Parameters::parse_q_scaler(const char** param, int num_param)
   if (q_scaler_input < 0.01f || q_scaler_input > 0.1f) {
     PRINT_INPUT_ERROR("q_scaler must be in [0.01 0.1].");
   }
+}
+
+void Parameters::parse_import_q_scaler(const char** param, int num_param)
+{
+  if (num_param != 2) {
+    PRINT_INPUT_ERROR("import_q_scaler should have 1 parameter.\n");
+  }
+
+  int flag = 0;
+  if (!is_valid_int(param[1], &flag)) {
+    PRINT_INPUT_ERROR("import_q_scaler should be an integer.\n");
+  }
+  if (flag != 0 && flag != 1) {
+    PRINT_INPUT_ERROR("import_q_scaler should be 0 or 1.");
+  }
+  import_q_scaler = (flag == 1);
 }

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -76,6 +76,7 @@ public:
   std::string fine_tune_nep_txt = "";
   std::string fine_tune_nep_restart = "";
   float q_scaler_input;
+  bool import_q_scaler = false; // read q_scaler from the local nep.txt instead of recomputing it
 
   // check if a parameter has been set:
   bool is_train_mode_set;
@@ -137,7 +138,7 @@ private:
   void read_zbl_in();
   void calculate_parameters();
   void report_inputs();
-  void check_foundation_model();
+  void check_foundation_model(const std::string& filename);
 
   void parse_one_keyword(std::vector<std::string>& tokens);
 
@@ -173,4 +174,5 @@ private:
   void parse_fine_tune(const char** param, int num_param);
   void parse_save_potential(const char** param, int num_param);
   void parse_q_scaler(const char** param, int num_param);
+  void parse_import_q_scaler(const char** param, int num_param);
 };


### PR DESCRIPTION
This PR introduces the `import_q_scaler` input parameter for `nep`.If set to `1` the `q_scaler` will taken from the `nep.txt` file available in the run directory. This allows a user to override the reinitialization of the `q_scaler` on restart. This behavior is necessary for truthful fine-tuning based on externally provided restart files. The `fine_tune` command does this already internally.