### PR TITLE
Add output interval control for nep

### DIFF
--- a/doc/nep/input_parameters/index.rst
+++ b/doc/nep/input_parameters/index.rst
@@ -37,6 +37,7 @@ Below you can find a listing of keywords for the ``nep.in`` input file.
    population
    generation
    save_potential
+   output_interval
    output_descriptor
    fine_tune
    charge_mode

--- a/doc/nep/input_parameters/output_interval.rst
+++ b/doc/nep/input_parameters/output_interval.rst
@@ -1,0 +1,14 @@
+.. _kw_output_interval:
+.. index::
+   single: output_interval (keyword in nep.in)
+
+:attr:`output_interval`
+========================
+
+This keyword sets the number of generations between writes to :ref:`loss.out <loss_out>` (and the corresponding console output, ``nep.txt``, and test-set output files).
+
+The syntax is::
+
+  output_interval <number_of_generations>
+
+Here, :attr:`<number_of_generations>` must be a positive integer and defaults to :math:`100`.

--- a/doc/nep/output_files/loss_out.rst
+++ b/doc/nep/output_files/loss_out.rst
@@ -5,7 +5,7 @@
 ``loss.out``
 ============
 
-This files contains the terms that enter the :ref:`loss function <nep_loss_function>` for every 100-th generation.
+This files contains the terms that enter the :ref:`loss function <nep_loss_function>`, written every :ref:`output_interval <kw_output_interval>` generations (100 by default).
 
 If a potential model is trained, each row contains the following fields::
 

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -435,7 +435,7 @@ void Fitness::report_error(
   const float loss_L2,
   float* elite)
 {
-  if (0 == (generation + 1) % 100) {
+  if (0 == (generation + 1) % para.output_interval) {
     int batch_id = generation % num_batches;
     potential->find_force(para, elite, train_set[batch_id], false, 1);
     float energy_shift_per_structure;
@@ -610,10 +610,10 @@ void Fitness::report_error(
         fclose(fid_polarizability);
       }
     }
+  }
 
-    if (0 == (generation + 1) % 1000) {
-      predict(para, elite);
-    }
+  if (0 == (generation + 1) % 1000) {
+    predict(para, elite);
   }
 }
 

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -76,6 +76,7 @@ void Parameters::set_default_parameters()
   is_use_typewise_cutoff_zbl_set = false;
   is_charge_mode_set = false;
   is_save_potential_set = false;
+  is_output_interval_set = false;
   is_q_scaler_set = false;
 
   train_mode = 0;              // potential
@@ -106,6 +107,7 @@ void Parameters::set_default_parameters()
   maximum_generation = 100000; // a good starting point
   save_potential = 100000;     // write checkpoint nep.txt files at these intervals
   save_potential_format = 1;   // 1 = include time stamp when writing checkpoint nep.txt files
+  output_interval = 100;       // write loss.out (and related output) every N generations
   initial_para = 1.0f;
   sigma0 = 0.1f;
   atomic_v = 0;
@@ -592,6 +594,12 @@ void Parameters::report_inputs()
     printf("    (default) save potential every N = %d generations.\n", save_potential);
   }
 
+  if (is_output_interval_set) {
+    printf("    (input)   output_interval = %d generations.\n", output_interval);
+  } else {
+    printf("    (default) output_interval = %d generations.\n", output_interval);
+  }
+
   if (fine_tune) {
     printf("    (input)   will fine-tune based on %s and %s.\n", 
       fine_tune_nep_txt.c_str(), fine_tune_nep_restart.c_str());
@@ -688,6 +696,8 @@ void Parameters::parse_one_keyword(std::vector<std::string>& tokens)
     parse_fine_tune(param, num_param);
   } else if (strcmp(param[0], "save_potential") == 0) {
     parse_save_potential(param, num_param);
+  } else if (strcmp(param[0], "output_interval") == 0) {
+    parse_output_interval(param, num_param);
   } else if (strcmp(param[0], "q_scaler") == 0) {
     parse_q_scaler(param, num_param);
   } else {
@@ -1439,7 +1449,22 @@ void Parameters::parse_save_potential(const char** param, int num_param)
   }
   if (save_potential_restart != 0 && save_potential_restart != 1) {
     PRINT_INPUT_ERROR("save_potential save restart should be 0 or 1.");
-  }  
+  }
+}
+
+void Parameters::parse_output_interval(const char** param, int num_param)
+{
+  is_output_interval_set = true;
+
+  if (num_param != 2) {
+    PRINT_INPUT_ERROR("output_interval should have 1 parameter.\n");
+  }
+  if (!is_valid_int(param[1], &output_interval)) {
+    PRINT_INPUT_ERROR("output_interval should be an integer.\n");
+  }
+  if (output_interval <= 0) {
+    PRINT_INPUT_ERROR("output_interval should be > 0.");
+  }
 }
 
 void Parameters::parse_q_scaler(const char** param, int num_param)

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -30,9 +30,10 @@ public:
   int num_types;          // number of atom types
   int population_size;    // population size for SNES
   int maximum_generation; // maximum number of generations for SNES;
-  int save_potential;     // number of generations between writing a checkpoint nep.txt file. 
+  int save_potential;     // number of generations between writing a checkpoint nep.txt file.
   int save_potential_format;   // format of checkpoint nep.txt file name
   int save_potential_restart;  // if restart files should be written or not. 0=no, 1=yes
+  int output_interval;    // number of generations between writing a line to loss.out and related output
   int num_neurons1;       // number of nuerons in the 1st hidden layer (only one hidden layer)
   int num_neurons2;       // number of nuerons in the 2nd hidden layer (only two hidden layers)
   int num_hidden_layers;  // number of hidden layers
@@ -98,6 +99,7 @@ public:
   bool is_population_set;
   bool is_generation_set;
   bool is_save_potential_set;
+  bool is_output_interval_set;
   bool is_type_weight_set;
   bool is_force_delta_set;
   bool is_zbl_set;
@@ -172,5 +174,6 @@ private:
   void parse_charge_mode(const char** param, int num_param);
   void parse_fine_tune(const char** param, int num_param);
   void parse_save_potential(const char** param, int num_param);
+  void parse_output_interval(const char** param, int num_param);
   void parse_q_scaler(const char** param, int num_param);
 };


### PR DESCRIPTION
This PR introduces the `output_interval` parameter, which allows one to set the dump frequency to `loss.out` directly. The default is 100 as before, so not setting the keyword recovers the known behavior. The keyword is meant as an expert option that allow users to inspect the early stages of a training run, in particular during fine tuning.