### PR TITLE
`heat_hybrid:` An ensemble can handle both NH and Langevin thermostats during NEMD simulations with a single heat source and multiple heat sinks.

### DIFF
--- a/src/integrate/ensemble.cu
+++ b/src/integrate/ensemble.cu
@@ -877,3 +877,82 @@ void Ensemble::scale_velocity_local(
     velocity_per_atom.data() + 2 * number_of_atoms);
   GPU_CHECK_KERNEL
 }
+
+static __global__ void gpu_scale_velocity_n_groups(
+  const int number_of_particles,
+  const int num_groups,
+  const int* g_group_labels, // Array of group labels to scale
+  const double* g_factors,   // Array of scaling factors (one per group)
+  const int* g_atom_label,
+  const double* g_vcx,
+  const double* g_vcy,
+  const double* g_vcz,
+  const double* g_ke,
+  double* g_vx,
+  double* g_vy,
+  double* g_vz)
+{
+  int n = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n < number_of_particles) {
+    int atom_label = g_atom_label[n];
+    double factor = 1.0;
+
+    // Find if this atom belongs to any of the groups we're scaling
+    for (int i = 0; i < num_groups; i++) {
+      if (atom_label == g_group_labels[i]) {
+        factor = g_factors[i];
+        break;
+      }
+    }
+
+    if (factor != 1.0) {
+      double vcx = g_vcx[atom_label];
+      double vcy = g_vcy[atom_label];
+      double vcz = g_vcz[atom_label];
+
+      // Scale velocity while conserving momentum
+      g_vx[n] = vcx + factor * (g_vx[n] - vcx);
+      g_vy[n] = vcy + factor * (g_vy[n] - vcy);
+      g_vz[n] = vcz + factor * (g_vz[n] - vcz);
+    }
+  }
+}
+
+void Ensemble::scale_velocity_groups(
+  const std::vector<double>& factors,
+  const std::vector<int>& labels,
+  const double* vcx,
+  const double* vcy,
+  const double* vcz,
+  const double* ke,
+  const std::vector<Group>& group,
+  GPU_Vector<double>& velocity_per_atom)
+{
+  const int number_of_atoms = velocity_per_atom.size() / 3;
+  const int num_groups = factors.size();
+
+  if (num_groups == 0)
+    return;
+
+  // Create device arrays for factors and labels
+  GPU_Vector<double> d_factors(num_groups);
+  GPU_Vector<int> d_labels(num_groups);
+
+  d_factors.copy_from_host(factors.data());
+  d_labels.copy_from_host(labels.data());
+
+  gpu_scale_velocity_n_groups<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
+    number_of_atoms,
+    num_groups,
+    d_labels.data(),
+    d_factors.data(),
+    group[0].label.data(),
+    vcx,
+    vcy,
+    vcz,
+    ke,
+    velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms,
+    velocity_per_atom.data() + 2 * number_of_atoms);
+  GPU_CHECK_KERNEL
+}

--- a/src/integrate/ensemble.cuh
+++ b/src/integrate/ensemble.cuh
@@ -88,8 +88,20 @@ public:
   int deform_y = 0;
   int deform_z = 0;
   double deform_rate[3];
-
+  
   double energy_transferred[2]; // energy transferred from system to heat baths
+
+  std::vector<double> energy_transferred_n; // energy transferred from system to multiple heat baths
+  // addtional function for scaling velocities in multiple groups
+  virtual void scale_velocity_groups(
+    const std::vector<double>& factors,
+    const std::vector<int>& labels,
+    const double* vcx,
+    const double* vcy,
+    const double* vcz,
+    const double* ke,
+    const std::vector<Group>& group,
+    GPU_Vector<double>& velocity_per_atom);
 
   double mas_nhc1[NOSE_HOOVER_CHAIN_LENGTH];
   double pos_nhc1[NOSE_HOOVER_CHAIN_LENGTH];

