### PR TITLE
Removed unused q_scaler keyword from nep.in

### DIFF
--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -76,7 +76,6 @@ void Parameters::set_default_parameters()
   is_use_typewise_cutoff_zbl_set = false;
   is_charge_mode_set = false;
   is_save_potential_set = false;
-  is_q_scaler_set = false;
 
   train_mode = 0;              // potential
   prediction = 0;              // not prediction mode
@@ -113,7 +112,6 @@ void Parameters::set_default_parameters()
   typewise_cutoff_zbl_factor = -1.0f;
   output_descriptor = false;
   charge_mode = 0;
-  q_scaler_input = 0.02f;
 
   type_weight_cpu.resize(NUM_ELEMENTS);
   rc_radial.resize(NUM_ELEMENTS);
@@ -597,10 +595,6 @@ void Parameters::report_inputs()
       fine_tune_nep_txt.c_str(), fine_tune_nep_restart.c_str());
   }
 
-  if (is_q_scaler_set) {
-    printf("    (input)   q_scaler = %g.\n", q_scaler_input);
-  }
-
   // some calcuated parameters:
   printf("Some calculated parameters:\n");
   printf("    number of radial descriptor components = %d.\n", dim_radial);
@@ -688,8 +682,6 @@ void Parameters::parse_one_keyword(std::vector<std::string>& tokens)
     parse_fine_tune(param, num_param);
   } else if (strcmp(param[0], "save_potential") == 0) {
     parse_save_potential(param, num_param);
-  } else if (strcmp(param[0], "q_scaler") == 0) {
-    parse_q_scaler(param, num_param);
   } else {
     PRINT_KEYWORD_ERROR(param[0]);
   }
@@ -1439,23 +1431,5 @@ void Parameters::parse_save_potential(const char** param, int num_param)
   }
   if (save_potential_restart != 0 && save_potential_restart != 1) {
     PRINT_INPUT_ERROR("save_potential save restart should be 0 or 1.");
-  }  
-}
-
-void Parameters::parse_q_scaler(const char** param, int num_param)
-{
-  if (num_param != 2) {
-    PRINT_INPUT_ERROR("q_scaler should have 1 parameter.\n");
-  }
-
-  double q_scaler_tmp = 0.0;
-  if (!is_valid_real(param[1], &q_scaler_tmp)) {
-    PRINT_INPUT_ERROR("q_scaler should be a number.\n");
-  }
-  q_scaler_input = static_cast<float>(q_scaler_tmp);
-  is_q_scaler_set = true;
-
-  if (q_scaler_input < 0.01f || q_scaler_input > 0.1f) {
-    PRINT_INPUT_ERROR("q_scaler must be in [0.01 0.1].");
   }
 }

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -75,7 +75,6 @@ public:
   int fine_tune_descriptor = 1; // fine-tune descriptor; 0=no, 1=yes
   std::string fine_tune_nep_txt = "";
   std::string fine_tune_nep_restart = "";
-  float q_scaler_input;
 
   // check if a parameter has been set:
   bool is_train_mode_set;
@@ -103,7 +102,6 @@ public:
   bool is_zbl_set;
   bool is_use_typewise_cutoff_zbl_set;
   bool is_charge_mode_set;
-  bool is_q_scaler_set;
 
   // other parameters
   int dim;                            // dimension of the descriptor vector
@@ -172,5 +170,4 @@ private:
   void parse_charge_mode(const char** param, int num_param);
   void parse_fine_tune(const char** param, int num_param);
   void parse_save_potential(const char** param, int num_param);
-  void parse_q_scaler(const char** param, int num_param);
 };


### PR DESCRIPTION
While working on #1605 I noticed that the `nep.in` parser parses the `q_scaler` keyword but that this command is not used anywhere in the code. It was presumably introduced for testing purpose to allow a user to manually set the `q_scaler` but the actual functionality was later removed while the keyword remained. This PR removes this unused keyword.