### PR TITLE
Enhance dump_netcdf trajectory output

### DIFF
--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -5,7 +5,8 @@
 :attr:`dump_netcdf`
 ===================
 
-Write the atomic positions (coordinates) and (optionally) velocities in NetCDF format to a `movie.nc file <http://ambermd.org/netcdf/nctraj.pdf>`_.
+Write the atomic positions (coordinates) and (optionally) velocities to a user-specified
+NetCDF trajectory file based on the `AMBER 1.0 conventions <http://ambermd.org/netcdf/nctraj.pdf>`_.
 
 
 Syntax
@@ -13,47 +14,76 @@ Syntax
 
 This keyword has the following format::
 
-  dump_netcdf <interval> <has_velocity> [{optional_args}]
+  dump_netcdf <grouping_method> <group_id> <interval> <has_velocity> <filename> [{optional_args}]
 
-The :attr:`interval` parameter is the output interval (number of steps) of the atom positions. `has_velocity` can be 1 or 0, which means the velocities will or will not be included in the output.
-The optinal arguments (:attr:`optional_args`) provide additional functionality.
-Currently, the following optional argument is accepted:
+The :attr:`grouping_method` parameter selects one of the grouping methods defined by
+``group:I:number_of_grouping_methods`` in the :ref:`simulation model file <model_xyz>`.
+Grouping methods are numbered from 0. When :attr:`grouping_method` is non-negative,
+:attr:`group_id` selects a group label within that grouping method, and only the atoms
+belonging to that group are written. Both values must identify an existing, non-empty
+group. When :attr:`grouping_method` is negative, :attr:`group_id` is ignored and all atoms
+in the system are written. These selection rules are the same as for
+:ref:`dump_xyz <kw_dump_xyz>`.
+The :attr:`interval` parameter is the output interval (number of steps) of the atom positions. :attr:`has_velocity` can be 1 or 0, which means the velocities will or will not be included in the output. :attr:`filename` is the relative or absolute path of the output file.
+The optional arguments (:attr:`optional_args`) provide additional functionality.
+Currently, the following optional arguments are accepted:
 
 * :attr:`precision <value>`
   
   * If :attr:`value` is ``single``, the output data are 32-bit floating point numbers.
   * If :attr:`value` is ``double``, the output data are 64-bit floating point numbers.
 
-  The default value is ``double``.
+  The default value is ``single``.
+
+* :attr:`compression none|deflate <level>`
+
+  * ``none`` writes an uncompressed NetCDF file in the 64-bit-offset (CDF-2) format and is the default.
+    Here, 64-bit offset refers to the file layout, not the precision of the coordinates and velocities;
+    these data use 32-bit floating point numbers when the default ``precision single`` is used.
+  * ``deflate`` writes a NetCDF4/HDF5 file using lossless compression and requires NetCDF-C built
+    with NetCDF4/HDF5 and zlib support. :attr:`level` must be an integer from 0 to 9.
+    Level 0 applies no compression. For large, frequently written trajectories, use ``none`` for
+    maximum write speed, ``deflate 1`` for a practical balance, or ``deflate 9`` when minimizing
+    file size is more important than write speed.
 
 Requirements and specifications
 -------------------------------
 
 * This keyword requires an external package to operate.
   Instructions for how to set up the `NetCDF package <https://www.unidata.ucar.edu/software/netcdf>`_ can be found :ref:`here <netcdf_setup>`.
-* The NetCDF format follows the `AMBER specifications <http://ambermd.org/netcdf/nctraj.pdf>`_. 
-* The ``single`` option is good for saving space, but does not follow the official AMBER 1.0 conventions.
-* NetCDF output files can be read for example by `VMD <https://www.ks.uiuc.edu/Research/vmd/>`_ or `OVITO <https://ovito.org/>`_ for visualization. 
-* The NetCDF files also contain cell lengths and angles, which can be used in the visualization software to illustrate boundaries and show periodic copies of the structure.
+* The ``single`` option is good for saving space and is the default.
+* NetCDF output files can be read for example by `VMD <https://www.ks.uiuc.edu/Research/vmd/>`_ or `OVITO <https://ovito.org/>`_ for visualization.
+* The NetCDF files also contain atom types, cell lengths, and angles, which can be used in visualization and analysis software.
+* The atomic positions are always included in the output. For periodic MD, the wrapped
+  positions are written.
 
 Examples
 --------
 
-Single precision without veolocities
+Single precision without velocities
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To dump the positions every 1000 steps to a NetCDF file with 32-bit floating point values, one can add::
+To dump the whole-system positions every 1000 steps using the default single precision and no compression, one can add::
 
-  dump_netcdf 1000 0 precision single
+  dump_netcdf -1 0 1000 0 movie.nc
 
 before the :ref:`run command <kw_run>`.
 
 Double precision with velocities
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To dump the positions and velocities every 1000 steps to a NetCDF file with 64-bit floating point values, one can add::
+To dump the whole-system positions and velocities every 1000 steps with 64-bit floating point values, one can add::
 
-  dump_netcdf 1000 1
+  dump_netcdf -1 0 1000 1 movie.nc precision double
+
+before the :ref:`run command <kw_run>`.
+
+Group output with compression
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To dump group 0 from grouping method 1 with lossless deflate compression, one can add::
+
+  dump_netcdf 1 0 15 1 group.nc compression deflate 1
 
 before the :ref:`run command <kw_run>`.
 
@@ -61,12 +91,11 @@ before the :ref:`run command <kw_run>`.
 Caveats
 -------
 
-* Following the `AMBER 1.0 conventions <http://ambermd.org/netcdf/nctraj.pdf>`_, length is in units of Ångström
-  and velocity is in units of Ångström/picosecond.
+* Length is in units of Ångström and velocity is in units of Ångström/picosecond.
 * This keyword is not propagating.
   That means, its effect will not be passed from one run to the next.
-* The output appends to the same file for different runs in the same simulation.
-  Re-running the simulation will create a new output file.
-* If the file "movie.nc" already exists in the current directory, it will not be overwritten.
-  Instead, files will be generated with names "movie_2.nc", "movie_3.nc", ..., "movie_n.nc".
-* If the :attr:`precision` changes between different runs, the first defined precision will still be used (i.e., changes in precision are ignored during a simulation). 
+* An existing output file is overwritten the first time its name is used in a GPUMD execution.
+* Repeating the keyword with the same filename in later runs of the same GPUMD execution
+  appends to that file. A different filename creates a separate trajectory file.
+* Group, precision, velocity, and compression settings cannot change while appending to the same file.
+* The new syntax is not compatible with the former ``dump_netcdf <interval> <has_velocity>`` syntax.

--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -56,6 +56,9 @@ Requirements and specifications
 * The NetCDF files also contain atom types, cell lengths, and angles, which can be used in visualization and analysis software.
 * The atomic positions are always included in the output. For periodic MD, the wrapped
   positions are written.
+* AMBER NetCDF represents a periodic cell using lengths and angles in a standard orientation.
+  If the GPUMD cell has a different orientation, the output positions and velocities are
+  rigidly transformed with the cell so that periodic geometry is preserved.
 
 Examples
 --------

--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -64,7 +64,7 @@ Examples
 --------
 
 Single precision without velocities
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To dump the whole-system positions every 1000 steps using the default single precision and no compression, one can add::
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -135,12 +135,12 @@ NetCDF setup
 ============
 
 To use `NetCDF <https://www.unidata.ucar.edu/software/netcdf/>`_ (see :ref:`dump_netcdf keyword <kw_dump_netcdf>`) with :program:`GPUMD`, a few extra steps must be taken before building :program:`GPUMD`.
-First, you must download and install the correct version of NetCDF.
-Currently, :program:`GPUMD` is coded to work with `netCDF-C 4.6.3 <https://github.com/Unidata/netcdf-c/releases/tag/v4.6.3>`_ and it is recommended that this version is used (not newer versions).
+First, you must download and install a compatible version of NetCDF.
+:program:`GPUMD` requires netCDF-C 4.6.3 or later; version 4.6.3 remains a known-compatible baseline.
 
 The setup instructions are below:
 
-* Download `netCDF-C 4.6.3 <https://github.com/Unidata/netcdf-c/releases/tag/v4.6.3>`_
+* Download `netCDF-C 4.6.3 <https://github.com/Unidata/netcdf-c/releases/tag/v4.6.3>`_ or a `newer release <https://github.com/Unidata/netcdf-c/releases>`_.
 * Configure and build NetCDF.
   It is best to follow the instructions included with the software but, for the configuration, please use the following flags seen in our example line
 
@@ -148,7 +148,13 @@ The setup instructions are below:
 
      ./configure --prefix=<path> --disable-netcdf-4 --disable-dap
 
-  Here, the :attr:`--prefix` determines the output directory of the build. Then make and install NetCDF:
+  This configuration supports the default uncompressed NetCDF output and avoids the
+  additional HDF5 and zlib dependencies. To use the optional ``compression deflate``
+  mode, install NetCDF-C with NetCDF4/HDF5 and zlib support by omitting
+  ``--disable-netcdf-4``. For newer NetCDF-C releases, if ``configure`` reports that
+  ``xml2-config`` cannot be found, add ``--disable-libxml2`` to use the bundled XML
+  parser. Here, the :attr:`--prefix` determines the output directory of the build.
+  Then make and install NetCDF:
 
   .. code:: bash
 
@@ -167,10 +173,14 @@ The setup instructions are below:
   .. code:: make
 
      INC = -I<path>/include -I./
-     LDFLAGS = -L<path>/lib
-     LIBS = -lcublas -lcusolver -l:libnetcdf.a
+     LDFLAGS = -L<path>/lib -Xlinker=-rpath -Xlinker=<path>/lib
+     LIBS = -lcublas -lcusolver -lcufft -lnetcdf
 