--- a/src/integrate/ensemble_heat_hybrid.cu
+++ b/src/integrate/ensemble_heat_hybrid.cu
@@ -1,0 +1,337 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+*/
+
+/*---------------------------------------------------------------------------------------------------------------------------
+
+    Hybrid local heat baths with Nose-Hoover chain and Langevin thermostats.
+
+    heat_hybrid can be used to perform NEMD simulations using both Nose-Hoover
+    and Langevin thermostats. It can be used to analyze systems with a single heat source
+    and multiple heat sinks. This functionality requires a minimum of two thermal reservoirs.
+
+    Syntax :
+    Example 1: system with a single heat source and sink
+    ensemble    heat_hybrid nhc lan <T> <T_coup> <T_coup> <delta_T> <label_source> <label_sink>
+
+    Example 2: system with a single heat source and multiple heat sinks
+    ensemble    heat_hybrid lan nhc nhc <T> <T_coup> <T_coup> <T_coup> <delta_T> <label_source> <label_sink1> <label_sink2>
+
+    Contributors: Vivekkumar Panneerselvam and Weikang (Shanghai Jiao Tong University)
+
+------------------------------------------------------------------------------------------------------------------------------*/
+
+#include "ensemble_heat_hybrid.cuh"
+#include "langevin_utilities.cuh"
+#include "utilities/common.cuh"
+#include "utilities/gpu_macro.cuh"
+#include <cstdlib>
+#define DIM 3
+
+static double nhc(
+  int M,
+  double* pos_eta,
+  double* vel_eta,
+  double* mas_eta,
+  double Ek2,
+  double kT,
+  double dN,
+  double dt2_particle)
+{
+  int n_sy = 7;
+  int n_respa = 4;
+  const double w[7] = {
+    0.784513610477560,
+    0.235573213359357,
+    -1.17767998417887,
+    1.31518632068391,
+    -1.17767998417887,
+    0.235573213359357,
+    0.784513610477560};
+
+  double factor = 1.0;
+
+  for (int n1 = 0; n1 < n_sy; n1++) {
+    double dt2 = dt2_particle * w[n1] / n_respa;
+    double dt4 = dt2 * 0.5;
+    double dt8 = dt4 * 0.5;
+    for (int n2 = 0; n2 < n_respa; n2++) {
+      double G = vel_eta[M - 2] * vel_eta[M - 2] / mas_eta[M - 2] - kT;
+      vel_eta[M - 1] += dt4 * G;
+
+      for (int m = M - 2; m >= 0; m--) {
+        double tmp = exp(-dt8 * vel_eta[m + 1] / mas_eta[m + 1]);
+        if (m == 0) {
+          G = Ek2 - dN * kT;
+        } else {
+          G = vel_eta[m - 1] * vel_eta[m - 1] / mas_eta[m - 1] - kT;
+        }
+        vel_eta[m] = tmp * (tmp * vel_eta[m] + dt4 * G);
+      }
+
+      for (int m = M - 1; m >= 0; m--) {
+        pos_eta[m] += dt2 * vel_eta[m] / mas_eta[m];
+      }
+
+      double factor_local = exp(-dt2 * vel_eta[0] / mas_eta[0]);
+      Ek2 *= factor_local * factor_local;
+      factor *= factor_local;
+
+      for (int m = 0; m < M - 1; m++) {
+        double tmp = exp(-dt8 * vel_eta[m + 1] / mas_eta[m + 1]);
+        if (m == 0) {
+          G = Ek2 - dN * kT;
+        } else {
+          G = vel_eta[m - 1] * vel_eta[m - 1] / mas_eta[m - 1] - kT;
+        }
+        vel_eta[m] = tmp * (tmp * vel_eta[m] + dt4 * G);
+      }
+
+      G = vel_eta[M - 2] * vel_eta[M - 2] / mas_eta[M - 2] - kT;
+      vel_eta[M - 1] += dt4 * G;
+    }
+  }
+  return factor;
+}
+
+Ensemble_Heat_Hybrid::Ensemble_Heat_Hybrid(
+  int type_input,
+  const std::vector<int>& thermostat_type_input,
+  const std::vector<int>& label_input,
+  const std::vector<int>& size_input,
+  const std::vector<int>& offset_input,
+  double temperature_input,
+  const std::vector<double>& coupling_input,
+  double delta_temperature_input,
+  double time_step)
+{
+  type = type_input;
+  temperature = temperature_input;
+  delta_temperature = delta_temperature_input;
+
+  num_thermostats = thermostat_type_input.size();
+  thermostat_type = thermostat_type_input;
+  label = label_input;
+  size = size_input;
+  offset = offset_input;
+  coupling = coupling_input;
+
+  // Resize vectors
+  c1.resize(num_thermostats);
+  c2.resize(num_thermostats);
+  curand_states.resize(num_thermostats);
+  energy_transferred_n.resize(num_thermostats, 0.0);
+
+  // Resize NHC arrays
+  pos_nhc.resize(num_thermostats * NOSE_HOOVER_CHAIN_LENGTH);
+  vel_nhc.resize(num_thermostats * NOSE_HOOVER_CHAIN_LENGTH);
+  mas_nhc.resize(num_thermostats * NOSE_HOOVER_CHAIN_LENGTH);
+
+  for (int i = 0; i < num_thermostats; i++) {
+    double target = target_temperature(i);
+    if (thermostat_type[i] == 0) {
+      double* pos_eta = get_nhc_pos(i);
+      double* vel_eta = get_nhc_vel(i);
+      double* mas_eta = get_nhc_mas(i);
+      double tau = time_step * coupling[i];
+      for (int m = 0; m < NOSE_HOOVER_CHAIN_LENGTH; m++) {
+        pos_eta[m] = 0.0;
+        vel_eta[m] = (m % 2 == 0) ? 1.0 : -1.0;
+        mas_eta[m] = K_B * target * tau * tau;
+      }
+      mas_eta[0] *= DIM * size[i];
+    } else {
+      c1[i] = exp(-0.5 / coupling[i]);
+      c2[i] = sqrt((1.0 - c1[i] * c1[i]) * K_B * target);
+      curand_states[i].resize(size[i]);
+      initialize_curand_states<<<(size[i] - 1) / 128 + 1, 128>>>(
+        curand_states[i].data(), size[i], rand());
+      GPU_CHECK_KERNEL
+    }
+  }
+}
+
+Ensemble_Heat_Hybrid::~Ensemble_Heat_Hybrid(void) {}
+
+double Ensemble_Heat_Hybrid::target_temperature(int index) const
+{
+  return temperature + ((index == 0) ? delta_temperature : -delta_temperature);
+}
+
+double* Ensemble_Heat_Hybrid::get_nhc_pos(int index)
+{
+  return pos_nhc.data() + index * NOSE_HOOVER_CHAIN_LENGTH;
+}
+
+double* Ensemble_Heat_Hybrid::get_nhc_vel(int index)
+{
+  return vel_nhc.data() + index * NOSE_HOOVER_CHAIN_LENGTH;
+}
+
+double* Ensemble_Heat_Hybrid::get_nhc_mas(int index)
+{
+  return mas_nhc.data() + index * NOSE_HOOVER_CHAIN_LENGTH;
+}
+
+void Ensemble_Heat_Hybrid::integrate_heat_hybrid_half(
+  const double time_step,
+  const std::vector<Group>& group,
+  const GPU_Vector<double>& mass,
+  GPU_Vector<double>& velocity_per_atom)
+{
+  const int number_of_atoms = mass.size();
+  const int number_of_groups = group[0].number;
+  bool has_nhc = false;
+  bool has_lan = false;
+  for (int i = 0; i < num_thermostats; i++) {
+    has_nhc = has_nhc || thermostat_type[i] == 0;
+    has_lan = has_lan || thermostat_type[i] == 1;
+  }
+
+  if (has_nhc) {
+    std::vector<double> ek2(number_of_groups);
+    GPU_Vector<double> vcx(number_of_groups), vcy(number_of_groups), vcz(number_of_groups),
+      ke(number_of_groups);
+    std::vector<double> factor(num_thermostats, 1.0);
+    std::vector<int> nhc_labels;
+    std::vector<double> nhc_factors;
+
+    find_vc_and_ke(group, mass, velocity_per_atom, vcx.data(), vcy.data(), vcz.data(), ke.data());
+    ke.copy_to_host(ek2.data());
+
+    for (int i = 0; i < num_thermostats; i++) {
+      if (thermostat_type[i] == 0) {
+        double* pos_eta = get_nhc_pos(i);
+        double* vel_eta = get_nhc_vel(i);
+        double* mas_eta = get_nhc_mas(i);
+        double kT = K_B * target_temperature(i);
+        double dN = (double)DIM * size[i];
+        factor[i] = nhc(
+          NOSE_HOOVER_CHAIN_LENGTH,
+          pos_eta,
+          vel_eta,
+          mas_eta,
+          ek2[label[i]],
+          kT,
+          dN,
+          time_step * 0.5);
+        energy_transferred_n[i] += ek2[label[i]] * 0.5 * (1.0 - factor[i] * factor[i]);
+
+        nhc_labels.push_back(label[i]);
+        nhc_factors.push_back(factor[i]);
+      }
+    }
+
+    // Use the GPU-based scaling function
+    if (!nhc_labels.empty()) {
+      scale_velocity_groups(
+        nhc_factors,
+        nhc_labels,
+        vcx.data(),
+        vcy.data(),
+        vcz.data(),
+        ke.data(),
+        group,
+        velocity_per_atom);
+    }
+  }
+
+  if (has_lan) {
+    std::vector<double> ek2(number_of_groups);
+    GPU_Vector<double> ke(number_of_groups);
+
+    find_ke<<<number_of_groups, 512>>>(
+      group[0].size.data(),
+      group[0].size_sum.data(),
+      group[0].contents.data(),
+      mass.data(),
+      velocity_per_atom.data(),
+      velocity_per_atom.data() + number_of_atoms,
+      velocity_per_atom.data() + 2 * number_of_atoms,
+      ke.data());
+    GPU_CHECK_KERNEL
+
+    ke.copy_to_host(ek2.data());
+    for (int i = 0; i < num_thermostats; i++) {
+      if (thermostat_type[i] == 1) {
+        energy_transferred_n[i] += ek2[label[i]] * 0.5;
+      }
+    }
+
+    for (int i = 0; i < num_thermostats; i++) {
+      if (thermostat_type[i] == 1) {
+        gpu_langevin<<<(size[i] - 1) / 128 + 1, 128>>>(
+          curand_states[i].data(),
+          size[i],
+          offset[i],
+          group[0].contents.data(),
+          c1[i],
+          c2[i],
+          mass.data(),
+          velocity_per_atom.data(),
+          velocity_per_atom.data() + number_of_atoms,
+          velocity_per_atom.data() + 2 * number_of_atoms);
+        GPU_CHECK_KERNEL
+      }
+    }
+
+    find_ke<<<number_of_groups, 512>>>(
+      group[0].size.data(),
+      group[0].size_sum.data(),
+      group[0].contents.data(),
+      mass.data(),
+      velocity_per_atom.data(),
+      velocity_per_atom.data() + number_of_atoms,
+      velocity_per_atom.data() + 2 * number_of_atoms,
+      ke.data());
+    GPU_CHECK_KERNEL
+
+    ke.copy_to_host(ek2.data());
+    for (int i = 0; i < num_thermostats; i++) {
+      if (thermostat_type[i] == 1) {
+        energy_transferred_n[i] -= ek2[label[i]] * 0.5;
+      }
+    }
+  }
+}
+
+void Ensemble_Heat_Hybrid::compute1(
+  const double time_step,
+  const std::vector<Group>& group,
+  Box& box,
+  Atom& atom,
+  GPU_Vector<double>& thermo)
+{
+  integrate_heat_hybrid_half(time_step, group, atom.mass, atom.velocity_per_atom);
+  velocity_verlet(
+    true,
+    time_step,
+    group,
+    atom.mass,
+    atom.force_per_atom,
+    atom.position_per_atom,
+    atom.velocity_per_atom);
+}
+
+void Ensemble_Heat_Hybrid::compute2(
+  const double time_step,
+  const std::vector<Group>& group,
+  Box& box,
+  Atom& atom,
+  GPU_Vector<double>& thermo)
+{
+  velocity_verlet(
+    false,
+    time_step,
+    group,
+    atom.mass,
+    atom.force_per_atom,
+    atom.position_per_atom,
+    atom.velocity_per_atom);
+  integrate_heat_hybrid_half(time_step, group, atom.mass, atom.velocity_per_atom);
+}

