### PR TITLE
Fix restart output interval

### DIFF
--- a/doc/nep/input_parameters/output_interval.rst
+++ b/doc/nep/input_parameters/output_interval.rst
@@ -5,7 +5,7 @@
 :attr:`output_interval`
 ========================
 
-This keyword sets the number of generations between writes to :ref:`loss.out <loss_out>` (and the corresponding console output, ``nep.txt``, and test-set output files).
+This keyword sets the number of generations between writes to :ref:`loss.out <loss_out>` (and the corresponding console output, ``nep.txt``, :ref:`nep.restart <nep_restart>`, and test-set output files).
 
 The syntax is::
 

--- a/doc/nep/output_files/nep_restart.rst
+++ b/doc/nep/output_files/nep_restart.rst
@@ -7,7 +7,7 @@
 
 This file enables restarting an optimization run.
 If the file is present, training will start from the state saved in this file.
-The file is continuously updated during training.
+The file is updated during training every :ref:`output_interval <kw_output_interval>` generations.
 
 The user does not need to understand the contents of this file.
 One must, however, ensure that the hyperparameters in the :ref:`nep.in input file <nep_in>` related to the descriptor are the same as those used to generate the restart file.

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -106,7 +106,7 @@ void Parameters::set_default_parameters()
   maximum_generation = 100000; // a good starting point
   save_potential = 100000;     // write checkpoint nep.txt files at these intervals
   save_potential_format = 1;   // 1 = include time stamp when writing checkpoint nep.txt files
-  output_interval = 100;       // write loss.out (and related output) every N generations
+  output_interval = 100;       // write loss.out, nep.txt, nep.restart (and related output) every N generations
   initial_para = 1.0f;
   sigma0 = 0.1f;
   atomic_v = 0;

--- a/src/main_nep/parameters.cuh
+++ b/src/main_nep/parameters.cuh
@@ -33,7 +33,7 @@ public:
   int save_potential;     // number of generations between writing a checkpoint nep.txt file.
   int save_potential_format;   // format of checkpoint nep.txt file name
   int save_potential_restart;  // if restart files should be written or not. 0=no, 1=yes
-  int output_interval;    // number of generations between writing a line to loss.out and related output
+  int output_interval;    // number of generations between writing loss.out, nep.txt, nep.restart and related output
   int num_neurons1;       // number of nuerons in the 1st hidden layer (only one hidden layer)
   int num_neurons2;       // number of nuerons in the 2nd hidden layer (only two hidden layers)
   int num_hidden_layers;  // number of hidden layers

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -377,7 +377,7 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
         population.data() + number_of_variables * best_index);
 
       update_mu_and_sigma();
-      if (0 == (n + 1) % 100) {
+      if (0 == (n + 1) % para.output_interval) {
         const char* filename = "nep.restart";
         output_mu_and_sigma(filename);
       }


### PR DESCRIPTION
When the `output_interval` keyword was introduced the output interval was made flexible for `nep.txt` but not `nep.restart` (which stayed at the fixed 100 value). This PR fixes this behavior so that `nep.restart` is also written every `output_interval` generations.