-  where :attr:`<path>` should be replaced with the installation path for NetCDF (defined in :attr:`--prefix` of the ``./configure`` command).
+  where :attr:`<path>` should be replaced with the installation path for NetCDF
+  (defined in :attr:`--prefix` of the ``./configure`` command). The ``-L`` option
+  specifies where to find NetCDF while linking, and the ``-rpath`` linker option
+  records this location so that the shared NetCDF library can also be found when
+  running :program:`GPUMD`.
 * Follow the remaining :program:`GPUMD` installation instructions
 
 Following these steps will enable the :ref:`dump_netcdf keyword <kw_dump_netcdf>`.

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -400,7 +400,7 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
   } else if (strcmp(param[0], "dump_netcdf") == 0) {
 #ifdef USE_NETCDF
     std::unique_ptr<Property> property;
-    property.reset(new DUMP_NETCDF(param, num_param));
+    property.reset(new DUMP_NETCDF(param, num_param, group));
     measure.properties.emplace_back(std::move(property));
 #else
     PRINT_INPUT_ERROR("dump_netcdf is available only when USE_NETCDF flag is set.\n");

--- a/src/main_mdi/run.cu
+++ b/src/main_mdi/run.cu
@@ -642,7 +642,7 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
   } else if (strcmp(param[0], "dump_netcdf") == 0) {
 #ifdef USE_NETCDF
     std::unique_ptr<Property> property;
-    property.reset(new DUMP_NETCDF(param, num_param));
+    property.reset(new DUMP_NETCDF(param, num_param, group));
     measure.properties.emplace_back(std::move(property));
 #else
     PRINT_INPUT_ERROR("dump_netcdf is available only when USE_NETCDF flag is set.\n");

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -14,24 +14,26 @@
 */
 
 /*----------------------------------------------------------------------------80
-Dump atom positions using AMBER conventions for NetCDF files. Additional
-readers, such as VMD, OVITO, and ASE, can read/visualize the outputs.
+Write atom types, positions, and optional velocities to NetCDF trajectory
+files. The layout is based on the AMBER 1.0 trajectory conventions, with
+GPUMD extensions for atom types, group metadata, selectable precision, and
+optional NetCDF4 deflate compression.
 
 Contributing authors: Alexander Gabourie (Stanford University)
                       Liang Ting (The Chinese University of Hong Kong)
 
-Code was written for NetCDF version 4.6.3 and the style was influenced by
-LAMMPS' implementation by Lars Pastewka (University of Freiburg). The netCDF
-documentation used can be found here:
-https://www.unidata.ucar.edu/software/netcdf/docs/index.html
-and the AMBER conventions followed are here:
-http://ambermd.org/netcdf/nctraj.xhtml
+The implementation was influenced by LAMMPS' NetCDF output developed by
+Lars Pastewka (University of Freiburg). Documentation can be found at:
+https://docs.unidata.ucar.edu/netcdf-c/current/
+https://ambermd.org/netcdf/nctraj.pdf
 ------------------------------------------------------------------------------*/
 
 #ifdef USE_NETCDF
 
 #include "dump_netcdf.cuh"
+#include "model/atom.cuh"
 #include "model/box.cuh"
+#include "model/group.cuh"
 #include "netcdf.h"
 #include "parse_utilities.cuh"
 #include "utilities/common.cuh"
@@ -39,11 +41,11 @@ http://ambermd.org/netcdf/nctraj.xhtml
 #include "utilities/gpu_macro.cuh"
 #include "utilities/gpu_vector.cuh"
 #include "utilities/read_file.cuh"
-#include <unistd.h>
+#include <algorithm>
+#include <cmath>
 #include <cstring>
 
-const int FILE_NAME_LENGTH = 200;
-#define GPUMD_VERSION "3.9"
+#define GPUMD_VERSION "5.6"
 
 /* Handle errors by printing an error message and exiting with a
  * non-zero status. */
@@ -72,36 +74,69 @@ const char TYPE_STR[] = "type";
 const char CELL_LENGTHS_STR[] = "cell_lengths";
 const char CELL_ANGLES_STR[] = "cell_angles";
 const char UNITS_STR[] = "units";
-bool DUMP_NETCDF::append = false;
+std::vector<std::string> DUMP_NETCDF::initialized_files_;
 
-DUMP_NETCDF::DUMP_NETCDF(const char** param, int num_param)
+DUMP_NETCDF::DUMP_NETCDF(
+  const char** param, int num_param, const std::vector<Group>& groups)
 {
-  parse(param, num_param);
+  parse(param, num_param, groups);
   property_name = "dump_netcdf";
 }
 
-void DUMP_NETCDF::parse(const char** param, int num_param)
+void DUMP_NETCDF::parse(
+  const char** param, int num_param, const std::vector<Group>& groups)
 {
   dump_ = true;
-  printf("Dump data (position or velocity) in NetCDF format.\n");
+  printf("Dump positions and optional velocities in NetCDF format.\n");
 
-  if (num_param < 3) {
-    PRINT_INPUT_ERROR("dump_netcdf should have 2 parameters at least.");
+  if (num_param < 6) {
+    PRINT_INPUT_ERROR("dump_netcdf should have at least 5 parameters.\n");
   }
-  if (num_param > 5) {
+  if (num_param > 11) {
     PRINT_INPUT_ERROR("dump_netcdf has too many parameters.");
   }
 
-  if (!is_valid_int(param[1], &interval)) {
+  if (!is_valid_int(param[1], &grouping_method_)) {
+    PRINT_INPUT_ERROR("grouping method of dump_netcdf should be integer.");
+  }
+  if (grouping_method_ < 0) {
+    printf("    for the whole system.\n");
+  } else {
+    if (grouping_method_ >= int(groups.size())) {
+      PRINT_INPUT_ERROR("grouping method exceeds the bound.");
+    }
+    printf("    for grouping method %d.\n", grouping_method_);
+  }
+
+  if (!is_valid_int(param[2], &group_id_)) {
+    PRINT_INPUT_ERROR("group id of dump_netcdf should be integer.");
+  }
+  if (grouping_method_ >= 0) {
+    if (group_id_ < 0) {
+      PRINT_INPUT_ERROR("group id is negative.");
+    }
+    if (group_id_ >= groups[grouping_method_].number) {
+      PRINT_INPUT_ERROR("group id exceeds the bound.");
+    }
+    if (groups[grouping_method_].cpu_size[group_id_] <= 0) {
+      PRINT_INPUT_ERROR("dump_netcdf cannot output an empty group.");
+    }
+    printf("    for group id %d.\n", group_id_);
+  }
+
+  if (!is_valid_int(param[3], &interval_)) {
     PRINT_INPUT_ERROR("dump interval should be an integer.");
   }
-  if (interval <= 0) {
+  if (interval_ <= 0) {
     PRINT_INPUT_ERROR("dump interval should > 0.");
   }
-  printf("    every %d steps.\n", interval);
+  printf("    every %d steps.\n", interval_);
 
-  if (!is_valid_int(param[2], &has_velocity_)) {
+  if (!is_valid_int(param[4], &has_velocity_)) {
     PRINT_INPUT_ERROR("has_velocity should be an integer.");
+  }
+  if (has_velocity_ != 0 && has_velocity_ != 1) {
+    PRINT_INPUT_ERROR("has_velocity should be 0 or 1.");
   }
   if (has_velocity_ == 0) {
     printf("    without velocity data.\n");
@@ -109,18 +144,55 @@ void DUMP_NETCDF::parse(const char** param, int num_param)
     printf("    with velocity data.\n");
   }
 
-  for (int k = 3; k < num_param; k++) {
-    if (strcmp(param[k], "precision") == 0) {
-      parse_precision(param, num_param, k, precision);
+  filename_ = param[5];
+  if (filename_.empty()) {
+    PRINT_INPUT_ERROR("dump_netcdf filename should not be empty.");
+  }
+  printf("    into file %s.\n", filename_.c_str());
 
+  bool precision_seen = false;
+  bool compression_seen = false;
+  for (int k = 6; k < num_param; k++) {
+    if (strcmp(param[k], "precision") == 0) {
+      if (precision_seen) {
+        PRINT_INPUT_ERROR("Option 'precision' is specified more than once in dump_netcdf.\n");
+      }
+      parse_precision(param, num_param, k, precision_);
+      precision_seen = true;
+    } else if (strcmp(param[k], "compression") == 0) {
+      if (compression_seen) {
+        PRINT_INPUT_ERROR("Option 'compression' is specified more than once in dump_netcdf.\n");
+      }
+      if (k + 1 >= num_param) {
+        PRINT_INPUT_ERROR("Not enough arguments for option 'compression'.\n");
+      }
+      if (strcmp(param[k + 1], "none") == 0) {
+        compression_level_ = -1;
+        printf("    without compression.\n");
+        ++k;
+      } else if (strcmp(param[k + 1], "deflate") == 0) {
+        if (k + 2 >= num_param) {
+          PRINT_INPUT_ERROR("A deflate level is required for dump_netcdf compression.\n");
+        }
+        if (!is_valid_int(param[k + 2], &compression_level_)) {
+          PRINT_INPUT_ERROR("The dump_netcdf deflate level should be an integer.\n");
+        }
+        if (compression_level_ < 0 || compression_level_ > 9) {
+          PRINT_INPUT_ERROR("The dump_netcdf deflate level should be between 0 and 9.\n");
+        }
+        printf("    with lossless deflate compression at level %d.\n", compression_level_);
+        k += 2;
+      } else {
+        PRINT_INPUT_ERROR("Compression should be 'none' or 'deflate <0-9>'.\n");
+      }
+      compression_seen = true;
     } else {
       PRINT_INPUT_ERROR("Unrecognized argument in dump_netcdf.\n");
     }
   }
 
-  if (precision == 1) {
-    printf("Note: Single precision NetCDF output does not follow AMBER conventions.\n"
-           "      However, it will still work for many readers.\n");
+  if (precision_ == 1) {
+    printf("    using single precision for NetCDF output.\n");
   } else {
     printf("    using double precision for NetCDF output.\n");
   }
@@ -138,36 +210,62 @@ void DUMP_NETCDF::preprocess(
   if (!dump_)
     return;
 
-  strcpy(file_position, "movie.nc");
-
-  // find appropriate file name
-  // Append if same simulation, new file otherwise
-  bool done = false;
-  char filename[FILE_NAME_LENGTH];
-  int filenum = 1;
-  while (!done) {
-
-    if (access(file_position, F_OK) != -1) {
-      filenum++;
-      sprintf(filename, "movie_%d.nc", filenum);
-      strcpy(file_position, filename);
-    } else {
-      done = true;
+  if (grouping_method_ < 0) {
+    number_of_atoms_to_dump_ = atom.number_of_atoms;
+  } else {
+    const Group& selected_group = group[grouping_method_];
+    number_of_atoms_to_dump_ = selected_group.cpu_size[group_id_];
+    cpu_type_to_dump_.resize(number_of_atoms_to_dump_);
+    group_position_.resize(number_of_atoms_to_dump_ * 3);
+    cpu_group_position_.resize(number_of_atoms_to_dump_ * 3);
+    if (has_velocity_) {
+      group_velocity_.resize(number_of_atoms_to_dump_ * 3);
+      cpu_group_velocity_.resize(number_of_atoms_to_dump_ * 3);
     }
   }
 
-  if (append) {
-    if (filenum == 2) {
-      strcpy(file_position, "movie.nc");
-    } else {
-      sprintf(filename, "movie_%d.nc", filenum - 1);
-      strcpy(file_position, filename);
+  const size_t frame_values = size_t(number_of_atoms_to_dump_) * 3;
+  if (precision_ == 1) {
+    cpu_position_float_.resize(frame_values);
+    if (has_velocity_) {
+      cpu_velocity_float_.resize(frame_values);
     }
-    return; // creation of file & other info not needed
+  } else {
+    cpu_position_double_.resize(frame_values);
+    if (has_velocity_) {
+      cpu_velocity_double_.resize(frame_values);
+    }
   }
 
-  // create file (automatically placed in 'define' mode)
-  NC_CHECK(nc_create(file_position, NC_64BIT_OFFSET, &ncid));
+  const bool initialized =
+    std::find(initialized_files_.begin(), initialized_files_.end(), filename_) !=
+    initialized_files_.end();
+  if (initialized) {
+    NC_CHECK(nc_open(filename_.c_str(), NC_WRITE, &ncid));
+    load_file_definition();
+    validate_file_definition();
+    NC_CHECK(nc_inq_dimlen(ncid, frame_dim, &lenp));
+  } else {
+    create_file();
+    initialized_files_.push_back(filename_);
+  }
+}
+
+void DUMP_NETCDF::create_file()
+{
+  const int creation_mode = compression_level_ >= 0 ? NC_NETCDF4 : NC_64BIT_OFFSET;
+  const int create_status = nc_create(filename_.c_str(), creation_mode, &ncid);
+  if (create_status != NC_NOERR) {
+    if (
+      compression_level_ >= 0 &&
+      (create_status == NC_ENOTBUILT || create_status == NC_ENOTNC4)) {
+      fprintf(
+        stderr,
+        "Error: dump_netcdf deflate compression requires a NetCDF-C build with "
+        "NetCDF4/HDF5 support.\n");
+    }
+    ERR(create_status);
+  }
 
   // Global attributes
   NC_CHECK(nc_put_att_text(ncid, NC_GLOBAL, "program", 5, "GPUMD"));
@@ -175,12 +273,19 @@ void DUMP_NETCDF::preprocess(
     nc_put_att_text(ncid, NC_GLOBAL, "programVersion", strlen(GPUMD_VERSION), GPUMD_VERSION));
   NC_CHECK(nc_put_att_text(ncid, NC_GLOBAL, "Conventions", 5, "AMBER"));
   NC_CHECK(nc_put_att_text(ncid, NC_GLOBAL, "ConventionVersion", 3, "1.0"));
+  NC_CHECK(nc_put_att_int(
+    ncid, NC_GLOBAL, "gpumd_grouping_method", NC_INT, 1, &grouping_method_));
+  NC_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "gpumd_group_id", NC_INT, 1, &group_id_));
+  NC_CHECK(nc_put_att_int(
+    ncid, NC_GLOBAL, "gpumd_has_velocity", NC_INT, 1, &has_velocity_));
+  NC_CHECK(nc_put_att_int(
+    ncid, NC_GLOBAL, "gpumd_compression_level", NC_INT, 1, &compression_level_));
 
   // dimensions
   NC_CHECK(nc_def_dim(
     ncid, FRAME_STR, NC_UNLIMITED, &frame_dim)); // unlimited number of steps (can append)
   NC_CHECK(nc_def_dim(ncid, SPATIAL_STR, 3, &spatial_dim));         // number of spatial dimensions
-  NC_CHECK(nc_def_dim(ncid, ATOM_STR, atom.number_of_atoms, &atom_dim)); // number of atoms in system
+  NC_CHECK(nc_def_dim(ncid, ATOM_STR, number_of_atoms_to_dump_, &atom_dim));
   NC_CHECK(nc_def_dim(ncid, CELL_SPATIAL_STR, 3, &cell_spatial_dim)); // unitcell lengths
   NC_CHECK(nc_def_dim(ncid, CELL_ANGULAR_STR, 3, &cell_angular_dim)); // unitcell angles
   NC_CHECK(nc_def_dim(ncid, LABEL_STR, 10, &label_dim));              // needed for cell_angular
@@ -208,7 +313,7 @@ void DUMP_NETCDF::preprocess(
   dimids[1] = atom_dim;
   dimids[2] = spatial_dim;
 
-  if (precision == 1) // single precision
+  if (precision_ == 1) // single precision
   {
     NC_CHECK(nc_def_var(ncid, COORDINATES_STR, NC_FLOAT, 3, dimids, &coordinates_var));
     if (has_velocity_) {
@@ -221,6 +326,27 @@ void DUMP_NETCDF::preprocess(
     }
   }
   NC_CHECK(nc_def_var(ncid, TYPE_STR, NC_INT, 2, dimids, &type_var));
+
+  if (compression_level_ >= 0) {
+    const size_t bytes_per_value = precision_ == 1 ? sizeof(float) : sizeof(double);
+    const size_t target_chunk_bytes = 1024 * 1024;
+    const size_t max_chunk_atoms =
+      std::max<size_t>(1, target_chunk_bytes / (bytes_per_value * 3));
+    size_t chunks[3] = {
+      1, std::min<size_t>(number_of_atoms_to_dump_, max_chunk_atoms), 3};
+    NC_CHECK(nc_def_var_chunking(ncid, coordinates_var, NC_CHUNKED, chunks));
+    NC_CHECK(nc_def_var_deflate(ncid, coordinates_var, 1, 1, compression_level_));
+    if (has_velocity_) {
+      NC_CHECK(nc_def_var_chunking(ncid, velocities_var, NC_CHUNKED, chunks));
+      NC_CHECK(nc_def_var_deflate(ncid, velocities_var, 1, 1, compression_level_));
+    }
+    size_t type_chunks[2] = {
+      1,
+      std::min<size_t>(
+        number_of_atoms_to_dump_, target_chunk_bytes / sizeof(int))};
+    NC_CHECK(nc_def_var_chunking(ncid, type_var, NC_CHUNKED, type_chunks));
+    NC_CHECK(nc_def_var_deflate(ncid, type_var, 1, 1, compression_level_));
+  }
 
   // Units
   NC_CHECK(nc_put_att_text(ncid, time_var, UNITS_STR, 10, "picosecond"));
@@ -249,79 +375,75 @@ void DUMP_NETCDF::preprocess(
   startp[0] = 2;
   countp[1] = 5;
   NC_CHECK(nc_put_vara_text(ncid, cell_angular_var, startp, countp, "gamma"));
-
-  // File not used until first dump. Close for now.
-  NC_CHECK(nc_close(ncid));
-
-  // Append to this file for the rest of this simulation
-  append = true;
+  lenp = 0;
 }
 
-void DUMP_NETCDF::open_file(int frame_in_run)
+void DUMP_NETCDF::load_file_definition()
 {
-  if (access(file_position, F_OK) != -1) {
-    NC_CHECK(nc_open(file_position, NC_WRITE, &ncid));
+  NC_CHECK(nc_inq_dimid(ncid, FRAME_STR, &frame_dim));
+  NC_CHECK(nc_inq_dimid(ncid, SPATIAL_STR, &spatial_dim));
+  NC_CHECK(nc_inq_dimid(ncid, ATOM_STR, &atom_dim));
+  NC_CHECK(nc_inq_dimid(ncid, CELL_SPATIAL_STR, &cell_spatial_dim));
+  NC_CHECK(nc_inq_dimid(ncid, CELL_ANGULAR_STR, &cell_angular_dim));
+  NC_CHECK(nc_inq_dimid(ncid, LABEL_STR, &label_dim));
+  NC_CHECK(nc_inq_varid(ncid, SPATIAL_STR, &spatial_var));
+  NC_CHECK(nc_inq_varid(ncid, CELL_SPATIAL_STR, &cell_spatial_var));
+  NC_CHECK(nc_inq_varid(ncid, CELL_ANGULAR_STR, &cell_angular_var));
+  NC_CHECK(nc_inq_varid(ncid, TIME_STR, &time_var));
+  NC_CHECK(nc_inq_varid(ncid, CELL_LENGTHS_STR, &cell_lengths_var));
+  NC_CHECK(nc_inq_varid(ncid, CELL_ANGLES_STR, &cell_angles_var));
+  NC_CHECK(nc_inq_varid(ncid, COORDINATES_STR, &coordinates_var));
+  NC_CHECK(nc_inq_varid(ncid, TYPE_STR, &type_var));
+}
+
+void DUMP_NETCDF::validate_file_definition()
+{
+  size_t previous_number_of_atoms = 0;
+  NC_CHECK(nc_inq_dimlen(ncid, atom_dim, &previous_number_of_atoms));
+  if (previous_number_of_atoms != size_t(number_of_atoms_to_dump_)) {
+    PRINT_INPUT_ERROR("Cannot append dump_netcdf data with a different number of atoms.\n");
   }
 
-  /*
-   * If another dump in simulation, must reload IDs from object.
-   * Don't reload IDs more than once.
-   */
-  if (append && frame_in_run == 1) {
-    // get all dimension ids
-    NC_CHECK(nc_inq_dimid(ncid, FRAME_STR, &frame_dim));
-    NC_CHECK(nc_inq_dimid(ncid, SPATIAL_STR, &spatial_dim));
-    NC_CHECK(nc_inq_dimid(ncid, ATOM_STR, &atom_dim));
-    NC_CHECK(nc_inq_dimid(ncid, CELL_SPATIAL_STR, &cell_spatial_dim));
-    NC_CHECK(nc_inq_dimid(ncid, CELL_ANGULAR_STR, &cell_angular_dim));
-    NC_CHECK(nc_inq_dimid(ncid, LABEL_STR, &label_dim));
-
-    // Label Variables
-    NC_CHECK(nc_inq_varid(ncid, SPATIAL_STR, &spatial_var));
-    NC_CHECK(nc_inq_varid(ncid, CELL_SPATIAL_STR, &cell_spatial_var));
-    NC_CHECK(nc_inq_varid(ncid, CELL_ANGULAR_STR, &cell_angular_var));
-
-    // Data Variables
-    NC_CHECK(nc_inq_varid(ncid, TIME_STR, &time_var));
-    NC_CHECK(nc_inq_varid(ncid, CELL_LENGTHS_STR, &cell_lengths_var));
-    NC_CHECK(nc_inq_varid(ncid, CELL_ANGLES_STR, &cell_angles_var));
-
-    NC_CHECK(nc_inq_varid(ncid, COORDINATES_STR, &coordinates_var));
-    if (has_velocity_) {
-      NC_CHECK(nc_inq_varid(ncid, VELOCITIES_STR, &velocities_var));
-    }
-    NC_CHECK(nc_inq_varid(ncid, TYPE_STR, &type_var));
-
-    // check data type -> must use precision of last run
-    nc_type typep;
-    int prev_precision = 0;
-    NC_CHECK(nc_inq_vartype(ncid, coordinates_var, &typep));
-    if (typep == NC_FLOAT)
-      prev_precision = 1;
-    else if (typep == NC_DOUBLE)
-      prev_precision = 2;
-
-    if (prev_precision != precision) {
-      printf("Warning: GPUMD currently does not support changing netCDF\n"
-             "         file precision after an initial definition.\n");
-      precision = prev_precision;
-    }
+  nc_type coordinate_type;
+  NC_CHECK(nc_inq_vartype(ncid, coordinates_var, &coordinate_type));
+  const nc_type expected_type = precision_ == 1 ? NC_FLOAT : NC_DOUBLE;
+  if (coordinate_type != expected_type) {
+    PRINT_INPUT_ERROR("Cannot change dump_netcdf precision between run commands.\n");
   }
 
-  // get frame number
-  NC_CHECK(nc_inq_dimlen(ncid, frame_dim, &lenp))
+  int previous_grouping_method;
+  int previous_group_id;
+  int previous_has_velocity;
+  int previous_compression_level;
+  NC_CHECK(nc_get_att_int(
+    ncid, NC_GLOBAL, "gpumd_grouping_method", &previous_grouping_method));
+  NC_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "gpumd_group_id", &previous_group_id));
+  NC_CHECK(nc_get_att_int(
+    ncid, NC_GLOBAL, "gpumd_has_velocity", &previous_has_velocity));
+  NC_CHECK(nc_get_att_int(
+    ncid, NC_GLOBAL, "gpumd_compression_level", &previous_compression_level));
+  if (previous_grouping_method != grouping_method_ || previous_group_id != group_id_) {
+    PRINT_INPUT_ERROR("Cannot change the dump_netcdf group between run commands.\n");
+  }
+  if (previous_has_velocity != has_velocity_) {
+    PRINT_INPUT_ERROR("Cannot change dump_netcdf velocity output between run commands.\n");
+  }
+  if (has_velocity_) {
+    NC_CHECK(nc_inq_varid(ncid, VELOCITIES_STR, &velocities_var));
+  }
+  if (previous_compression_level != compression_level_) {
+    PRINT_INPUT_ERROR("Cannot change dump_netcdf compression between run commands.\n");
+  }
 }
 
 void DUMP_NETCDF::write(
   const double global_time,
   const Box& box,
   const std::vector<int>& cpu_type,
-  GPU_Vector<double>& position_per_atom,
-  std::vector<double>& cpu_position_per_atom,
-  GPU_Vector<double>& velocity_per_atom,
-  std::vector<double>& cpu_velocity_per_atom)
+  const std::vector<double>& cpu_position_per_atom,
+  const std::vector<double>& cpu_velocity_per_atom)
 {
-  const int number_of_atoms = cpu_type.size();
+  const int number_of_atoms = number_of_atoms_to_dump_;
 
   //// Write Frame Header ////
   // Get cell lengths and angles
@@ -361,93 +483,59 @@ void DUMP_NETCDF::write(
   if (!box.pbc_z)
     cell_lengths[2] = 0;
 
-  size_t countp[3] = {1, 3, 0}; // 3rd dimension unused until per-atom
-  size_t startp[3] = {lenp, 0, 0};
+  size_t frame_start[1] = {lenp};
+  size_t cell_start[2] = {lenp, 0};
+  size_t cell_count[2] = {1, 3};
   double time = global_time / 1000.0 * TIME_UNIT_CONVERSION; // convert fs to ps
-  NC_CHECK(nc_put_var1_double(ncid, time_var, startp, &time));
-  NC_CHECK(nc_put_vara_double(ncid, cell_lengths_var, startp, countp, cell_lengths));
-  NC_CHECK(nc_put_vara_double(ncid, cell_angles_var, startp, countp, cell_angles));
-
-  //// Write Per-Atom Data ////
-  position_per_atom.copy_to_host(cpu_position_per_atom.data());
+  NC_CHECK(nc_put_var1_double(ncid, time_var, frame_start, &time));
+  NC_CHECK(nc_put_vara_double(ncid, cell_lengths_var, cell_start, cell_count, cell_lengths));
+  NC_CHECK(nc_put_vara_double(ncid, cell_angles_var, cell_start, cell_count, cell_angles));
 
   const double natural_to_A_per_ps =
     1.0 / TIME_UNIT_CONVERSION * 1000.0; // * 1000 from A/fs to A/ps
-  if (has_velocity_) {
-    velocity_per_atom.copy_to_host(cpu_velocity_per_atom.data());
-  }
+  size_t atom_start[2] = {lenp, 0};
+  size_t atom_count[2] = {1, size_t(number_of_atoms)};
+  size_t vector_start[3] = {lenp, 0, 0};
+  size_t vector_count[3] = {1, size_t(number_of_atoms), 3};
+  NC_CHECK(nc_put_vara_int(ncid, type_var, atom_start, atom_count, cpu_type.data()));
 
-  if (precision == 1) // single precision
+  if (precision_ == 1) // single precision
   {
-    // must convert data
-    std::vector<float> cpu_x(number_of_atoms);
-    std::vector<float> cpu_y(number_of_atoms);
-    std::vector<float> cpu_z(number_of_atoms);
-    std::vector<float> cpu_velocity_x(number_of_atoms);
-    std::vector<float> cpu_velocity_y(number_of_atoms);
-    std::vector<float> cpu_velocity_z(number_of_atoms);
     for (int i = 0; i < number_of_atoms; i++) {
-      cpu_x[i] = static_cast<float>(cpu_position_per_atom[i]);
-      cpu_y[i] = static_cast<float>(cpu_position_per_atom[i + number_of_atoms]);
-      cpu_z[i] = static_cast<float>(cpu_position_per_atom[i + number_of_atoms * 2]);
-      if (has_velocity_) {
-        cpu_velocity_x[i] = static_cast<float>(cpu_velocity_per_atom[i] * natural_to_A_per_ps);
-        cpu_velocity_y[i] =
-          static_cast<float>(cpu_velocity_per_atom[i + number_of_atoms] * natural_to_A_per_ps);
-        cpu_velocity_z[i] =
-          static_cast<float>(cpu_velocity_per_atom[i + number_of_atoms * 2] * natural_to_A_per_ps);
+      for (int dim = 0; dim < 3; ++dim) {
+        cpu_position_float_[i * 3 + dim] =
+          static_cast<float>(cpu_position_per_atom[i + number_of_atoms * dim]);
+        if (has_velocity_) {
+          cpu_velocity_float_[i * 3 + dim] = static_cast<float>(
+            cpu_velocity_per_atom[i + number_of_atoms * dim] * natural_to_A_per_ps);
+        }
       }
     }
-
-    countp[0] = 1;
-    countp[1] = number_of_atoms;
-    countp[2] = 1;
-    NC_CHECK(nc_put_vara_int(ncid, type_var, startp, countp, cpu_type.data()));
-    NC_CHECK(nc_put_vara_float(ncid, coordinates_var, startp, countp, cpu_x.data()));
+    NC_CHECK(nc_put_vara_float(
+      ncid, coordinates_var, vector_start, vector_count, cpu_position_float_.data()));
     if (has_velocity_) {
-      NC_CHECK(nc_put_vara_float(ncid, velocities_var, startp, countp, cpu_velocity_x.data()));
-    }
-    startp[2] = 1;
-    NC_CHECK(nc_put_vara_float(ncid, coordinates_var, startp, countp, cpu_y.data()));
-    if (has_velocity_) {
-      NC_CHECK(nc_put_vara_float(ncid, velocities_var, startp, countp, cpu_velocity_y.data()));
-    }
-    startp[2] = 2;
-    NC_CHECK(nc_put_vara_float(ncid, coordinates_var, startp, countp, cpu_z.data()));
-    if (has_velocity_) {
-      NC_CHECK(nc_put_vara_float(ncid, velocities_var, startp, countp, cpu_velocity_z.data()));
+      NC_CHECK(nc_put_vara_float(
+        ncid, velocities_var, vector_start, vector_count, cpu_velocity_float_.data()));
     }
   } else {
-    countp[0] = 1;
-    countp[1] = number_of_atoms;
-    countp[2] = 1;
-    NC_CHECK(nc_put_vara_int(ncid, type_var, startp, countp, cpu_type.data()));
-
-    for (int dim = 0; dim < 3; ++dim) {
-      startp[2] = dim;
-      NC_CHECK(nc_put_vara_double(
-        ncid,
-        coordinates_var,
-        startp,
-        countp,
-        cpu_position_per_atom.data() + number_of_atoms * dim));
-    }
-
-    if (has_velocity_) {
-
-      std::vector<double> scaled_velocity(number_of_atoms * 3);
-
+    for (int i = 0; i < number_of_atoms; ++i) {
       for (int dim = 0; dim < 3; ++dim) {
-        startp[2] = dim;
-        for (int i = 0; i < number_of_atoms; ++i) {
-          scaled_velocity[i + number_of_atoms * dim] =
+        cpu_position_double_[i * 3 + dim] =
+          cpu_position_per_atom[i + number_of_atoms * dim];
+        if (has_velocity_) {
+          cpu_velocity_double_[i * 3 + dim] =
             cpu_velocity_per_atom[i + number_of_atoms * dim] * natural_to_A_per_ps;
         }
-        NC_CHECK(nc_put_vara_double(
-          ncid, velocities_var, startp, countp, scaled_velocity.data() + number_of_atoms * dim));
       }
     }
+    NC_CHECK(nc_put_vara_double(
+      ncid, coordinates_var, vector_start, vector_count, cpu_position_double_.data()));
+    if (has_velocity_) {
+      NC_CHECK(nc_put_vara_double(
+        ncid, velocities_var, vector_start, vector_count, cpu_velocity_double_.data()));
+    }
   }
+  ++lenp;
 }
 
 void DUMP_NETCDF::postprocess(
@@ -459,8 +547,33 @@ void DUMP_NETCDF::postprocess(
   const double temperature)
 {
   if (dump_) {
+    NC_CHECK(nc_close(ncid));
+    ncid = -1;
     dump_ = false;
-    precision = 2;
+  }
+}
+
+static __global__ void gather_netcdf_group(
+  const int number_of_atoms_in_group,
+  const int number_of_atoms,
+  const int group_offset,
+  const int* group_contents,
+  const double* position,
+  const double* velocity,
+  double* group_position,
+  double* group_velocity)
+{
+  const int n = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n < number_of_atoms_in_group) {
+    const int atom_index = group_contents[group_offset + n];
+    for (int d = 0; d < 3; ++d) {
+      group_position[n + number_of_atoms_in_group * d] =
+        position[atom_index + number_of_atoms * d];
+      if (group_velocity != nullptr) {
+        group_velocity[n + number_of_atoms_in_group * d] =
+          velocity[atom_index + number_of_atoms * d];
+      }
+    }
   }
 }
 
@@ -480,20 +593,44 @@ void DUMP_NETCDF::process(
 {
   if (!dump_)
     return;
-  if ((step + 1) % interval != 0)
+  if ((step + 1) % interval_ != 0)
     return;
 
-  int frame_in_run = (step + 1) / interval;
-  open_file(frame_in_run);
-  write(
-    global_time,
-    box,
-    atom.cpu_type,
-    atom.position_per_atom,
-    atom.cpu_position_per_atom,
-    atom.velocity_per_atom,
-    atom.cpu_velocity_per_atom);
-  NC_CHECK(nc_close(ncid));
+  const std::vector<double>* cpu_position = &atom.cpu_position_per_atom;
+  const std::vector<double>* cpu_velocity = &atom.cpu_velocity_per_atom;
+  const std::vector<int>* cpu_type = &atom.cpu_type;
+  if (grouping_method_ < 0) {
+    atom.position_per_atom.copy_to_host(atom.cpu_position_per_atom.data());
+    if (has_velocity_) {
+      atom.velocity_per_atom.copy_to_host(atom.cpu_velocity_per_atom.data());
+    }
+  } else {
+    const Group& selected_group = group[grouping_method_];
+    const int group_offset = selected_group.cpu_size_sum[group_id_];
+    gather_netcdf_group<<<(number_of_atoms_to_dump_ - 1) / 128 + 1, 128>>>(
+      number_of_atoms_to_dump_,
+      atom.number_of_atoms,
+      group_offset,
+      selected_group.contents.data(),
+      atom.position_per_atom.data(),
+      has_velocity_ ? atom.velocity_per_atom.data() : nullptr,
+      group_position_.data(),
+      has_velocity_ ? group_velocity_.data() : nullptr);
+    GPU_CHECK_KERNEL
+    group_position_.copy_to_host(cpu_group_position_.data());
+    if (has_velocity_) {
+      group_velocity_.copy_to_host(cpu_group_velocity_.data());
+    }
+    for (int n = 0; n < number_of_atoms_to_dump_; ++n) {
+      const int atom_index = selected_group.cpu_contents[group_offset + n];
+      cpu_type_to_dump_[n] = atom.cpu_type[atom_index];
+    }
+    cpu_position = &cpu_group_position_;
+    cpu_velocity = &cpu_group_velocity_;
+    cpu_type = &cpu_type_to_dump_;
+  }
+
+  write(global_time, box, *cpu_type, *cpu_position, *cpu_velocity);
 }
 
 #endif

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -436,6 +436,92 @@ void DUMP_NETCDF::validate_file_definition()
   }
 }
 
+static bool get_netcdf_cell(
+  const Box& box, double cell_lengths[3], double cell_angles[3], double rotation[9])
+{
+  // AMBER NetCDF stores only cell lengths and angles. Readers reconstruct a
+  // canonical cell with a along +x and b in the xy plane. Build the orthonormal
+  // transformation that maps GPUMD's general cell and Cartesian vectors to
+  // that same orientation.
+  const double* h = box.cpu_h;
+  const double a[3] = {h[0], h[3], h[6]};
+  const double b[3] = {h[1], h[4], h[7]};
+  const double c[3] = {h[2], h[5], h[8]};
+
+  cell_lengths[0] = 0.0;
+  cell_lengths[1] = 0.0;
+  cell_lengths[2] = 0.0;
+  for (int d = 0; d < 3; ++d) {
+    cell_lengths[0] += a[d] * a[d];
+    cell_lengths[1] += b[d] * b[d];
+    cell_lengths[2] += c[d] * c[d];
+  }
+  for (int d = 0; d < 3; ++d) {
+    cell_lengths[d] = sqrt(cell_lengths[d]);
+  }
+
+  double e1[3];
+  double e2[3];
+  for (int d = 0; d < 3; ++d) {
+    e1[d] = a[d] / cell_lengths[0];
+  }
+  const double b_along_e1 = e1[0] * b[0] + e1[1] * b[1] + e1[2] * b[2];
+  double b_perpendicular[3];
+  double b_perpendicular_length = 0.0;
+  for (int d = 0; d < 3; ++d) {
+    b_perpendicular[d] = b[d] - b_along_e1 * e1[d];
+    b_perpendicular_length += b_perpendicular[d] * b_perpendicular[d];
+  }
+  b_perpendicular_length = sqrt(b_perpendicular_length);
+  for (int d = 0; d < 3; ++d) {
+    e2[d] = b_perpendicular[d] / b_perpendicular_length;
+  }
+
+  double e3[3] = {
+    e1[1] * e2[2] - e1[2] * e2[1],
+    e1[2] * e2[0] - e1[0] * e2[2],
+    e1[0] * e2[1] - e1[1] * e2[0]};
+  if (e3[0] * c[0] + e3[1] * c[1] + e3[2] * c[2] < 0.0) {
+    for (int d = 0; d < 3; ++d) {
+      e3[d] = -e3[d];
+    }
+  }
+
+  for (int d = 0; d < 3; ++d) {
+    rotation[d] = e1[d];
+    rotation[3 + d] = e2[d];
+    rotation[6 + d] = e3[d];
+  }
+
+  const auto clamp_cosine = [](double value) {
+    return std::max(-1.0, std::min(1.0, value));
+  };
+  const double cosalpha = clamp_cosine(
+    (b[0] * c[0] + b[1] * c[1] + b[2] * c[2]) /
+    (cell_lengths[1] * cell_lengths[2]));
+  const double cosbeta = clamp_cosine(
+    (a[0] * c[0] + a[1] * c[1] + a[2] * c[2]) /
+    (cell_lengths[0] * cell_lengths[2]));
+  const double cosgamma = clamp_cosine(
+    (a[0] * b[0] + a[1] * b[1] + a[2] * b[2]) /
+    (cell_lengths[0] * cell_lengths[1]));
+  cell_angles[0] = acos(cosalpha) * 180.0 / PI;
+  cell_angles[1] = acos(cosbeta) * 180.0 / PI;
+  cell_angles[2] = acos(cosgamma) * 180.0 / PI;
+
+  return h[3] != 0.0 || h[6] != 0.0 || h[7] != 0.0 || h[0] < 0.0 || h[4] < 0.0 ||
+         h[8] < 0.0;
+}
+
+static void rotate_netcdf_vector(
+  const double rotation[9], const double input[3], double output[3])
+{
+  for (int d = 0; d < 3; ++d) {
+    output[d] = rotation[d * 3] * input[0] + rotation[d * 3 + 1] * input[1] +
+                rotation[d * 3 + 2] * input[2];
+  }
+}
+
 void DUMP_NETCDF::write(
   const double global_time,
   const Box& box,
@@ -445,35 +531,11 @@ void DUMP_NETCDF::write(
 {
   const int number_of_atoms = number_of_atoms_to_dump_;
 
-  //// Write Frame Header ////
-  // Get cell lengths and angles
   double cell_lengths[3];
   double cell_angles[3];
-  if (box.cpu_h[1] != 0 || box.cpu_h[2] != 0 || box.cpu_h[3] != 0 ||
-      box.cpu_h[5] != 0 || box.cpu_h[6] != 0 || box.cpu_h[7] != 0) {
-    const double* t = box.cpu_h;
-    double cosgamma, cosbeta, cosalpha;
-    cell_lengths[0] = sqrt(t[0] * t[0] + t[3] * t[3] + t[6] * t[6]); // a-side
-    cell_lengths[1] = sqrt(t[1] * t[1] + t[4] * t[4] + t[7] * t[7]); // b-side
-    cell_lengths[2] = sqrt(t[2] * t[2] + t[5] * t[5] + t[8] * t[8]); // c-side
-
-    cosgamma = (t[0] * t[1] + t[3] * t[4] + t[6] * t[7]) / (cell_lengths[0] * cell_lengths[1]);
-    cosbeta = (t[0] * t[2] + t[3] * t[5] + t[6] * t[8]) / (cell_lengths[0] * cell_lengths[2]);
-    cosalpha = (t[1] * t[2] + t[4] * t[5] + t[7] * t[8]) / (cell_lengths[1] * cell_lengths[2]);
-
-    cell_angles[0] = acos(cosalpha) * 180.0 / PI;
-    cell_angles[1] = acos(cosbeta) * 180.0 / PI;
-    cell_angles[2] = acos(cosgamma) * 180.0 / PI;
-
-  } else {
-    cell_lengths[0] = box.cpu_h[0];
-    cell_lengths[1] = box.cpu_h[4];
-    cell_lengths[2] = box.cpu_h[8];
-
-    cell_angles[0] = 90;
-    cell_angles[1] = 90;
-    cell_angles[2] = 90;
-  }
+  double cell_rotation[9];
+  const bool rotate_output =
+    get_netcdf_cell(box, cell_lengths, cell_angles, cell_rotation);
 
   // Set lengths to 0 if PBC is off
   if (!box.pbc_x)
@@ -502,12 +564,30 @@ void DUMP_NETCDF::write(
   if (precision_ == 1) // single precision
   {
     for (int i = 0; i < number_of_atoms; i++) {
+      double position[3] = {
+        cpu_position_per_atom[i],
+        cpu_position_per_atom[i + number_of_atoms],
+        cpu_position_per_atom[i + number_of_atoms * 2]};
+      double velocity[3] = {0.0, 0.0, 0.0};
+      if (has_velocity_) {
+        velocity[0] = cpu_velocity_per_atom[i];
+        velocity[1] = cpu_velocity_per_atom[i + number_of_atoms];
+        velocity[2] = cpu_velocity_per_atom[i + number_of_atoms * 2];
+      }
+      double rotated_position[3] = {0.0, 0.0, 0.0};
+      double rotated_velocity[3] = {0.0, 0.0, 0.0};
+      if (rotate_output) {
+        rotate_netcdf_vector(cell_rotation, position, rotated_position);
+        if (has_velocity_) {
+          rotate_netcdf_vector(cell_rotation, velocity, rotated_velocity);
+        }
+      }
       for (int dim = 0; dim < 3; ++dim) {
         cpu_position_float_[i * 3 + dim] =
-          static_cast<float>(cpu_position_per_atom[i + number_of_atoms * dim]);
+          static_cast<float>(rotate_output ? rotated_position[dim] : position[dim]);
         if (has_velocity_) {
           cpu_velocity_float_[i * 3 + dim] = static_cast<float>(
-            cpu_velocity_per_atom[i + number_of_atoms * dim] * natural_to_A_per_ps);
+            (rotate_output ? rotated_velocity[dim] : velocity[dim]) * natural_to_A_per_ps);
         }
       }
     }
@@ -519,12 +599,30 @@ void DUMP_NETCDF::write(
     }
   } else {
     for (int i = 0; i < number_of_atoms; ++i) {
+      double position[3] = {
+        cpu_position_per_atom[i],
+        cpu_position_per_atom[i + number_of_atoms],
+        cpu_position_per_atom[i + number_of_atoms * 2]};
+      double velocity[3] = {0.0, 0.0, 0.0};
+      if (has_velocity_) {
+        velocity[0] = cpu_velocity_per_atom[i];
+        velocity[1] = cpu_velocity_per_atom[i + number_of_atoms];
+        velocity[2] = cpu_velocity_per_atom[i + number_of_atoms * 2];
+      }
+      double rotated_position[3] = {0.0, 0.0, 0.0};
+      double rotated_velocity[3] = {0.0, 0.0, 0.0};
+      if (rotate_output) {
+        rotate_netcdf_vector(cell_rotation, position, rotated_position);
+        if (has_velocity_) {
+          rotate_netcdf_vector(cell_rotation, velocity, rotated_velocity);
+        }
+      }
       for (int dim = 0; dim < 3; ++dim) {
         cpu_position_double_[i * 3 + dim] =
-          cpu_position_per_atom[i + number_of_atoms * dim];
+          rotate_output ? rotated_position[dim] : position[dim];
         if (has_velocity_) {
           cpu_velocity_double_[i * 3 + dim] =
-            cpu_velocity_per_atom[i + number_of_atoms * dim] * natural_to_A_per_ps;
+            (rotate_output ? rotated_velocity[dim] : velocity[dim]) * natural_to_A_per_ps;
         }
       }
     }

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -436,89 +436,106 @@ void DUMP_NETCDF::validate_file_definition()
   }
 }
 
-static bool get_netcdf_cell(
-  const Box& box, double cell_lengths[3], double cell_angles[3], double rotation[9])
+static bool build_netcdf_transform(
+  const Box& box, double cell_lengths[3], double cell_angles[3], double transform[9])
 {
   // AMBER NetCDF stores only cell lengths and angles. Readers reconstruct a
-  // canonical cell with a along +x and b in the xy plane. Build the orthonormal
-  // transformation that maps GPUMD's general cell and Cartesian vectors to
-  // that same orientation.
+  // restricted cell with a along +x and b in the xy plane. Use the same
+  // general-to-restricted transformation for every GPUMD cell.
   const double* h = box.cpu_h;
   const double a[3] = {h[0], h[3], h[6]};
   const double b[3] = {h[1], h[4], h[7]};
   const double c[3] = {h[2], h[5], h[8]};
-
-  cell_lengths[0] = 0.0;
-  cell_lengths[1] = 0.0;
-  cell_lengths[2] = 0.0;
-  for (int d = 0; d < 3; ++d) {
-    cell_lengths[0] += a[d] * a[d];
-    cell_lengths[1] += b[d] * b[d];
-    cell_lengths[2] += c[d] * c[d];
-  }
-  for (int d = 0; d < 3; ++d) {
-    cell_lengths[d] = sqrt(cell_lengths[d]);
-  }
-
-  double e1[3];
-  double e2[3];
-  for (int d = 0; d < 3; ++d) {
-    e1[d] = a[d] / cell_lengths[0];
-  }
-  const double b_along_e1 = e1[0] * b[0] + e1[1] * b[1] + e1[2] * b[2];
-  double b_perpendicular[3];
-  double b_perpendicular_length = 0.0;
-  for (int d = 0; d < 3; ++d) {
-    b_perpendicular[d] = b[d] - b_along_e1 * e1[d];
-    b_perpendicular_length += b_perpendicular[d] * b_perpendicular[d];
-  }
-  b_perpendicular_length = sqrt(b_perpendicular_length);
-  for (int d = 0; d < 3; ++d) {
-    e2[d] = b_perpendicular[d] / b_perpendicular_length;
-  }
-
-  double e3[3] = {
-    e1[1] * e2[2] - e1[2] * e2[1],
-    e1[2] * e2[0] - e1[0] * e2[2],
-    e1[0] * e2[1] - e1[1] * e2[0]};
-  if (e3[0] * c[0] + e3[1] * c[1] + e3[2] * c[2] < 0.0) {
-    for (int d = 0; d < 3; ++d) {
-      e3[d] = -e3[d];
-    }
-  }
-
-  for (int d = 0; d < 3; ++d) {
-    rotation[d] = e1[d];
-    rotation[3 + d] = e2[d];
-    rotation[6 + d] = e3[d];
-  }
-
+  const auto dot = [](const double x[3], const double y[3]) {
+    return x[0] * y[0] + x[1] * y[1] + x[2] * y[2];
+  };
   const auto clamp_cosine = [](double value) {
     return std::max(-1.0, std::min(1.0, value));
   };
-  const double cosalpha = clamp_cosine(
-    (b[0] * c[0] + b[1] * c[1] + b[2] * c[2]) /
-    (cell_lengths[1] * cell_lengths[2]));
-  const double cosbeta = clamp_cosine(
-    (a[0] * c[0] + a[1] * c[1] + a[2] * c[2]) /
-    (cell_lengths[0] * cell_lengths[2]));
-  const double cosgamma = clamp_cosine(
-    (a[0] * b[0] + a[1] * b[1] + a[2] * b[2]) /
-    (cell_lengths[0] * cell_lengths[1]));
+
+  cell_lengths[0] = sqrt(dot(a, a));
+  cell_lengths[1] = sqrt(dot(b, b));
+  cell_lengths[2] = sqrt(dot(c, c));
+
+  // The rows of transform are the axes of the restricted NetCDF cell written
+  // in GPUMD Cartesian coordinates.
+  for (int d = 0; d < 3; ++d) {
+    transform[d] = a[d] / cell_lengths[0];
+  }
+  const double bx = transform[0] * b[0] + transform[1] * b[1] + transform[2] * b[2];
+  double by = 0.0;
+  for (int d = 0; d < 3; ++d) {
+    transform[3 + d] = b[d] - bx * transform[d];
+    by += transform[3 + d] * transform[3 + d];
+  }
+  by = sqrt(by);
+  for (int d = 0; d < 3; ++d) {
+    transform[3 + d] /= by;
+  }
+
+  transform[6] = transform[1] * transform[5] - transform[2] * transform[4];
+  transform[7] = transform[2] * transform[3] - transform[0] * transform[5];
+  transform[8] = transform[0] * transform[4] - transform[1] * transform[3];
+  if (transform[6] * c[0] + transform[7] * c[1] + transform[8] * c[2] < 0.0) {
+    for (int d = 0; d < 3; ++d) {
+      transform[6 + d] = -transform[6 + d];
+    }
+  }
+
+  const double cosalpha =
+    clamp_cosine(dot(b, c) / (cell_lengths[1] * cell_lengths[2]));
+  const double cosbeta =
+    clamp_cosine(dot(a, c) / (cell_lengths[0] * cell_lengths[2]));
+  const double cosgamma =
+    clamp_cosine(dot(a, b) / (cell_lengths[0] * cell_lengths[1]));
   cell_angles[0] = acos(cosalpha) * 180.0 / PI;
   cell_angles[1] = acos(cosbeta) * 180.0 / PI;
   cell_angles[2] = acos(cosgamma) * 180.0 / PI;
 
-  return h[3] != 0.0 || h[6] != 0.0 || h[7] != 0.0 || h[0] < 0.0 || h[4] < 0.0 ||
-         h[8] < 0.0;
+  bool transform_vectors = false;
+  for (int i = 0; i < 9; ++i) {
+    const double identity_value = i % 4 == 0 ? 1.0 : 0.0;
+    transform_vectors |= fabs(transform[i] - identity_value) > 1.0e-12;
+  }
+  return transform_vectors;
 }
 
-static void rotate_netcdf_vector(
-  const double rotation[9], const double input[3], double output[3])
+template <typename T>
+static void pack_netcdf_frame(
+  const int number_of_atoms,
+  const bool has_velocity,
+  const bool transform_vectors,
+  const double transform[9],
+  const double velocity_scale,
+  const std::vector<double>& position,
+  const std::vector<double>& velocity,
+  std::vector<T>& packed_position,
+  std::vector<T>& packed_velocity)
 {
-  for (int d = 0; d < 3; ++d) {
-    output[d] = rotation[d * 3] * input[0] + rotation[d * 3 + 1] * input[1] +
-                rotation[d * 3 + 2] * input[2];
+  for (int i = 0; i < number_of_atoms; ++i) {
+    for (int output_dim = 0; output_dim < 3; ++output_dim) {
+      double position_value = position[i + number_of_atoms * output_dim];
+      double velocity_value =
+        has_velocity ? velocity[i + number_of_atoms * output_dim] : 0.0;
+      if (transform_vectors) {
+        position_value = 0.0;
+        velocity_value = 0.0;
+        for (int input_dim = 0; input_dim < 3; ++input_dim) {
+          const double coefficient = transform[output_dim * 3 + input_dim];
+          position_value +=
+            coefficient * position[i + number_of_atoms * input_dim];
+          if (has_velocity) {
+            velocity_value +=
+              coefficient * velocity[i + number_of_atoms * input_dim];
+          }
+        }
+      }
+      packed_position[i * 3 + output_dim] = static_cast<T>(position_value);
+      if (has_velocity) {
+        packed_velocity[i * 3 + output_dim] =
+          static_cast<T>(velocity_value * velocity_scale);
+      }
+    }
   }
 }
 
@@ -533,9 +550,9 @@ void DUMP_NETCDF::write(
 
   double cell_lengths[3];
   double cell_angles[3];
-  double cell_rotation[9];
-  const bool rotate_output =
-    get_netcdf_cell(box, cell_lengths, cell_angles, cell_rotation);
+  double cell_transform[9];
+  const bool transform_vectors =
+    build_netcdf_transform(box, cell_lengths, cell_angles, cell_transform);
 
   // Set lengths to 0 if PBC is off
   if (!box.pbc_x)
@@ -563,34 +580,16 @@ void DUMP_NETCDF::write(
 
   if (precision_ == 1) // single precision
   {
-    for (int i = 0; i < number_of_atoms; i++) {
-      double position[3] = {
-        cpu_position_per_atom[i],
-        cpu_position_per_atom[i + number_of_atoms],
-        cpu_position_per_atom[i + number_of_atoms * 2]};
-      double velocity[3] = {0.0, 0.0, 0.0};
-      if (has_velocity_) {
-        velocity[0] = cpu_velocity_per_atom[i];
-        velocity[1] = cpu_velocity_per_atom[i + number_of_atoms];
-        velocity[2] = cpu_velocity_per_atom[i + number_of_atoms * 2];
-      }
-      double rotated_position[3] = {0.0, 0.0, 0.0};
-      double rotated_velocity[3] = {0.0, 0.0, 0.0};
-      if (rotate_output) {
-        rotate_netcdf_vector(cell_rotation, position, rotated_position);
-        if (has_velocity_) {
-          rotate_netcdf_vector(cell_rotation, velocity, rotated_velocity);
-        }
-      }
-      for (int dim = 0; dim < 3; ++dim) {
-        cpu_position_float_[i * 3 + dim] =
-          static_cast<float>(rotate_output ? rotated_position[dim] : position[dim]);
-        if (has_velocity_) {
-          cpu_velocity_float_[i * 3 + dim] = static_cast<float>(
-            (rotate_output ? rotated_velocity[dim] : velocity[dim]) * natural_to_A_per_ps);
-        }
-      }
-    }
+    pack_netcdf_frame(
+      number_of_atoms,
+      has_velocity_,
+      transform_vectors,
+      cell_transform,
+      natural_to_A_per_ps,
+      cpu_position_per_atom,
+      cpu_velocity_per_atom,
+      cpu_position_float_,
+      cpu_velocity_float_);
     NC_CHECK(nc_put_vara_float(
       ncid, coordinates_var, vector_start, vector_count, cpu_position_float_.data()));
     if (has_velocity_) {
@@ -598,34 +597,16 @@ void DUMP_NETCDF::write(
         ncid, velocities_var, vector_start, vector_count, cpu_velocity_float_.data()));
     }
   } else {
-    for (int i = 0; i < number_of_atoms; ++i) {
-      double position[3] = {
-        cpu_position_per_atom[i],
-        cpu_position_per_atom[i + number_of_atoms],
-        cpu_position_per_atom[i + number_of_atoms * 2]};
-      double velocity[3] = {0.0, 0.0, 0.0};
-      if (has_velocity_) {
-        velocity[0] = cpu_velocity_per_atom[i];
-        velocity[1] = cpu_velocity_per_atom[i + number_of_atoms];
-        velocity[2] = cpu_velocity_per_atom[i + number_of_atoms * 2];
-      }
-      double rotated_position[3] = {0.0, 0.0, 0.0};
-      double rotated_velocity[3] = {0.0, 0.0, 0.0};
-      if (rotate_output) {
-        rotate_netcdf_vector(cell_rotation, position, rotated_position);
-        if (has_velocity_) {
-          rotate_netcdf_vector(cell_rotation, velocity, rotated_velocity);
-        }
-      }
-      for (int dim = 0; dim < 3; ++dim) {
-        cpu_position_double_[i * 3 + dim] =
-          rotate_output ? rotated_position[dim] : position[dim];
-        if (has_velocity_) {
-          cpu_velocity_double_[i * 3 + dim] =
-            (rotate_output ? rotated_velocity[dim] : velocity[dim]) * natural_to_A_per_ps;
-        }
-      }
-    }
+    pack_netcdf_frame(
+      number_of_atoms,
+      has_velocity_,
+      transform_vectors,
+      cell_transform,
+      natural_to_A_per_ps,
+      cpu_position_per_atom,
+      cpu_velocity_per_atom,
+      cpu_position_double_,
+      cpu_velocity_double_);
     NC_CHECK(nc_put_vara_double(
       ncid, coordinates_var, vector_start, vector_count, cpu_position_double_.data()));
     if (has_velocity_) {

--- a/src/measure/dump_netcdf.cuh
+++ b/src/measure/dump_netcdf.cuh
@@ -18,14 +18,16 @@
 #pragma once
 #include "property.cuh"
 #include "utilities/gpu_vector.cuh"
+#include <string>
 #include <vector>
 class Box;
+class Group;
 
 class DUMP_NETCDF : public Property
 {
 public:
-  DUMP_NETCDF(const char** param, int num_param);
-  void parse(const char** param, int num_param);
+  DUMP_NETCDF(const char** param, int num_param, const std::vector<Group>& groups);
+  void parse(const char** param, int num_param, const std::vector<Group>& groups);
   virtual void preprocess(
     const int number_of_steps,
     const double time_step,
@@ -59,13 +61,27 @@ public:
 
 private:
   bool dump_ = false;
-  int interval = 1;      // output interval
-  int has_velocity_ = 0; // 0 wthout velocities, 1 with velocities
-  char file_position[200];
-  int precision = 2; // 1 = single precision, 2 = double
+  int grouping_method_ = -1;
+  int group_id_ = 0;
+  int interval_ = 1;
+  int has_velocity_ = 0;
+  int precision_ = 1;          // 1 = single precision, 2 = double
+  int compression_level_ = -1; // -1 = classic NetCDF, 0-9 = NetCDF4 deflate
+  int number_of_atoms_to_dump_ = 0;
+  std::string filename_;
 
-  int ncid; // NetCDF ID
-  static bool append;
+  std::vector<int> cpu_type_to_dump_;
+  std::vector<double> cpu_group_position_;
+  std::vector<double> cpu_group_velocity_;
+  std::vector<float> cpu_position_float_;
+  std::vector<float> cpu_velocity_float_;
+  std::vector<double> cpu_position_double_;
+  std::vector<double> cpu_velocity_double_;
+  GPU_Vector<double> group_position_;
+  GPU_Vector<double> group_velocity_;
+
+  int ncid = -1; // NetCDF ID
+  static std::vector<std::string> initialized_files_;
 
   // dimensions
   int frame_dim;
@@ -90,15 +106,15 @@ private:
 
   size_t lenp; // frame number
 
-  void open_file(int frame_in_run);
+  void create_file();
+  void load_file_definition();
+  void validate_file_definition();
   void write(
     const double global_time,
     const Box& box,
     const std::vector<int>& cpu_type,
-    GPU_Vector<double>& position_per_atom,
-    std::vector<double>& cpu_position_per_atom,
-    GPU_Vector<double>& velocity_per_atom,
-    std::vector<double>& cpu_velocity_per_atom);
+    const std::vector<double>& cpu_position_per_atom,
+    const std::vector<double>& cpu_velocity_per_atom);
 };
 
 #endif

--- a/tests_pytest/test_io_dump_commands.py
+++ b/tests_pytest/test_io_dump_commands.py
@@ -11,6 +11,7 @@ commands do.
 """
 import numpy as np
 import pytest
+from ase.cell import Cell
 from ase.io import read
 from calorine.gpumd import read_xyz
 
@@ -178,6 +179,48 @@ def test_dump_netcdf_group_double_deflate(
         assert velocities.filters()['zlib']
         assert dataset.getncattr('gpumd_grouping_method') == 0
         assert dataset.getncattr('gpumd_group_id') == 1
+
+
+def test_dump_netcdf_rotates_general_cell(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    netcdf4 = pytest.importorskip('netCDF4')
+    rotated_structure = structure.copy()
+    general_cell = rotated_structure.cell.array.copy()
+    general_cell[0] += 0.05 * general_cell[2]
+    rotated_structure.set_cell(general_cell, scale_atoms=True)
+    rotated_structure.rotate(17.0, 'y', center=(0.0, 0.0, 0.0), rotate_cell=True)
+    case = CommandIOCase(
+        name='dump_netcdf_general_cell',
+        run_in_lines=[
+            ('dump_xyz', [-1, 0, 1, 'reference.xyz', 'velocity']),
+            ('dump_netcdf', [
+                -1, 0, 1, 1, 'general-cell.nc', 'precision', 'double',
+            ]),
+        ],
+        expected_output_files=['reference.xyz', 'general-cell.nc'],
+    )
+    result = run_command_io_case(
+        tmp_path, rotated_structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+
+    reference = read(tmp_path / 'reference.xyz', index=0)
+    with netcdf4.Dataset(tmp_path / 'general-cell.nc') as dataset:
+        lengths = dataset.variables['cell_lengths'][0]
+        angles = dataset.variables['cell_angles'][0]
+        netcdf_cell = Cell.fromcellpar(np.concatenate((lengths, angles))).array
+        netcdf_positions = dataset.variables['coordinates'][0]
+        netcdf_velocities = dataset.variables['velocities'][0]
+
+    reference_cell = reference.cell.array
+    rotation_transpose = np.linalg.solve(reference_cell, netcdf_cell)
+    assert not np.allclose(reference_cell, netcdf_cell)
+    assert not np.allclose(angles, (90.0, 90.0, 90.0))
+    np.testing.assert_allclose(
+        netcdf_positions, reference.positions @ rotation_transpose, atol=1.0e-6)
+    np.testing.assert_allclose(
+        netcdf_velocities,
+        reference.arrays['vel'] @ rotation_transpose * 1000.0,
+        atol=1.0e-5)
 
 
 def test_dump_observer(tmp_path, structure, model_path, model_type, gpumd_command):

--- a/tests_pytest/test_io_dump_commands.py
+++ b/tests_pytest/test_io_dump_commands.py
@@ -14,7 +14,7 @@ import pytest
 from ase.io import read
 from calorine.gpumd import read_xyz
 
-from io_helpers import CommandIOCase, run_and_check
+from io_helpers import BASE_N_STEPS, CommandIOCase, run_and_check, run_command_io_case
 from test_parsing import read_thermo_out
 
 pytestmark = pytest.mark.fast
@@ -92,9 +92,92 @@ def test_command_io(tmp_path, structure, model_path, model_type, gpumd_command, 
     run_and_check(tmp_path, structure, model_path, model_type, gpumd_command, case)
 
 
-def test_dump_netcdf():
-    pytest.skip('gpumd binary lacks NetCDF support despite makefile.loc listing -DUSE_NETCDF '
-                '(confirmed via strings); revisit once rebuilt.')
+def _check_netcdf_result(result):
+    output = result.stdout + result.stderr
+    if 'dump_netcdf is available only when USE_NETCDF flag is set' in output:
+        pytest.skip('gpumd binary was built without USE_NETCDF')
+    assert result.returncode == 0, (
+        f'dump_netcdf: gpumd exited {result.returncode}\nstdout:\n{result.stdout}\n'
+        f'stderr:\n{result.stderr}')
+
+
+def test_dump_netcdf_default_overwrite_and_append(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    netcdf4 = pytest.importorskip('netCDF4')
+    output_path = tmp_path / 'sed.nc'
+    output_path.write_bytes(b'an existing file that must be overwritten')
+    case = CommandIOCase(
+        name='dump_netcdf',
+        run_in_lines=[
+            ('dump_netcdf', [-1, 0, 1, 1, 'sed.nc']),
+            ('run', BASE_N_STEPS),
+            ('dump_netcdf', [-1, 0, 1, 1, 'sed.nc']),
+        ],
+        expected_output_files=['sed.nc'],
+    )
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+
+    with netcdf4.Dataset(output_path) as dataset:
+        assert dataset.data_model == 'NETCDF3_64BIT_OFFSET'
+        assert len(dataset.dimensions['frame']) == 2 * BASE_N_STEPS
+        assert len(dataset.dimensions['atom']) == len(structure)
+        assert dataset.variables['coordinates'].dtype == np.dtype('float32')
+        assert dataset.variables['velocities'].dtype == np.dtype('float32')
+        assert dataset.variables['type'].dimensions == ('frame', 'atom')
+        assert dataset.variables['type'].shape == (2 * BASE_N_STEPS, len(structure))
+        assert dataset.getncattr('gpumd_compression_level') == -1
+
+
+def test_dump_netcdf_without_velocity(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    netcdf4 = pytest.importorskip('netCDF4')
+    case = CommandIOCase(
+        name='dump_netcdf_positions',
+        run_in_lines=[('dump_netcdf', [-1, 0, 1, 0, 'positions.nc'])],
+        expected_output_files=['positions.nc'],
+    )
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+
+    with netcdf4.Dataset(tmp_path / 'positions.nc') as dataset:
+        assert dataset.variables['coordinates'].dtype == np.dtype('float32')
+        assert 'velocities' not in dataset.variables
+
+
+def test_dump_netcdf_group_double_deflate(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    netcdf4 = pytest.importorskip('netCDF4')
+    half = len(structure) // 2
+    expected_group_size = len(structure) - half
+    case = CommandIOCase(
+        name='dump_netcdf_group',
+        run_in_lines=[('dump_netcdf', [
+            0, 1, 1, 1, 'group.nc',
+            'precision', 'double', 'compression', 'deflate', 1,
+        ])],
+        expected_output_files=['group.nc'],
+        n_groups=2,
+    )
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+
+    with netcdf4.Dataset(tmp_path / 'group.nc') as dataset:
+        coordinates = dataset.variables['coordinates']
+        velocities = dataset.variables['velocities']
+        assert dataset.data_model == 'NETCDF4'
+        assert len(dataset.dimensions['frame']) == BASE_N_STEPS
+        assert len(dataset.dimensions['atom']) == expected_group_size
+        assert coordinates.dtype == np.dtype('float64')
+        assert velocities.dtype == np.dtype('float64')
+        assert coordinates.filters()['zlib']
+        assert coordinates.filters()['complevel'] == 1
+        assert velocities.filters()['zlib']
+        assert dataset.getncattr('gpumd_grouping_method') == 0
+        assert dataset.getncattr('gpumd_group_id') == 1
 
 
 def test_dump_observer(tmp_path, structure, model_path, model_type, gpumd_command):


### PR DESCRIPTION
## Summary

Enhance `dump_netcdf` with atom-group selection, user-defined filenames, selectable floating-point precision, and optional lossless compression. The updated command provides a compact binary trajectory format for SED/DSF analysis, visualization, and other trajectory-based workflows.

This change also fixes inconsistent periodic geometry for general simulation cells whose basis is not already in the standard orientation reconstructed by AMBER NetCDF readers.

Fixes #550.

## Interface

```text
dump_netcdf <grouping_method> <group_id> <interval> <has_velocity> <filename>
            [precision single|double]
            [compression none|deflate <0-9>]
```

The defaults are `precision single` and `compression none`. This interface intentionally replaces the former `dump_netcdf <interval> <has_velocity>` syntax.

## Changes

### Output selection and format

- Follow the same group-selection rules as `dump_xyz`, including whole-system output with a negative grouping method.
- Accept relative or absolute output filenames instead of always writing `movie.nc`.
- Write uncompressed trajectories in NetCDF 64-bit-offset (CDF-2) format.
- Support double precision and optional NetCDF4/HDF5 deflate compression in addition to the default single-precision, uncompressed output.
- Store integer atom types for every frame, including trajectories in which MCMD changes atom types.

### File handling and performance

- Overwrite a file on its first use in a GPUMD execution and append when the same filename is reused by later `run` commands.
- Keep each NetCDF file open during a run, reuse persistent frame buffers, and write interleaved XYZ data in one operation.
- Validate atom count, group selection, precision, velocity output, and compression settings before appending.

### General-cell correctness

AMBER NetCDF represents periodic cells using lengths and angles in a standard orientation. For a GPUMD cell with a different orientation, the output now applies one orthogonal transformation to the cell, coordinates, and velocities. This preserves cell lengths and angles, periodic distances, velocity magnitudes, and the physical trajectory while preventing cell-coordinate mismatches in OVITO and MDAnalysis.

Cells already in the standard orthogonal or restricted-triclinic orientation use the identity transformation and skip the matrix multiplication. The transformation is performed in the CPU output path and requires no additional GPU memory.

### Integration and documentation

- Update command parsing in both GPUMD and MDI.
- Document the new syntax, file lifecycle, precision, compression, dependencies, and general-cell behavior.
- Add pytest coverage for default CDF-2 output, overwrite and multi-run append behavior, position-only output, group selection, double precision, deflate compression, and rotated general triclinic cells.

## Validation

- `git diff --check upstream/master...HEAD`
- `python -m py_compile tests_pytest/test_io_dump_commands.py`
- `python -m sphinx -W --keep-going -b html doc <output-dir>` (192 documentation pages; no warnings)
- Verified 1,000 random nonsingular general cells; the maximum metric-tensor error was below `6e-15` and the maximum orthogonality error was below `3e-15`.
- Reproduced issue #550. Without transforming coordinates, about 45% of pair distances differed by more than `0.01 angstrom`, with a maximum error of approximately `1.63 angstrom`. Applying the transformation reduced the maximum numerical distance error to approximately `5e-14 angstrom`.

The NetCDF-specific pytest cases require GPUMD built with `USE_NETCDF` and Python `netCDF4`; they skip automatically when either dependency is unavailable.

## Dependencies

The command continues to require NetCDF-C. `compression none` works with a classic NetCDF build. `compression deflate` additionally requires NetCDF4/HDF5 and zlib support.

## Licensing

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.