--- a/src/integrate/ensemble_heat_hybrid.cuh
+++ b/src/integrate/ensemble_heat_hybrid.cuh
@@ -1,0 +1,74 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+*/
+
+#pragma once
+#include "ensemble.cuh"
+#include "utilities/gpu_macro.cuh"
+#ifdef USE_HIP
+#include <hiprand/hiprand_kernel.h>
+#else
+#include <curand_kernel.h>
+#endif
+
+class Ensemble_Heat_Hybrid : public Ensemble
+{
+public:
+  Ensemble_Heat_Hybrid(
+    int type,
+    const std::vector<int>& thermostat_type,
+    const std::vector<int>& label,
+    const std::vector<int>& size,
+    const std::vector<int>& offset,
+    double temperature,
+    const std::vector<double>& coupling,
+    double delta_temperature,
+    double time_step);
+  virtual ~Ensemble_Heat_Hybrid(void);
+
+  virtual void compute1(
+    const double time_step,
+    const std::vector<Group>& group,
+    Box& box,
+    Atom& atom,
+    GPU_Vector<double>& thermo);
+
+  virtual void compute2(
+    const double time_step,
+    const std::vector<Group>& group,
+    Box& box,
+    Atom& atom,
+    GPU_Vector<double>& thermo);
+
+protected:
+  int num_thermostats;
+  std::vector<int> thermostat_type;
+  std::vector<int> label;
+  std::vector<int> size;
+  std::vector<int> offset;
+  std::vector<double> coupling;
+  std::vector<double> c1;
+  std::vector<double> c2;
+  std::vector<GPU_Vector<gpurandState>> curand_states;
+
+  // Flattened NHC arrays: [thermostat_index * NOSE_HOOVER_CHAIN_LENGTH + chain_index]
+  std::vector<double> pos_nhc;
+  std::vector<double> vel_nhc;
+  std::vector<double> mas_nhc;
+
+  void integrate_heat_hybrid_half(
+    const double time_step,
+    const std::vector<Group>& group,
+    const GPU_Vector<double>& mass,
+    GPU_Vector<double>& velocity_per_atom);
+
+  double* get_nhc_pos(int index);
+  double* get_nhc_vel(int index);
+  double* get_nhc_mas(int index);
+  double target_temperature(int index) const;
+};

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -21,11 +21,12 @@ The driver class for the various integrators.
 #include "ensemble_bdp.cuh"
 #include "ensemble_ber.cuh"
 #include "ensemble_lan.cuh"
