### PR TITLE
Allow multiple NetCDF dumps per run

### DIFF
--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -97,6 +97,18 @@ To dump group 0 from grouping method 1 with lossless deflate compression, one ca
 
 before the :ref:`run command <kw_run>`.
 
+Multiple groups in one run
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Multiple :attr:`dump_netcdf` commands can write different groups during the
+same MD run. Each command must use a distinct filename and can use its own
+output interval, so every output file contains one independently sampled group::
+
+  dump_netcdf 0 0 10 1 group_0.nc compression deflate 1
+  dump_netcdf 0 1 25 1 group_1.nc compression deflate 1
+
+  run 100000
+
 
 Caveats
 -------
@@ -104,6 +116,9 @@ Caveats
 * Length is in units of Ångström and velocity is in units of Ångström/picosecond.
 * This keyword is not propagating.
   That means, its effect will not be passed from one run to the next.
+* This keyword can be invoked multiple times within one run to write different
+  groups to different files. Each invocation must use a distinct filename and
+  can use its own output interval and options.
 * An existing output file is overwritten the first time its name is used in a GPUMD execution.
 * Repeating the keyword with the same filename in later runs of the same GPUMD execution
   appends to that file. A different filename creates a separate trajectory file.

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -76,6 +76,7 @@ const char CELL_LENGTHS_STR[] = "cell_lengths";
 const char CELL_ANGLES_STR[] = "cell_angles";
 const char UNITS_STR[] = "units";
 std::vector<std::string> DUMP_NETCDF::initialized_files_;
+std::vector<std::string> DUMP_NETCDF::active_files_;
 
 DUMP_NETCDF::DUMP_NETCDF(
   const char** param, int num_param, const std::vector<Group>& groups)
@@ -210,6 +211,12 @@ void DUMP_NETCDF::preprocess(
 {
   if (!dump_)
     return;
+
+  if (
+    std::find(active_files_.begin(), active_files_.end(), filename_) != active_files_.end()) {
+    PRINT_INPUT_ERROR("dump_netcdf filenames must be unique within one run.");
+  }
+  active_files_.push_back(filename_);
 
   if (grouping_method_ < 0) {
     number_of_atoms_to_dump_ = atom.number_of_atoms;
@@ -632,6 +639,10 @@ void DUMP_NETCDF::postprocess(
     NC_CHECK(nc_close(ncid));
     ncid = -1;
     dump_ = false;
+    const auto active_file = std::find(active_files_.begin(), active_files_.end(), filename_);
+    if (active_file != active_files_.end()) {
+      active_files_.erase(active_file);
+    }
   }
 }
 

--- a/src/measure/dump_netcdf.cuh
+++ b/src/measure/dump_netcdf.cuh
@@ -82,6 +82,7 @@ private:
 
   int ncid = -1; // NetCDF ID
   static std::vector<std::string> initialized_files_;
+  static std::vector<std::string> active_files_;
 
   // dimensions
   int frame_dim;

--- a/src/measure/measure.cu
+++ b/src/measure/measure.cu
@@ -40,8 +40,9 @@ void Measure::initialize(
       exit(1);
     }
 
-    // dump_xyz is allowed to be called multiple times; others are not
-    if (prop->property_name != "dump_xyz") {
+    // dump_xyz and dump_netcdf are allowed to be called multiple times; others are not
+    if (
+      prop->property_name != "dump_xyz" && prop->property_name != "dump_netcdf") {
       for (auto& property_name : property_names) {
         if (property_name == prop->property_name) {
           std::cout << "There are multiple " << prop->property_name << " keywords within one run.\n";

--- a/tests_pytest/test_io_dump_commands.py
+++ b/tests_pytest/test_io_dump_commands.py
@@ -181,6 +181,61 @@ def test_dump_netcdf_group_double_deflate(
         assert dataset.getncattr('gpumd_group_id') == 1
 
 
+def test_dump_netcdf_multiple_groups_in_one_run(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    netcdf4 = pytest.importorskip('netCDF4')
+    half = len(structure) // 2
+    group_sizes = (half, len(structure) - half)
+    filenames = ('group_0.nc', 'group_1.nc')
+    intervals = (1, 2)
+    case = CommandIOCase(
+        name='dump_netcdf_multiple_groups',
+        run_in_lines=[
+            ('dump_netcdf', [0, 0, intervals[0], 1, filenames[0]]),
+            ('dump_netcdf', [0, 1, intervals[1], 1, filenames[1]]),
+        ],
+        expected_output_files=list(filenames),
+        n_groups=2,
+    )
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+
+    trajectories = []
+    for group_id, (filename, group_size, interval) in enumerate(
+            zip(filenames, group_sizes, intervals)):
+        with netcdf4.Dataset(tmp_path / filename) as dataset:
+            assert len(dataset.dimensions['frame']) == BASE_N_STEPS // interval
+            assert len(dataset.dimensions['atom']) == group_size
+            assert dataset.getncattr('gpumd_grouping_method') == 0
+            assert dataset.getncattr('gpumd_group_id') == group_id
+            assert 'velocities' in dataset.variables
+            trajectories.append(dataset.variables['time'][:])
+
+    np.testing.assert_allclose(
+        trajectories[0][intervals[1] - 1::intervals[1]], trajectories[1])
+
+
+def test_dump_netcdf_rejects_duplicate_filename_in_one_run(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    pytest.importorskip('netCDF4')
+    case = CommandIOCase(
+        name='dump_netcdf_duplicate_filename',
+        run_in_lines=[
+            ('dump_netcdf', [0, 0, 1, 1, 'duplicate.nc']),
+            ('dump_netcdf', [0, 1, 1, 1, 'duplicate.nc']),
+        ],
+        n_groups=2,
+    )
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    output = result.stdout + result.stderr
+    if 'dump_netcdf is available only when USE_NETCDF flag is set' in output:
+        pytest.skip('gpumd binary was built without USE_NETCDF')
+    assert result.returncode != 0
+    assert 'dump_netcdf filenames must be unique within one run.' in output
+
+
 def test_dump_netcdf_rotates_general_cell(
         tmp_path, structure, model_path, model_type, gpumd_command):
     netcdf4 = pytest.importorskip('netCDF4')


### PR DESCRIPTION
## Summary

- allow multiple `dump_netcdf` commands within one MD run, matching the existing `dump_xyz` behavior
- require a distinct output filename for each active NetCDF dump to prevent concurrent writes to the same file
- preserve append behavior when the same filename is reused in a later `run` command
- document per-dump group, interval, and option selection
- add coverage for multiple groups with independent intervals and for duplicate-filename rejection

## Motivation

Previously, `Measure::initialize` rejected more than one `dump_netcdf` property in a run even though each `DUMP_NETCDF` instance owns its own file handle and buffers. This prevented trajectories for several groups from being sampled concurrently.

The change permits repeated `dump_netcdf` keywords while tracking filenames that are active in the current run. The tracking entry is removed during postprocessing, so a later run can reopen and append to the same trajectory as before.

## User impact

Users can now write several groups to separate NetCDF trajectories in one run, with independent output intervals and options. Existing single-dump input and logging behavior are unchanged.

## Validation

- `git diff --check upstream/master...HEAD`
- `python -m py_compile tests_pytest/test_io_dump_commands.py`
- added pytest coverage for two simultaneous group trajectories with different intervals
- added pytest coverage rejecting the same filename for simultaneous dumps

The NetCDF runtime tests were not executed locally because this Windows environment lacks the NetCDF-C development headers and a buildable `calorine` installation; they are left for CI.
