### PR TITLE
Fix handling of netcdf/HDF5 linking

### DIFF
--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -45,6 +45,13 @@ Currently, the following optional arguments are accepted:
     Level 0 applies no compression. For large, frequently written trajectories, use ``none`` for
     maximum write speed, ``deflate 1`` for a practical balance, or ``deflate 9`` when minimizing
     file size is more important than write speed.
+    GPUMD itself does not require NetCDF4/HDF5 support unless ``deflate`` is used.
+    If the linked NetCDF-C library was built without NetCDF4/HDF5 support, requesting
+    ``deflate`` causes the underlying ``nc_create`` call to fail when GPUMD asks for the
+    NetCDF4 file format.
+    GPUMD already checks for this and reports a clear error instead of silently writing an
+    uncompressed file.
+    See :ref:`NetCDF setup <netcdf_setup>` for how to build NetCDF-C with NetCDF4/HDF5 support.
 
 Requirements and specifications
 -------------------------------

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -35,6 +35,7 @@ https://ambermd.org/netcdf/nctraj.pdf
 #include "model/box.cuh"
 #include "model/group.cuh"
 #include "netcdf.h"
+#include "netcdf_meta.h"
 #include "parse_utilities.cuh"
 #include "utilities/common.cuh"
 #include "utilities/error.cuh"
@@ -328,6 +329,7 @@ void DUMP_NETCDF::create_file()
   NC_CHECK(nc_def_var(ncid, TYPE_STR, NC_INT, 2, dimids, &type_var));
 
   if (compression_level_ >= 0) {
+#if NC_HAS_HDF5
     const size_t bytes_per_value = precision_ == 1 ? sizeof(float) : sizeof(double);
     const size_t target_chunk_bytes = 1024 * 1024;
     const size_t max_chunk_atoms =
@@ -346,6 +348,7 @@ void DUMP_NETCDF::create_file()
         number_of_atoms_to_dump_, target_chunk_bytes / sizeof(int))};
     NC_CHECK(nc_def_var_chunking(ncid, type_var, NC_CHUNKED, type_chunks));
     NC_CHECK(nc_def_var_deflate(ncid, type_var, 1, 1, compression_level_));
+#endif // NC_HAS_HDF5
   }
 
   // Units

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -329,7 +329,7 @@ void DUMP_NETCDF::create_file()
   NC_CHECK(nc_def_var(ncid, TYPE_STR, NC_INT, 2, dimids, &type_var));
 
   if (compression_level_ >= 0) {
-#if NC_HAS_HDF5
+#if defined(NC_HAS_HDF5) && NC_HAS_HDF5
     const size_t bytes_per_value = precision_ == 1 ? sizeof(float) : sizeof(double);
     const size_t target_chunk_bytes = 1024 * 1024;
     const size_t max_chunk_atoms =


### PR DESCRIPTION
## Summary

When linking against a netcdf library that has been compiled without HDF5 and compression support the compilation fails. This occurs after the addition of support for HDF5 and compression in #1631. While the documentation states that the compression is optional the code calls functions (e.g., `nc_def_var_chunking`) that are only available in netcdf if it has been compiled with HDF5 support.

This PR adds a preprocessor if-statement that only includes these calls at link/compile time if HDF5 support is actually available. It also adds a short clarifying statement to the documentation of the `dump_netcdf` command.

## Additional note
On  my system (ubuntu) several additional steps were required to compile netcdf with HDF5 and compression support.
I did not add any of the information below to the installation page because I am unsure about how generalizable it is.
But one should consider where this information could or should land.
* I had to install HDF5 with development headers as well as `m4` (apt install libhdf5-dev m4).
* The HDF5 headers/libraries ended up under a non-standard path (`/usr/include/hdf5/serial` and `/usr/lib/<arch>/hdf5/serial`), which meant that `configure` had to be pointed at these path explicitly
  ```
   CPPFLAGS=-I/usr/include/hdf5/serial LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/serial
   ./configure --prefix=<path> --enable-netcdf-4 --disable-dap
  ```
* One should note that `configure` silently falls back to `--disable-netcdf-4` if it cannot find a working HDF5 installation. To check that HDF5 is actually available one can run `bin/nc-config --has-hdf5` in the netcdf base directory.
* Furthermore I had to include the HDF5 paths and libraries in the `makefile`
  ```
  INC = -I<path>/include -I./ -I<hdf5_path>/include
  LDFLAGS = -L<path>/lib -Xlinker=-rpath -Xlinker=<path>/lib -L<hdf5_path>/lib
  LIBS = -lcublas -lcusolver -lcufft -lnetcdf -lhdf5_hl -lhdf5 -lz
  ```