+#include "ensemble_heat_hybrid.cuh"
 #include "ensemble_msst.cuh"
 #include "ensemble_mttk.cuh"
 #include "ensemble_nhc.cuh"
-#include "ensemble_npt_qtb.cuh"
 #include "ensemble_nphug.cuh"
+#include "ensemble_npt_qtb.cuh"
 #include "ensemble_npt_scr.cuh"
 #include "ensemble_nve.cuh"
 #include "ensemble_pimd.cuh"
@@ -102,13 +103,7 @@ void Integrate::initialize(
       break;
     case 6: // NVT-QTB
       ensemble.reset(new Ensemble_QTB(
-        type,
-        number_of_atoms,
-        temperature,
-        temperature_coupling,
-        time_step,
-        qtb_f_max,
-        qtb_n_f));
+        type, number_of_atoms, temperature, temperature_coupling, time_step, qtb_f_max, qtb_n_f));
       break;
     case 11: // NPT-Berendsen
       ensemble.reset(new Ensemble_BER(
@@ -175,7 +170,7 @@ void Integrate::initialize(
     case 22: // heat-Langevin
       ensemble.reset(new Ensemble_LAN(
         type,
-        move_group, 
+        move_group,
         move_velocity,
         source,
         sink,
@@ -216,6 +211,26 @@ void Integrate::initialize(
         ttm_parameters,
         box));
       break;
+    case 26: { // Heat-hybrid facilitates the use of both Langevin and Nose-Hoover thermostats
+      // Use vectors from the class (heat_labels, heat_thermostat, heat_coupling)
+      std::vector<int> sizes(heat_labels.size());
+      std::vector<int> offsets(heat_labels.size());
+      for (size_t i = 0; i < heat_labels.size(); i++) {
+        sizes[i] = group[0].cpu_size[heat_labels[i]];
+        offsets[i] = group[0].cpu_size_sum[heat_labels[i]];
+      }
+      ensemble.reset(new Ensemble_Heat_Hybrid(
+        type,
+        heat_thermostat, // Now a vector
+        heat_labels,     // Now a vector
+        sizes,
+        offsets,
+        temperature,
+        heat_coupling, // Now a vector
+        delta_temperature,
+        time_step));
+      break;
+    }
     case 31: // RPMD
       ensemble.reset(new Ensemble_PIMD(number_of_atoms, number_of_beads, false, atom));
       break;
@@ -478,6 +493,13 @@ void Integrate::parse_ensemble(
       PRINT_INPUT_ERROR(
         "ensemble ttm should have 12 required parameters plus optional key-value pairs.");
     }
+  } else if (strcmp(param[1], "heat_hybrid") == 0) {
+    type = 26;
+    // Minimum parameters
+    if (num_param < 9) {
+      PRINT_INPUT_ERROR("ensemble heat_hybrid needs at least 7 parameters.");
+    }
+    // The rest of the parsing happens in the dedicated section below
   } else if (strcmp(param[1], "rpmd") == 0) {
     type = 31;
     if (num_param != 3) {
@@ -736,6 +758,100 @@ void Integrate::parse_ensemble(
 
   if (type == 24 || type == 25) {
     parse_ttm_parameters(type, param, num_param, atom, box, group, source, sink, ttm_parameters);
+  }
+
+  // heating and cooling wiht hybrid thermostat
+
+  if (type == 26) {
+    // Clear vectors in case this is parsed multiple times
+    heat_thermostat.clear();
+    heat_coupling.clear();
+    heat_labels.clear();
+
+    // Parse thermostat types - variable number
+    int num_thermostats = 0;
+    while (num_thermostats + 2 < num_param) {
+      const char* type_str = param[2 + num_thermostats];
+      if (strcmp(type_str, "nhc") == 0) {
+        heat_thermostat.push_back(0);
+        num_thermostats++;
+      } else if (strcmp(type_str, "lan") == 0) {
+        heat_thermostat.push_back(1);
+        num_thermostats++;
+      } else {
+        // Not a thermostat type, stop parsing
+        break;
+      }
+    }
+
+    if (num_thermostats < 2) {
+      PRINT_INPUT_ERROR("Heat-hybrid needs at least 2 thermostats.");
+    }
+
+    int idx = 2 + num_thermostats; // Current position in param array
+
+    // Parse temperature
+    if (idx >= num_param || !is_valid_real(param[idx], &temperature)) {
+      PRINT_INPUT_ERROR("Temperature should be a number.");
+    }
+    if (temperature <= 0.0) {
+      PRINT_INPUT_ERROR("Temperature should > 0.");
+    }
+    idx++;
+
+    // Parse coupling parameters - must match number of thermostats
+    heat_coupling.resize(num_thermostats);
+    for (int n = 0; n < num_thermostats; n++) {
+      if (idx >= num_param || !is_valid_real(param[idx], &heat_coupling[n])) {
+        PRINT_INPUT_ERROR("Heat-hybrid damping parameter should be a number.");
+      }
+      if (heat_coupling[n] < 1.0) {
+        PRINT_INPUT_ERROR("Heat-hybrid damping parameter should >= 1.");
+      }
+      idx++;
+    }
+    temperature_coupling = heat_coupling[0];
+
+    // Parse delta_temperature
+    if (idx >= num_param || !is_valid_real(param[idx], &delta_temperature)) {
+      PRINT_INPUT_ERROR("Temperature difference should be a number.");
+    }
+    if (delta_temperature >= temperature || delta_temperature <= -temperature) {
+      PRINT_INPUT_ERROR("|Temperature difference| is too large.");
+    }
+    idx++;
+
+    // Parse group labels - must match number of thermostats
+    heat_labels.resize(num_thermostats);
+    for (int n = 0; n < num_thermostats; n++) {
+      if (idx >= num_param || !is_valid_int(param[idx], &heat_labels[n])) {
+        PRINT_INPUT_ERROR("Group ID for thermostat should be an integer.");
+      }
+      idx++;
+    }
+
+    if (group.size() < 1) {
+      PRINT_INPUT_ERROR("Cannot heat/cold without grouping method.");
+    }
+
+    // Validate all groups
+    for (int n = 0; n < num_thermostats; n++) {
+      if (heat_labels[n] < 0 || heat_labels[n] >= group[0].number) {
+        PRINT_INPUT_ERROR("Group ID for heat thermostat is out of range.");
+      }
+      if (group[0].cpu_size[heat_labels[n]] <= 0) {
+        PRINT_INPUT_ERROR("Heat thermostat group cannot be empty.");
+      }
+    }
+
+    // Check all groups are distinct
+    for (int i = 0; i < num_thermostats; i++) {
+      for (int j = i + 1; j < num_thermostats; j++) {
+        if (heat_labels[i] == heat_labels[j]) {
+          PRINT_INPUT_ERROR("Heat thermostats must use different groups.");
+        }
+      }
+    }
   }
 
   // 5. PIMD related
@@ -1069,6 +1185,32 @@ void Integrate::parse_ensemble(
       printf("Integrate with pure Two-Temperature Model (TTM) for this run.\n");
       print_ttm_settings(ttm_parameters);
       break;
+    case 26:
+      printf("Integrate with hybrid heating and cooling for this run.\n");
+      printf("    Number of thermostats: %zu\n", heat_thermostat.size());
+      for (size_t n = 0; n < heat_thermostat.size(); n++) {
+        printf(
+          "    Thermostat %zu: %s, group %d, tau = %g time_step, T = %g K\n",
+          n + 1,
+          heat_thermostat[n] == 0 ? "NHC" : "Langevin",
+          heat_labels[n],
+          heat_coupling[n],
+          (n == 0) ? temperature + delta_temperature : temperature - delta_temperature);
+      }
+      printf("    Average temperature: %g K\n", temperature);
+      printf("    Delta T: %g K\n", delta_temperature);
+      printf(
+        "    Hot thermostat (T = %g K) is group %d\n",
+        temperature + delta_temperature,
+        heat_labels[0]);
+      for (size_t n = 1; n < heat_labels.size(); n++) {
+        printf(
+          "    Cold thermostat %zu (T = %g K) is group %d\n",
+          n,
+          temperature - delta_temperature,
+          heat_labels[n]);
+      }
+      break;
     case 31:
       printf("Use ring-polymer MD (RPMD) for this run.\n");
       printf("    number of beads is %d.\n", number_of_beads);
@@ -1167,8 +1309,7 @@ void Integrate::parse_fix(const char** param, int num_param, std::vector<Group>&
     PRINT_INPUT_ERROR("Fixed group ID should < number of groups.");
   }
 
-  printf(
-    "Group %d in grouping method %d will be fixed.\n", fixed_group, fixed_grouping_method);
+  printf("Group %d in grouping method %d will be fixed.\n", fixed_group, fixed_grouping_method);
 }
 
 void Integrate::parse_move(const char** param, int num_param, std::vector<Group>& group)

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -95,6 +95,11 @@ public:
   int deform_y = 0;
   int deform_z = 0;
   double deform_rate[3];
+  
+  // Dynamic arrays for multiple thermostats
+  std::vector<int> heat_thermostat;  // Thermostat types (0=NHC, 1=Langevin)
+  std::vector<double> heat_coupling; // Coupling parameters for each thermostat
+  std::vector<int> heat_labels;      // Group labels for each thermostat
 
   // PIMD
   int number_of_beads;

--- a/src/measure/compute.cu
+++ b/src/measure/compute.cu
@@ -201,7 +201,6 @@ static __global__ void find_group_sum_1(
   }
   __syncthreads();
 
-
   for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
     if (tid < offset) {
       s_data[tid] += s_data[tid + offset];
@@ -524,7 +523,15 @@ void Compute::process(
     cpu_group_sum_ave[n] += cpu_group_sum[n];
 
   if (output_flag) {
-    output_results(integrate.ensemble->energy_transferred, group);
+    if (integrate.type == 26) {
+      //  Extract energy from multiple thermal reservoirs
+      int num_thermostats = integrate.ensemble->energy_transferred_n.size();
+      output_results_n(integrate.ensemble->energy_transferred_n.data(), group, num_thermostats);
+    } else {
+      // Use legacy version for other ensemble types
+      output_results(integrate.ensemble->energy_transferred, group);
+    }
+
     for (int n = 0; n < Ng * number_of_scalars; ++n)
       cpu_group_sum_ave[n] = 0.0;
   }
@@ -547,6 +554,32 @@ void Compute::output_results(const double energy_transferred[], const std::vecto
   if (compute_temperature) {
     fprintf(fid, "%15.6e", energy_transferred[0]);
     fprintf(fid, "%15.6e", energy_transferred[1]);
+  }
+
+  fprintf(fid, "\n");
+  fflush(fid);
+}
+
+void Compute::output_results_n(
+  const double energy_transferred_n[], const std::vector<Group>& group, int num_thermostats)
+{
+  int Ng = group[grouping_method].number;
+  for (int n = 0; n < number_of_scalars; ++n) {
+    int offset = n * Ng;
+    for (int k = 0; k < Ng; k++) {
+      double tmp = cpu_group_sum_ave[k + offset] / output_interval;
+      if (compute_temperature && n == 0) {
+        tmp /= group[grouping_method].cpu_size[k];
+      }
+      fprintf(fid, "%15.6e", tmp);
+    }
+  }
+
+  // Output energy transferred for ALL thermostats (dynamic number)
+  if (compute_temperature) {
+    for (int i = 0; i < num_thermostats; i++) {
+      fprintf(fid, "%15.6e", energy_transferred_n[i]);
+    }
   }
 
   fprintf(fid, "\n");

--- a/src/measure/compute.cuh
+++ b/src/measure/compute.cuh
@@ -80,6 +80,11 @@ private:
   GPU_Vector<double> gpu_per_atom_z;
 
   int number_of_scalars = 0;
+  
+  void output_results(
+    const double energy_transferred[], const std::vector<Group>& group);
 
-  void output_results(const double energy_transferred[], const std::vector<Group>& group);
+  // Handle multiple thermal reservoirs
+  void output_results_n(
+    const double energy_transferred_n[], const std::vector<Group>& group, int num_thermostats);
 };


### PR DESCRIPTION

**Summary** This PR adds `heat_hybrid` functionality to support both **NH (Nose-Hoover)** and **Langevin** thermostats during NMED simulations.

**Modification** The `heat_hybrid` feature can handle both Nose–Hoover and Langevin thermostats simultaneously while performing NEMD simulations. It was generalized for scenarios with a single heat source and multiple heat sinks. This feature allows NEMD simulations to be performed irrespective of thermostat type, **so that current `heat_lan` and `heat_nhc` options may no longer be required.** However, the current version still supports those options for backward compatibility.

Modified: `integrate.cuh`, `integrate.cu`, `ensemble.cu`, `ensemble.cuh`, `compute.cuh`, `compute.cu`
Added: `ensemble_heat_hybrid.cu`, `ensemble_heat_hybrid.cuh`

**Licensing** I agree to license this contribution under GPLv3.

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.

**Validation** 
- `heat_hybrid` tested against legacy `heat_lan` and `heat_nhc` methods with two thermal reservoirs
- `heat_lan` and `heat_nhc` were tested individually for backward compatibility.

**Usage**
Syntax :
Example 1: system with a single heat source and sink
`ensemble    heat_hybrid nhc lan <T> <T_coup> <T_coup> <delta_T> <label_source> <label_sink>`

Example 2: system with a single heat source and multiple heat sinks
`ensemble    heat_hybrid lan nhc nhc <T> <T_coup> <T_coup> <T_coup> <delta_T> <label_source> <label_sink1> <label_sink2>`
