### PR TITLE
Add constant-power NEMD ensemble `heat_nhc_power`

### DIFF
--- a/src/integrate/ensemble_nhc.cu
+++ b/src/integrate/ensemble_nhc.cu
@@ -22,6 +22,7 @@ Oxford University Press, 2010.
 #include "ensemble_nhc.cuh"
 #include "utilities/common.cuh"
 #include "utilities/gpu_macro.cuh"
+#include <cmath>
 #include <cstring>
 #define DIM 3
 
@@ -324,6 +325,80 @@ void Ensemble_NHC::integrate_heat_nhc_2(
     factor_1, factor_2, vcx.data(), vcy.data(), vcz.data(), ke.data(), group, velocity_per_atom);
 }
 
+// integrate by one step, with a constant heating/cooling power (custom command
+// heat_nhc_power): every step, a fixed energy dE = power * time_step is added to
+// the heat source and removed from the heat sink by scaling the velocities
+// about the group center-of-mass velocity (hence no net momentum is injected).
+// No Nose-Hoover chain thermostat acts on the source/sink here, so the
+// accumulated energy_transferred is exactly the explicitly injected/removed
+// energy; there is no additional thermostat work.
+void Ensemble_NHC::integrate_heat_nhc_power_1(
+  const double time_step,
+  const std::vector<Group>& group,
+  const GPU_Vector<double>& mass,
+  const GPU_Vector<double>& force_per_atom,
+  GPU_Vector<double>& position_per_atom,
+  GPU_Vector<double>& velocity_per_atom)
+{
+  velocity_verlet(
+    true, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+}
+
+void Ensemble_NHC::integrate_heat_nhc_power_2(
+  const double time_step,
+  const std::vector<Group>& group,
+  const GPU_Vector<double>& mass,
+  const GPU_Vector<double>& force_per_atom,
+  GPU_Vector<double>& position_per_atom,
+  GPU_Vector<double>& velocity_per_atom)
+{
+  int label_1 = source;
+  int label_2 = sink;
+
+  int Ng = group[0].number;
+
+  // allocate some memory (to be improved)
+  std::vector<double> ek2(Ng);
+  GPU_Vector<double> vcx(Ng), vcy(Ng), vcz(Ng), ke(Ng);
+
+  velocity_verlet(
+    false, time_step, group, mass, force_per_atom, position_per_atom, velocity_per_atom);
+
+  find_vc_and_ke(group, mass, velocity_per_atom, vcx.data(), vcy.data(), vcz.data(), ke.data());
+  // delta_temperature stores the heating power P in eV/fs (total for the whole
+  // group, not per atom) for this command; the energy exchanged per step is
+  // P * dt_fs, where dt_fs = time_step (in GPUMD natural time units) converted
+  // to fs via TIME_UNIT_CONVERSION
+  double dE = delta_temperature * time_step * TIME_UNIT_CONVERSION;
+  ke.copy_to_host(ek2.data());
+
+  const double K_source = ek2[label_1] * 0.5; // COM-relative kinetic energy
+  const double K_sink = ek2[label_2] * 0.5;
+  // Guards for pathological states (e.g. starting from a uniform-temperature
+  // configuration before a temperature gradient has been established): never
+  // remove more kinetic energy than the sink group has, and never heat a
+  // zero-kinetic-energy source group. The energy accounting below uses the
+  // ACTUAL energies, so any activation of these guards shows up as a
+  // deviation of the accumulated energies from +/- P * time.
+  double dE_in = (K_source > 0.0) ? dE : 0.0;
+  double dE_out = dE;
+  if (dE_out > 0.99 * K_sink) {
+    dE_out = 0.99 * K_sink;
+  }
+  if (dE_out < 0.0) {
+    dE_out = 0.0;
+  }
+  double factor_1 = (K_source > 0.0) ? sqrt(1.0 + dE_in / K_source) : 1.0; // energy in
+  double factor_2 = (K_sink > 0.0) ? sqrt(1.0 - dE_out / K_sink) : 0.0; // energy out
+
+  // accumulate the energies transferred from the system to the baths
+  energy_transferred[0] -= dE_in;
+  energy_transferred[1] += dE_out;
+
+  scale_velocity_local(
+    factor_1, factor_2, vcx.data(), vcy.data(), vcz.data(), ke.data(), group, velocity_per_atom);
+}
+
 void Ensemble_NHC::compute1(
   const double time_step,
   const std::vector<Group>& group,
@@ -343,6 +418,14 @@ void Ensemble_NHC::compute1(
       atom.position_per_atom,
       atom.velocity_per_atom,
       thermo);
+  } else if (type == 27) {
+    integrate_heat_nhc_power_1(
+      time_step,
+      group,
+      atom.mass,
+      atom.force_per_atom,
+      atom.position_per_atom,
+      atom.velocity_per_atom);
   } else {
     integrate_heat_nhc_1(
       time_step,
@@ -373,6 +456,14 @@ void Ensemble_NHC::compute2(
       atom.position_per_atom,
       atom.velocity_per_atom,
       thermo);
+  } else if (type == 27) {
+    integrate_heat_nhc_power_2(
+      time_step,
+      group,
+      atom.mass,
+      atom.force_per_atom,
+      atom.position_per_atom,
+      atom.velocity_per_atom);
   } else {
     integrate_heat_nhc_2(
       time_step,

--- a/src/integrate/ensemble_nhc.cuh
+++ b/src/integrate/ensemble_nhc.cuh
@@ -77,4 +77,20 @@ protected:
     const GPU_Vector<double>& force_per_atom,
     GPU_Vector<double>& position_per_atom,
     GPU_Vector<double>& velocity_per_atom);
+
+  void integrate_heat_nhc_power_1(
+    const double time_step,
+    const std::vector<Group>& group,
+    const GPU_Vector<double>& mass,
+    const GPU_Vector<double>& force_per_atom,
+    GPU_Vector<double>& position_per_atom,
+    GPU_Vector<double>& velocity_per_atom);
+
+  void integrate_heat_nhc_power_2(
+    const double time_step,
+    const std::vector<Group>& group,
+    const GPU_Vector<double>& mass,
+    const GPU_Vector<double>& force_per_atom,
+    GPU_Vector<double>& position_per_atom,
+    GPU_Vector<double>& velocity_per_atom);
 };

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -167,6 +167,18 @@ void Integrate::initialize(
         delta_temperature,
         time_step));
       break;
+    case 27: // heat with constant power (custom); delta_temperature stores power in eV/fs
+      ensemble.reset(new Ensemble_NHC(
+        type,
+        source,
+        sink,
+        group[0].cpu_size[source],
+        group[0].cpu_size[sink],
+        temperature,
+        temperature_coupling,
+        delta_temperature,
+        time_step));
+      break;
     case 22: // heat-Langevin
       ensemble.reset(new Ensemble_LAN(
         type,
@@ -479,6 +491,11 @@ void Integrate::parse_ensemble(
     if (num_param != 7) {
       PRINT_INPUT_ERROR("ensemble heat_bdp should have 5 parameters.");
     }
+  } else if (strcmp(param[1], "heat_nhc_power") == 0) {
+    type = 27;
+    if (num_param != 7) {
+      PRINT_INPUT_ERROR("ensemble heat_nhc_power should have 5 parameters.");
+    }
   } else if (strcmp(param[1], "heat_ttm") == 0) {
     type = 24;
     // ensemble heat_ttm ... T_e_init [ttm_out_interval N] [ttm_infile FILE]
@@ -721,6 +738,67 @@ void Integrate::parse_ensemble(
     }
     if (delta_temperature >= temperature || delta_temperature <= -temperature) {
       PRINT_INPUT_ERROR("|Temperature difference| is too large.");
+    }
+
+    // group labels of heat source and sink
+    if (!is_valid_int(param[5], &source)) {
+      PRINT_INPUT_ERROR("Group ID for heat source should be an integer.");
+    }
+    if (!is_valid_int(param[6], &sink)) {
+      PRINT_INPUT_ERROR("Group ID for heat sink should be an integer.");
+    }
+    if (group.size() < 1) {
+      PRINT_INPUT_ERROR("Cannot heat/cold without grouping method.");
+    }
+    if (source == sink) {
+      PRINT_INPUT_ERROR("Source and sink cannot be the same group.");
+    }
+    if (source < 0) {
+      PRINT_INPUT_ERROR("Group ID for heat source should >= 0.");
+    }
+    if (source >= group[0].number) {
+      PRINT_INPUT_ERROR("Group ID for heat source should < #groups.");
+    }
+    if (sink < 0) {
+      PRINT_INPUT_ERROR("Group ID for heat sink should >= 0.");
+    }
+    if (sink >= group[0].number) {
+      PRINT_INPUT_ERROR("Group ID for heat sink should < #groups.");
+    }
+  }
+
+  // 4b. heating and cooling with a constant power (custom command heat_nhc_power)
+  // syntax: ensemble heat_nhc_power T T_coup power source sink
+  //   T       : target/average temperature in K (used for output and velocity
+  //             initialization only; no thermostat acts on source/sink)
+  //   T_coup  : parsed for syntax compatibility but NOT used by this command
+  //   power   : heating power P in eV/fs, total for the whole source/sink group
+  //             (NOT per atom); stored in delta_temperature
+  //   source  : group ID of the heat source (P added)
+  //   sink    : group ID of the heat sink (P removed)
+  if (type == 27) {
+    // temperature
+    if (!is_valid_real(param[2], &temperature)) {
+      PRINT_INPUT_ERROR("Temperature should be a number.");
+    }
+    if (temperature <= 0.0) {
+      PRINT_INPUT_ERROR("Temperature should > 0.");
+    }
+
+    // temperature_coupling (unused by heat_nhc_power, kept for syntax compatibility)
+    if (!is_valid_real(param[3], &temperature_coupling)) {
+      PRINT_INPUT_ERROR("Temperature coupling should be a number.");
+    }
+    if (temperature_coupling < 1.0) {
+      PRINT_INPUT_ERROR("Temperature coupling should >= 1.");
+    }
+
+    // heating power in eV/fs (total for the whole group, not per atom)
+    if (!is_valid_real(param[4], &delta_temperature)) {
+      PRINT_INPUT_ERROR("Heating power should be a number.");
+    }
+    if (delta_temperature <= 0.0) {
+      PRINT_INPUT_ERROR("Heating power should > 0.");
     }
 
     // group labels of heat source and sink
@@ -1144,6 +1222,18 @@ void Integrate::parse_ensemble(
       printf("    delta_T is %g K.\n", delta_temperature);
       printf("    T_hot is %g K.\n", temperature + delta_temperature);
       printf("    T_cold is %g K.\n", temperature - delta_temperature);
+      printf("    heat source is group %d in grouping method 0.\n", source);
+      printf("    heat sink is group %d in grouping method 0.\n", sink);
+      break;
+    case 27:
+      printf("Integrate with constant-power heating and cooling for this run.\n");
+      printf("    choose the custom constant-power velocity-scaling method (heat_nhc_power).\n");
+      printf("    average temperature is %g K (no thermostat acts on source/sink).\n", temperature);
+      printf("    tau_T is %g time_step (parsed but NOT used by this command).\n", temperature_coupling);
+      printf("    heating power is %g eV/fs (total for the whole group, not per atom).\n",
+        delta_temperature);
+      printf("    every step, %g eV/fs * time_step is added to the source and removed from the sink.\n",
+        delta_temperature);
       printf("    heat source is group %d in grouping method 0.\n", source);
       printf("    heat sink is group %d in grouping method 0.\n", sink);
       break;


### PR DESCRIPTION
**Summary**

Add a new ensemble command `heat_nhc_power` for non-equilibrium molecular dynamics (NEMD) thermal transport simulations. Instead of imposing a temperature difference between the heat source and sink (as in `heat_nhc`), this method drives heat transport with a constant heating power `P` (in eV/fs, total for the whole group, not per atom).

**Modification**

New ensemble type 27 (the previously unused ID), touching 3 files: * `src/integrate/ensemble_nhc.cuh` Declare `integrate_heat_nhc_power_1` / `integrate_heat_nhc_power_2`. * `src/integrate/ensemble_nhc.cu` Implement the two half-step functions: the first half-step is a plain velocity-Verlet step; the second half-step computes per-group COM-relative kinetic energies via the existing `find_vc_and_ke`, applies the fixed-energy velocity scaling with `scale_velocity_local`, and accumulates `energy_transferred[0] -= dE_in`, `energy_transferred[1] += dE_out` with the actual energies. Dispatch type 27 in `compute1`/`compute2`. * `src/integrate/integrate.cu` Parse the `heat_nhc_power` keyword (5 parameters, same count as `heat_nhc`), validate inputs (T > 0, T_coup >= 1, power > 0, group IDs within range), construct `Ensemble_NHC` with the two-group constructor for type 27, and print the run information (making explicit that `T_coup` is parsed but unused).

**Validation**

Tested on crystalline silicon (NEP4, Si_2022_NEP4_4body) with a fixed boundary along z, comparing against the existing `heat_nhc` method on the identical model, after NPT + NVT equilibration (1e6 production steps, dt = 1 fs):

| method | command | heat current (eV/ps) | kappa (W/m/K) | 
|------------------|------------------------------------------|----------------------|---------------|
| `heat_nhc` | `ensemble heat_nhc 300 100 100 1 2` | 2.417 (measured) | 9.49 |
| `heat_nhc_power` | `ensemble heat_nhc_power 300 100 0.00242 1 2` | 2.420 (by construction, R^2 = 1) | 9.71 |

The two methods agree within ~2.3%. Full inputs, outputs, and post-processing scripts for both runs are available at: https://github.com/Kick-H/For_gpumd/tree/master/GPUMD_Command_Test/heat_nhc_power

**Licensing** (Please read and confirm before submitting this pull request)

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.

**Others**

* The documentation for the `ensemble` keyword (`doc/`) is not updated in this PR; happy to add it if desired. * Ensemble type ID 27 was the first free ID in the version this branch is based on; please let me know if it needs renumbering after rebase. 

* If you use the `heat_nhc_power` command in your work, please cite:                               

  K. Xu et al., Device-Scale Atomistic Simulations of Heat Transport in Advanced Field-Effect Transistors, arXiv:2511.18915 (2025). https://arxiv.org/abs/2511.18915                                                                 
