### PR TITLE
Revise and extend the `dump_netcdf` command

### DIFF
--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -53,7 +53,7 @@ Currently, the following optional arguments are accepted:
      * - :attr:`force`
        - ``forces``
        - ``(frame, atom, spatial)``
-       - eV/Å
+       - kcal/mol/Å
      * - :attr:`unwrapped_position`
        - ``unwrapped_coordinates``
        - ``(frame, atom, spatial)``
@@ -130,9 +130,12 @@ Requirements and specifications
   so that periodic geometry is preserved. Positions, velocities, forces and unwrapped positions
   are rotated as vectors, and the per-atom virial and the :term:`BEC` as rank-2 tensors, so that
   every quantity in a frame refers to the same axes.
-* The units of the ``forces``, ``potential_energy``, ``charge``, ``bec``, ``virial`` and ``mass``
-  variables are those GPUMD works in, and are given by the ``units`` attribute of each variable.
-  They are not the units the AMBER conventions specify for the variables AMBER defines.
+* The variables the AMBER conventions define, namely ``time``, ``coordinates``, ``velocities``,
+  ``forces``, ``cell_lengths`` and ``cell_angles``, carry the units those conventions specify, so
+  the velocities are written in Å/ps and the forces in kcal/mol/Å rather than in the units GPUMD
+  works in. This is what lets readers that trust the ``Conventions`` attribute, such as MDAnalysis,
+  open the file. The remaining variables are GPUMD extensions that the conventions do not cover and
+  carry GPUMD units. The ``units`` attribute of each variable is authoritative in either case.
 * For qNEP models the charge values are predicted by the model. For other models they are those
   specified in :ref:`model.xyz <model_xyz>` via ``charge:R:1``.
 * The Born effective charge (:term:`BEC`) requires a qNEP model trained with target :term:`BEC`,

--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -14,21 +14,30 @@ Syntax
 
 This keyword has the following format::
 
-  dump_netcdf <grouping_method> <group_id> <interval> <has_velocity> <filename> [{optional_args}]
+  dump_netcdf <interval> <filename> [{optional_args}]
 
-The :attr:`grouping_method` parameter selects one of the grouping methods defined by
-``group:I:number_of_grouping_methods`` in the :ref:`simulation model file <model_xyz>`.
-Grouping methods are numbered from 0. When :attr:`grouping_method` is non-negative,
-:attr:`group_id` selects a group label within that grouping method, and only the atoms
-belonging to that group are written. Both values must identify an existing, non-empty
-group. When :attr:`grouping_method` is negative, :attr:`group_id` is ignored and all atoms
-in the system are written.
-The :attr:`interval` parameter is the output interval (number of steps) of the atom positions. :attr:`has_velocity` can be 1 or 0, which means the velocities will or will not be included in the output. :attr:`filename` is the relative or absolute path of the output file.
+The :attr:`interval` parameter is the output interval (number of steps) of the atom positions.
+:attr:`filename` is the relative or absolute path of the output file.
 The optional arguments (:attr:`optional_args`) provide additional functionality.
 Currently, the following optional arguments are accepted:
 
+* :attr:`group <grouping_method> <group_id>`
+
+  Write only the atoms of one group.
+  :attr:`grouping_method` selects one of the grouping methods defined by
+  ``group:I:number_of_grouping_methods`` in the :ref:`simulation model file <model_xyz>`.
+  Grouping methods are numbered from 0.
+  :attr:`group_id` selects a group label within that grouping method.
+  Both values must identify an existing, non-empty group.
+  Without this option all atoms in the system are written.
+
+* :attr:`velocity`
+
+  Write the velocities in addition to the positions.
+  Without this option only the positions are written.
+
 * :attr:`precision <value>`
-  
+
   * If :attr:`value` is ``single``, the output data are 32-bit floating point numbers.
   * If :attr:`value` is ``double``, the output data are 64-bit floating point numbers.
 
@@ -74,7 +83,7 @@ Single precision without velocities
 
 To dump the whole-system positions every 1000 steps using the default single precision and no compression, one can add::
 
-  dump_netcdf -1 0 1000 0 movie.nc
+  dump_netcdf 1000 movie.nc
 
 before the :ref:`run command <kw_run>`.
 
@@ -83,7 +92,7 @@ Double precision with velocities
 
 To dump the whole-system positions and velocities every 1000 steps with 64-bit floating point values, one can add::
 
-  dump_netcdf -1 0 1000 1 movie.nc precision double
+  dump_netcdf 1000 movie.nc velocity precision double
 
 before the :ref:`run command <kw_run>`.
 
@@ -92,7 +101,7 @@ Group output with compression
 
 To dump group 0 from grouping method 1 with lossless deflate compression, one can add::
 
-  dump_netcdf 1 0 15 1 group.nc compression deflate 1
+  dump_netcdf 15 group.nc group 1 0 velocity compression deflate 1
 
 before the :ref:`run command <kw_run>`.
 
@@ -103,8 +112,8 @@ Multiple :attr:`dump_netcdf` commands can write different groups during the
 same MD run. Each command must use a distinct filename and can use its own
 output interval, so every output file contains one independently sampled group::
 
-  dump_netcdf 0 0 10 1 group_0.nc compression deflate 1
-  dump_netcdf 0 1 25 1 group_1.nc compression deflate 1
+  dump_netcdf 10 group_0.nc group 0 0 velocity compression deflate 1
+  dump_netcdf 25 group_1.nc group 0 1 velocity compression deflate 1
 
   run 100000
 
@@ -122,4 +131,3 @@ Caveats
 * Repeating the keyword with the same filename in later runs of the same GPUMD execution
   appends to that file. A different filename creates a separate trajectory file.
 * Group, precision, velocity, and compression settings cannot change while appending to the same file.
-* The new syntax is not compatible with the former ``dump_netcdf <interval> <has_velocity>`` syntax.

--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -201,7 +201,11 @@ Caveats
 * This keyword can be invoked multiple times within one run to write different
   groups to different files. Each invocation must use a distinct filename and
   can use its own output interval and options.
-* An existing output file is overwritten the first time its name is used in a GPUMD execution.
-* Repeating the keyword with the same filename in later runs of the same GPUMD execution
-  appends to that file. A different filename creates a separate trajectory file.
-* Group, quantity, precision, and compression settings cannot change while appending to the same file.
+* The output file has an appending behavior. Frames are added to an existing file of that name,
+  whether it was written by an earlier run of the same GPUMD execution or by an earlier execution.
+  A different filename creates a separate trajectory file.
+* The layout of a NetCDF file is fixed when the file is created, so the group, quantity, precision,
+  and compression settings must match those the existing file was written with. If they do not,
+  GPUMD stops with an error naming the file. Remove or rename that file to start a new trajectory.
+* The ``time`` variable restarts at the beginning of every GPUMD execution, while ``frame`` keeps
+  counting, so the times in a file appended to across executions are not monotonic.

--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -173,7 +173,7 @@ before the :ref:`run command <kw_run>`.
 Forces and per-atom virials
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To dump forces, per-atom potential energies and per-atom virials every 100 steps, one can add::
+To dump forces, per-atom potential energies and per-atom virials every 100 steps with lossless deflate compression, one can add::
 
   dump_netcdf 100 properties.nc force potential virial compression deflate 1
 

--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -5,8 +5,8 @@
 :attr:`dump_netcdf`
 ===================
 
-Write the atomic positions (coordinates) and (optionally) velocities to a user-specified
-NetCDF trajectory file based on the `AMBER 1.0 conventions <http://ambermd.org/netcdf/nctraj.pdf>`_.
+Write per-atom data to a user-specified NetCDF trajectory file based on the
+`AMBER 1.0 conventions <http://ambermd.org/netcdf/nctraj.pdf>`_.
 
 
 Syntax
@@ -31,10 +31,64 @@ Currently, the following optional arguments are accepted:
   Both values must identify an existing, non-empty group.
   Without this option all atoms in the system are written.
 
-* :attr:`velocity`
+* Per-atom quantities
 
-  Write the velocities in addition to the positions.
-  Without this option only the positions are written.
+  Any number of the names below can be given, in any order, each adding one quantity to the
+  output.
+  The atom types and the wrapped positions are always written, as the ``type`` and
+  ``coordinates`` variables.
+
+  .. list-table::
+     :header-rows: 1
+     :widths: 22 26 34 18
+
+     * - Argument
+       - Variable
+       - Dimensions
+       - Unit
+     * - :attr:`velocity`
+       - ``velocities``
+       - ``(frame, atom, spatial)``
+       - Å/ps
+     * - :attr:`force`
+       - ``forces``
+       - ``(frame, atom, spatial)``
+       - eV/Å
+     * - :attr:`unwrapped_position`
+       - ``unwrapped_coordinates``
+       - ``(frame, atom, spatial)``
+       - Å
+     * - :attr:`potential`
+       - ``potential_energy``
+       - ``(frame, atom)``
+       - eV
+     * - :attr:`charge`
+       - ``charge``
+       - ``(frame, atom)``
+       - e
+     * - :attr:`bec`
+       - ``bec``
+       - ``(frame, atom, spatial, spatial)``
+       - e
+     * - :attr:`virial`
+       - ``virial``
+       - ``(frame, atom, spatial, spatial)``
+       - eV
+     * - :attr:`mass`
+       - ``mass``
+       - ``(atom)``
+       - amu
+     * - :attr:`group_labels`
+       - ``group_labels``
+       - ``(atom, grouping_method)``
+       - --
+
+  The mass and the group labels cannot change during a run and are therefore written once,
+  without a frame dimension.
+  The ``group_labels`` variable holds one label per grouping method, giving the group each atom
+  belongs to.
+  The rank-2 tensors are stored row-major, so ``virial[frame, atom, i, j]`` is the *ij*
+  component.
 
 * :attr:`precision <value>`
 
@@ -72,8 +126,19 @@ Requirements and specifications
 * The atomic positions are always included in the output. For periodic MD, the wrapped
   positions are written.
 * AMBER NetCDF represents a periodic cell using lengths and angles in a standard orientation.
-  If the GPUMD cell has a different orientation, the output positions and velocities are
-  rigidly transformed with the cell so that periodic geometry is preserved.
+  If the GPUMD cell has a different orientation, the output is rigidly transformed with the cell
+  so that periodic geometry is preserved. Positions, velocities, forces and unwrapped positions
+  are rotated as vectors, and the per-atom virial and the :term:`BEC` as rank-2 tensors, so that
+  every quantity in a frame refers to the same axes.
+* The units of the ``forces``, ``potential_energy``, ``charge``, ``bec``, ``virial`` and ``mass``
+  variables are those GPUMD works in, and are given by the ``units`` attribute of each variable.
+  They are not the units the AMBER conventions specify for the variables AMBER defines.
+* For qNEP models the charge values are predicted by the model. For other models they are those
+  specified in :ref:`model.xyz <model_xyz>` via ``charge:R:1``.
+* The Born effective charge (:term:`BEC`) requires a qNEP model trained with target :term:`BEC`,
+  and is refused for any other model.
+* :attr:`group_labels` requires at least one grouping method to be defined in
+  :ref:`model.xyz <model_xyz>`.
 
 Examples
 --------
@@ -105,6 +170,15 @@ To dump group 0 from grouping method 1 with lossless deflate compression, one ca
 
 before the :ref:`run command <kw_run>`.
 
+Forces and per-atom virials
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To dump forces, per-atom potential energies and per-atom virials every 100 steps, one can add::
+
+  dump_netcdf 100 properties.nc force potential virial compression deflate 1
+
+before the :ref:`run command <kw_run>`.
+
 Multiple groups in one run
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -130,4 +204,4 @@ Caveats
 * An existing output file is overwritten the first time its name is used in a GPUMD execution.
 * Repeating the keyword with the same filename in later runs of the same GPUMD execution
   appends to that file. A different filename creates a separate trajectory file.
-* Group, precision, velocity, and compression settings cannot change while appending to the same file.
+* Group, quantity, precision, and compression settings cannot change while appending to the same file.

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -396,7 +396,7 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
   } else if (strcmp(param[0], "dump_netcdf") == 0) {
 #ifdef USE_NETCDF
     std::unique_ptr<Property> property;
-    property.reset(new DUMP_NETCDF(param, num_param, group));
+    property.reset(new DUMP_NETCDF(param, num_param, group, atom));
     measure.properties.emplace_back(std::move(property));
 #else
     PRINT_INPUT_ERROR("dump_netcdf is available only when USE_NETCDF flag is set.\n");

--- a/src/main_mdi/run.cu
+++ b/src/main_mdi/run.cu
@@ -638,7 +638,7 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
   } else if (strcmp(param[0], "dump_netcdf") == 0) {
 #ifdef USE_NETCDF
     std::unique_ptr<Property> property;
-    property.reset(new DUMP_NETCDF(param, num_param, group));
+    property.reset(new DUMP_NETCDF(param, num_param, group, atom));
     measure.properties.emplace_back(std::move(property));
 #else
     PRINT_INPUT_ERROR("dump_netcdf is available only when USE_NETCDF flag is set.\n");

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -89,6 +89,10 @@ const char VIRIAL_STR[] = "virial";
 const char MASS_STR[] = "mass";
 const char GROUP_LABELS_STR[] = "group_labels";
 
+// The AMBER convention specifies forces in kcal/mol/A, so they are converted on the way out,
+// as the velocities already are. 1 eV = 96.48533212331 kJ/mol and 1 kcal = 4.184 kJ.
+const double EV_TO_KCAL_PER_MOL = 23.06054783061903;
+
 // GPUMD keeps the per-atom virial in its own component order; this maps it to the row-major
 // order the file uses, as Dump_XYZ does. The BEC is already row-major.
 const int VIRIAL_COMPONENT[9] = {0, 3, 4, 6, 1, 5, 7, 8, 2};
@@ -579,7 +583,7 @@ void DUMP_NETCDF::create_file(const std::vector<Group>& groups, const Atom& atom
     define_per_frame_variable(VELOCITIES_STR, 3, 3, "angstrom/picosecond", velocities_var);
   }
   if (quantities_.has_force_) {
-    define_per_frame_variable(FORCES_STR, 3, 3, "eV/angstrom", forces_var);
+    define_per_frame_variable(FORCES_STR, 3, 3, "kilocalorie/mole/angstrom", forces_var);
   }
   if (quantities_.has_unwrapped_position_) {
     define_per_frame_variable(
@@ -905,7 +909,7 @@ void DUMP_NETCDF::write(const double global_time, const Box& box, const Atom& at
       number_of_atoms,
       rotate,
       cell_transform,
-      1.0,
+      EV_TO_KCAL_PER_MOL,
       cpu_force_per_atom_,
       pack_float_,
       pack_double_);

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -78,55 +78,33 @@ const char UNITS_STR[] = "units";
 std::vector<std::string> DUMP_NETCDF::initialized_files_;
 std::vector<std::string> DUMP_NETCDF::active_files_;
 
-DUMP_NETCDF::DUMP_NETCDF(
-  const char** param, int num_param, const std::vector<Group>& groups)
+DUMP_NETCDF::DUMP_NETCDF(const char** param, int num_param, const std::vector<Group>& groups)
 {
   parse(param, num_param, groups);
   property_name = "dump_netcdf";
 }
 
-void DUMP_NETCDF::parse(
-  const char** param, int num_param, const std::vector<Group>& groups)
+void DUMP_NETCDF::parse(const char** param, int num_param, const std::vector<Group>& groups)
 {
   dump_ = true;
   printf("Dump positions and optional velocities in NetCDF format.\n");
 
-  if (num_param < 6) {
-    PRINT_INPUT_ERROR("dump_netcdf should have at least 5 parameters.\n");
-  }
-  if (num_param > 11) {
-    PRINT_INPUT_ERROR("dump_netcdf has too many parameters.");
+  if (num_param < 3) {
+    PRINT_INPUT_ERROR("dump_netcdf should have at least 2 parameters.\n");
   }
 
-  if (!is_valid_int(param[1], &grouping_method_)) {
-    PRINT_INPUT_ERROR("grouping method of dump_netcdf should be integer.");
-  }
-  if (grouping_method_ < 0) {
-    printf("    for the whole system.\n");
-  } else {
-    if (grouping_method_ >= int(groups.size())) {
-      PRINT_INPUT_ERROR("grouping method exceeds the bound.");
-    }
-    printf("    for grouping method %d.\n", grouping_method_);
-  }
-
-  if (!is_valid_int(param[2], &group_id_)) {
-    PRINT_INPUT_ERROR("group id of dump_netcdf should be integer.");
-  }
-  if (grouping_method_ >= 0) {
-    if (group_id_ < 0) {
-      PRINT_INPUT_ERROR("group id is negative.");
-    }
-    if (group_id_ >= groups[grouping_method_].number) {
-      PRINT_INPUT_ERROR("group id exceeds the bound.");
-    }
-    if (groups[grouping_method_].cpu_size[group_id_] <= 0) {
-      PRINT_INPUT_ERROR("dump_netcdf cannot output an empty group.");
-    }
-    printf("    for group id %d.\n", group_id_);
+  // The old syntax started with <grouping_method> <group_id> <interval>, so param[2] and param[3]
+  // were both integers. In the current syntax param[2] is the file name and param[3] is an option
+  // or a quantity keyword, neither of which is an integer.
+  int scratch;
+  if (num_param >= 4 && is_valid_int(param[2], &scratch) && is_valid_int(param[3], &scratch)) {
+    PRINT_INPUT_ERROR(
+      "dump_netcdf no longer takes <grouping_method> <group_id> as its first two parameters, and "
+      "<has_velocity> is now the optional quantity 'velocity'. Use dump_netcdf <interval> "
+      "<filename> [group <grouping_method> <group_id>] [velocity] instead.");
   }
 
-  if (!is_valid_int(param[3], &interval_)) {
+  if (!is_valid_int(param[1], &interval_)) {
     PRINT_INPUT_ERROR("dump interval should be an integer.");
   }
   if (interval_ <= 0) {
@@ -134,28 +112,34 @@ void DUMP_NETCDF::parse(
   }
   printf("    every %d steps.\n", interval_);
 
-  if (!is_valid_int(param[4], &has_velocity_)) {
-    PRINT_INPUT_ERROR("has_velocity should be an integer.");
-  }
-  if (has_velocity_ != 0 && has_velocity_ != 1) {
-    PRINT_INPUT_ERROR("has_velocity should be 0 or 1.");
-  }
-  if (has_velocity_ == 0) {
-    printf("    without velocity data.\n");
-  } else {
-    printf("    with velocity data.\n");
-  }
-
-  filename_ = param[5];
-  if (filename_.empty()) {
-    PRINT_INPUT_ERROR("dump_netcdf filename should not be empty.");
-  }
+  filename_ = param[2];
   printf("    into file %s.\n", filename_.c_str());
 
+  bool group_seen = false;
+  bool velocity_seen = false;
   bool precision_seen = false;
   bool compression_seen = false;
-  for (int k = 6; k < num_param; k++) {
-    if (strcmp(param[k], "precision") == 0) {
+  for (int k = 3; k < num_param; k++) {
+    if (strcmp(param[k], "group") == 0) {
+      if (group_seen) {
+        PRINT_INPUT_ERROR("Option 'group' is specified more than once in dump_netcdf.\n");
+      }
+      parse_group(param, num_param, false, groups, k, grouping_method_, group_id_);
+      // parse_group does not check this, and an empty group would be silent rather than loud:
+      // NC_UNLIMITED is 0, so defining the atom dimension with a length of zero would turn it
+      // into a second unlimited dimension instead of failing.
+      if (groups[grouping_method_].cpu_size[group_id_] <= 0) {
+        PRINT_INPUT_ERROR("dump_netcdf cannot output an empty group.");
+      }
+      group_seen = true;
+    } else if (strcmp(param[k], "velocity") == 0) {
+      if (velocity_seen) {
+        PRINT_INPUT_ERROR("Quantity 'velocity' is specified more than once in dump_netcdf.\n");
+      }
+      has_velocity_ = 1;
+      velocity_seen = true;
+      printf("    with velocity data.\n");
+    } else if (strcmp(param[k], "precision") == 0) {
       if (precision_seen) {
         PRINT_INPUT_ERROR("Option 'precision' is specified more than once in dump_netcdf.\n");
       }
@@ -193,6 +177,12 @@ void DUMP_NETCDF::parse(
     }
   }
 
+  if (!group_seen) {
+    printf("    for the whole system.\n");
+  }
+  if (!has_velocity_) {
+    printf("    without velocity data.\n");
+  }
   if (precision_ == 1) {
     printf("    using single precision for NetCDF output.\n");
   } else {
@@ -212,8 +202,7 @@ void DUMP_NETCDF::preprocess(
   if (!dump_)
     return;
 
-  if (
-    std::find(active_files_.begin(), active_files_.end(), filename_) != active_files_.end()) {
+  if (std::find(active_files_.begin(), active_files_.end(), filename_) != active_files_.end()) {
     PRINT_INPUT_ERROR("dump_netcdf filenames must be unique within one run.");
   }
   active_files_.push_back(filename_);
@@ -264,9 +253,7 @@ void DUMP_NETCDF::create_file()
   const int creation_mode = compression_level_ >= 0 ? NC_NETCDF4 : NC_64BIT_OFFSET;
   const int create_status = nc_create(filename_.c_str(), creation_mode, &ncid);
   if (create_status != NC_NOERR) {
-    if (
-      compression_level_ >= 0 &&
-      (create_status == NC_ENOTBUILT || create_status == NC_ENOTNC4)) {
+    if (compression_level_ >= 0 && (create_status == NC_ENOTBUILT || create_status == NC_ENOTNC4)) {
       fprintf(
         stderr,
         "Error: dump_netcdf deflate compression requires a NetCDF-C build with "
@@ -281,18 +268,16 @@ void DUMP_NETCDF::create_file()
     nc_put_att_text(ncid, NC_GLOBAL, "programVersion", strlen(GPUMD_VERSION), GPUMD_VERSION));
   NC_CHECK(nc_put_att_text(ncid, NC_GLOBAL, "Conventions", 5, "AMBER"));
   NC_CHECK(nc_put_att_text(ncid, NC_GLOBAL, "ConventionVersion", 3, "1.0"));
-  NC_CHECK(nc_put_att_int(
-    ncid, NC_GLOBAL, "gpumd_grouping_method", NC_INT, 1, &grouping_method_));
+  NC_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "gpumd_grouping_method", NC_INT, 1, &grouping_method_));
   NC_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "gpumd_group_id", NC_INT, 1, &group_id_));
-  NC_CHECK(nc_put_att_int(
-    ncid, NC_GLOBAL, "gpumd_has_velocity", NC_INT, 1, &has_velocity_));
-  NC_CHECK(nc_put_att_int(
-    ncid, NC_GLOBAL, "gpumd_compression_level", NC_INT, 1, &compression_level_));
+  NC_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "gpumd_has_velocity", NC_INT, 1, &has_velocity_));
+  NC_CHECK(
+    nc_put_att_int(ncid, NC_GLOBAL, "gpumd_compression_level", NC_INT, 1, &compression_level_));
 
   // dimensions
   NC_CHECK(nc_def_dim(
     ncid, FRAME_STR, NC_UNLIMITED, &frame_dim)); // unlimited number of steps (can append)
-  NC_CHECK(nc_def_dim(ncid, SPATIAL_STR, 3, &spatial_dim));         // number of spatial dimensions
+  NC_CHECK(nc_def_dim(ncid, SPATIAL_STR, 3, &spatial_dim)); // number of spatial dimensions
   NC_CHECK(nc_def_dim(ncid, ATOM_STR, number_of_atoms_to_dump_, &atom_dim));
   NC_CHECK(nc_def_dim(ncid, CELL_SPATIAL_STR, 3, &cell_spatial_dim)); // unitcell lengths
   NC_CHECK(nc_def_dim(ncid, CELL_ANGULAR_STR, 3, &cell_angular_dim)); // unitcell angles
@@ -339,10 +324,8 @@ void DUMP_NETCDF::create_file()
 #if defined(NC_HAS_HDF5) && NC_HAS_HDF5
     const size_t bytes_per_value = precision_ == 1 ? sizeof(float) : sizeof(double);
     const size_t target_chunk_bytes = 1024 * 1024;
-    const size_t max_chunk_atoms =
-      std::max<size_t>(1, target_chunk_bytes / (bytes_per_value * 3));
-    size_t chunks[3] = {
-      1, std::min<size_t>(number_of_atoms_to_dump_, max_chunk_atoms), 3};
+    const size_t max_chunk_atoms = std::max<size_t>(1, target_chunk_bytes / (bytes_per_value * 3));
+    size_t chunks[3] = {1, std::min<size_t>(number_of_atoms_to_dump_, max_chunk_atoms), 3};
     NC_CHECK(nc_def_var_chunking(ncid, coordinates_var, NC_CHUNKED, chunks));
     NC_CHECK(nc_def_var_deflate(ncid, coordinates_var, 1, 1, compression_level_));
     if (has_velocity_) {
@@ -350,9 +333,7 @@ void DUMP_NETCDF::create_file()
       NC_CHECK(nc_def_var_deflate(ncid, velocities_var, 1, 1, compression_level_));
     }
     size_t type_chunks[2] = {
-      1,
-      std::min<size_t>(
-        number_of_atoms_to_dump_, target_chunk_bytes / sizeof(int))};
+      1, std::min<size_t>(number_of_atoms_to_dump_, target_chunk_bytes / sizeof(int))};
     NC_CHECK(nc_def_var_chunking(ncid, type_var, NC_CHUNKED, type_chunks));
     NC_CHECK(nc_def_var_deflate(ncid, type_var, 1, 1, compression_level_));
 #endif // NC_HAS_HDF5
@@ -425,13 +406,10 @@ void DUMP_NETCDF::validate_file_definition()
   int previous_group_id;
   int previous_has_velocity;
   int previous_compression_level;
-  NC_CHECK(nc_get_att_int(
-    ncid, NC_GLOBAL, "gpumd_grouping_method", &previous_grouping_method));
+  NC_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "gpumd_grouping_method", &previous_grouping_method));
   NC_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "gpumd_group_id", &previous_group_id));
-  NC_CHECK(nc_get_att_int(
-    ncid, NC_GLOBAL, "gpumd_has_velocity", &previous_has_velocity));
-  NC_CHECK(nc_get_att_int(
-    ncid, NC_GLOBAL, "gpumd_compression_level", &previous_compression_level));
+  NC_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "gpumd_has_velocity", &previous_has_velocity));
+  NC_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "gpumd_compression_level", &previous_compression_level));
   if (previous_grouping_method != grouping_method_ || previous_group_id != group_id_) {
     PRINT_INPUT_ERROR("Cannot change the dump_netcdf group between run commands.\n");
   }
@@ -459,9 +437,7 @@ static bool build_netcdf_transform(
   const auto dot = [](const double x[3], const double y[3]) {
     return x[0] * y[0] + x[1] * y[1] + x[2] * y[2];
   };
-  const auto clamp_cosine = [](double value) {
-    return std::max(-1.0, std::min(1.0, value));
-  };
+  const auto clamp_cosine = [](double value) { return std::max(-1.0, std::min(1.0, value)); };
 
   cell_lengths[0] = sqrt(dot(a, a));
   cell_lengths[1] = sqrt(dot(b, b));
@@ -492,12 +468,9 @@ static bool build_netcdf_transform(
     }
   }
 
-  const double cosalpha =
-    clamp_cosine(dot(b, c) / (cell_lengths[1] * cell_lengths[2]));
-  const double cosbeta =
-    clamp_cosine(dot(a, c) / (cell_lengths[0] * cell_lengths[2]));
-  const double cosgamma =
-    clamp_cosine(dot(a, b) / (cell_lengths[0] * cell_lengths[1]));
+  const double cosalpha = clamp_cosine(dot(b, c) / (cell_lengths[1] * cell_lengths[2]));
+  const double cosbeta = clamp_cosine(dot(a, c) / (cell_lengths[0] * cell_lengths[2]));
+  const double cosgamma = clamp_cosine(dot(a, b) / (cell_lengths[0] * cell_lengths[1]));
   cell_angles[0] = acos(cosalpha) * 180.0 / PI;
   cell_angles[1] = acos(cosbeta) * 180.0 / PI;
   cell_angles[2] = acos(cosgamma) * 180.0 / PI;
@@ -525,25 +498,21 @@ static void pack_netcdf_frame(
   for (int i = 0; i < number_of_atoms; ++i) {
     for (int output_dim = 0; output_dim < 3; ++output_dim) {
       double position_value = position[i + number_of_atoms * output_dim];
-      double velocity_value =
-        has_velocity ? velocity[i + number_of_atoms * output_dim] : 0.0;
+      double velocity_value = has_velocity ? velocity[i + number_of_atoms * output_dim] : 0.0;
       if (transform_vectors) {
         position_value = 0.0;
         velocity_value = 0.0;
         for (int input_dim = 0; input_dim < 3; ++input_dim) {
           const double coefficient = transform[output_dim * 3 + input_dim];
-          position_value +=
-            coefficient * position[i + number_of_atoms * input_dim];
+          position_value += coefficient * position[i + number_of_atoms * input_dim];
           if (has_velocity) {
-            velocity_value +=
-              coefficient * velocity[i + number_of_atoms * input_dim];
+            velocity_value += coefficient * velocity[i + number_of_atoms * input_dim];
           }
         }
       }
       packed_position[i * 3 + output_dim] = static_cast<T>(position_value);
       if (has_velocity) {
-        packed_velocity[i * 3 + output_dim] =
-          static_cast<T>(velocity_value * velocity_scale);
+        packed_velocity[i * 3 + output_dim] = static_cast<T>(velocity_value * velocity_scale);
       }
     }
   }
@@ -660,8 +629,7 @@ static __global__ void gather_netcdf_group(
   if (n < number_of_atoms_in_group) {
     const int atom_index = group_contents[group_offset + n];
     for (int d = 0; d < 3; ++d) {
-      group_position[n + number_of_atoms_in_group * d] =
-        position[atom_index + number_of_atoms * d];
+      group_position[n + number_of_atoms_in_group * d] = position[atom_index + number_of_atoms * d];
       if (group_velocity != nullptr) {
         group_velocity[n + number_of_atoms_in_group * d] =
           velocity[atom_index + number_of_atoms * d];

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -727,7 +727,21 @@ void DUMP_NETCDF::validate_file_definition()
   }
 
   // One attribute covers every quantity, so the whole set is compared at once rather than one
-  // flag at a time.
+  // flag at a time. Every file dump_netcdf writes records it, as an empty string when no quantity
+  // was requested, so one without the attribute cannot be compared against at all. Saying so here
+  // rather than where the file is opened leaves the checks above to speak first, so a file that
+  // already differs in atom count or precision still gets that more specific message.
+  int attribute_id;
+  if (nc_inq_attid(ncid, NC_GLOBAL, "gpumd_quantities", &attribute_id) != NC_NOERR) {
+    char message[512];
+    snprintf(
+      message,
+      sizeof(message),
+      "Cannot append to %s, which does not record which quantities it holds. Remove or rename it "
+      "to start a new trajectory.\n",
+      filename_.c_str());
+    PRINT_INPUT_ERROR(message);
+  }
   size_t previous_length = 0;
   NC_CHECK(nc_inq_attlen(ncid, NC_GLOBAL, "gpumd_quantities", &previous_length));
   std::string previous_quantities(previous_length, '\0');

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -125,9 +125,12 @@ void DUMP_NETCDF::parse(const char** param, int num_param, const std::vector<Gro
         PRINT_INPUT_ERROR("Option 'group' is specified more than once in dump_netcdf.\n");
       }
       parse_group(param, num_param, false, groups, k, grouping_method_, group_id_);
-      // parse_group does not check this, and an empty group would be silent rather than loud:
-      // NC_UNLIMITED is 0, so defining the atom dimension with a length of zero would turn it
-      // into a second unlimited dimension instead of failing.
+      // parse_group checks the bounds but not the size, and an empty group is not caught further
+      // down either. NC_UNLIMITED is 0, so defining the atom dimension with a length of zero
+      // makes it unlimited rather than failing: with compression the run then succeeds and
+      // writes a file whose coordinates have shape (frames, 0, 3), and without it the run dies
+      // mid-way with "NC_UNLIMITED size already in use", since the classic format allows only
+      // one unlimited dimension.
       if (groups[grouping_method_].cpu_size[group_id_] <= 0) {
         PRINT_INPUT_ERROR("dump_netcdf cannot output an empty group.");
       }

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -46,7 +46,9 @@ https://ambermd.org/netcdf/nctraj.pdf
 #include "utilities/read_file.cuh"
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <cstring>
+#include <fstream>
 
 #define GPUMD_VERSION "5.6"
 
@@ -92,7 +94,6 @@ const char GROUP_LABELS_STR[] = "group_labels";
 const int VIRIAL_COMPONENT[9] = {0, 3, 4, 6, 1, 5, 7, 8, 2};
 const int ROW_MAJOR_COMPONENT[9] = {0, 1, 2, 3, 4, 5, 6, 7, 8};
 
-std::vector<std::string> DUMP_NETCDF::initialized_files_;
 std::vector<std::string> DUMP_NETCDF::active_files_;
 
 // The three packing helpers below take one per-atom array laid out as src[atom + N * component],
@@ -443,17 +444,27 @@ void DUMP_NETCDF::preprocess(
     cpu_bec_.resize(atom.number_of_atoms * 9);
   }
 
-  const bool initialized =
-    std::find(initialized_files_.begin(), initialized_files_.end(), filename_) !=
-    initialized_files_.end();
-  if (initialized) {
-    NC_CHECK(nc_open(filename_.c_str(), NC_WRITE, &ncid));
+  // An existing file is extended rather than replaced, as dump_xyz does. Whether the file is
+  // there is decided by looking for it rather than by inferring absence from a NetCDF error
+  // code, which is not the same value in every netcdf-c build. This also covers a file written
+  // earlier in this execution: the previous command closed it, so it is simply on disk.
+  std::ifstream existing_file(filename_.c_str());
+  if (existing_file.good()) {
+    existing_file.close();
+    const int open_status = nc_open(filename_.c_str(), NC_WRITE, &ncid);
+    if (open_status != NC_NOERR) {
+      fprintf(
+        stderr,
+        "Error: dump_netcdf cannot open %s to append to it. Remove or rename it to start a new "
+        "trajectory.\n",
+        filename_.c_str());
+      ERR(open_status);
+    }
     load_file_definition();
     validate_file_definition();
     NC_CHECK(nc_inq_dimlen(ncid, frame_dim, &lenp));
   } else {
     create_file(group, atom);
-    initialized_files_.push_back(filename_);
   }
 }
 
@@ -671,19 +682,35 @@ void DUMP_NETCDF::load_file_definition()
   NC_CHECK(nc_inq_varid(ncid, TYPE_STR, &type_var));
 }
 
+// The layout of a NetCDF file is fixed when it is created, so appending is only meaningful when
+// the run produces exactly what the file already holds. The file is named because removing or
+// renaming it is what the user has to do next.
+void DUMP_NETCDF::append_mismatch(const char* what)
+{
+  char message[512];
+  snprintf(
+    message,
+    sizeof(message),
+    "Cannot append to %s, which was written with a different %s. Remove or rename it to start a "
+    "new trajectory.\n",
+    filename_.c_str(),
+    what);
+  PRINT_INPUT_ERROR(message);
+}
+
 void DUMP_NETCDF::validate_file_definition()
 {
   size_t previous_number_of_atoms = 0;
   NC_CHECK(nc_inq_dimlen(ncid, atom_dim, &previous_number_of_atoms));
   if (previous_number_of_atoms != size_t(number_of_atoms_to_dump_)) {
-    PRINT_INPUT_ERROR("Cannot append dump_netcdf data with a different number of atoms.\n");
+    append_mismatch("number of atoms");
   }
 
   nc_type coordinate_type;
   NC_CHECK(nc_inq_vartype(ncid, coordinates_var, &coordinate_type));
   const nc_type expected_type = precision_ == 1 ? NC_FLOAT : NC_DOUBLE;
   if (coordinate_type != expected_type) {
-    PRINT_INPUT_ERROR("Cannot change dump_netcdf precision between run commands.\n");
+    append_mismatch("precision");
   }
 
   int previous_grouping_method;
@@ -693,10 +720,10 @@ void DUMP_NETCDF::validate_file_definition()
   NC_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "gpumd_group_id", &previous_group_id));
   NC_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "gpumd_compression_level", &previous_compression_level));
   if (previous_grouping_method != grouping_method_ || previous_group_id != group_id_) {
-    PRINT_INPUT_ERROR("Cannot change the dump_netcdf group between run commands.\n");
+    append_mismatch("group");
   }
   if (previous_compression_level != compression_level_) {
-    PRINT_INPUT_ERROR("Cannot change dump_netcdf compression between run commands.\n");
+    append_mismatch("compression");
   }
 
   // One attribute covers every quantity, so the whole set is compared at once rather than one
@@ -706,7 +733,7 @@ void DUMP_NETCDF::validate_file_definition()
   std::string previous_quantities(previous_length, '\0');
   NC_CHECK(nc_get_att_text(ncid, NC_GLOBAL, "gpumd_quantities", &previous_quantities[0]));
   if (previous_quantities != quantity_list_) {
-    PRINT_INPUT_ERROR("Cannot change the dump_netcdf quantities between run commands.\n");
+    append_mismatch("set of quantities");
   }
 
   // The quantities match, so every variable they call for is in the file.

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -100,40 +100,38 @@ const int ROW_MAJOR_COMPONENT[9] = {0, 1, 2, 3, 4, 5, 6, 7, 8};
 
 std::vector<std::string> DUMP_NETCDF::active_files_;
 
-// The three packing helpers below take one per-atom array laid out as src[atom + N * component],
-// select the atoms of the output through `indices`, apply the rotation into the restricted
-// NetCDF cell where the quantity calls for one, and write the result out atom-major in the
-// element type the file uses.
+// The three packing helpers below take one staged per-atom array laid out as
+// src[atom + number_to_dump * component], apply the rotation into the restricted NetCDF cell where
+// the quantity calls for one, and write the result out atom-major in the element type the file
+// uses. Whether the staging held the whole system or only the selected group is already settled by
+// then, which is why there is no index list here.
 
 template <typename T, typename S>
-static void
-pack_scalar(const std::vector<int>& indices, const std::vector<S>& src, std::vector<T>& dst)
+static void pack_scalar(const int number_to_dump, const std::vector<S>& src, std::vector<T>& dst)
 {
-  for (size_t n = 0; n < indices.size(); ++n) {
-    dst[n] = static_cast<T>(src[indices[n]]);
+  for (int n = 0; n < number_to_dump; ++n) {
+    dst[n] = static_cast<T>(src[n]);
   }
 }
 
 template <typename T, typename S>
 static void pack_vector(
-  const std::vector<int>& indices,
-  const int number_of_atoms,
+  const int number_to_dump,
   const bool rotate,
   const double transform[9],
   const double scale,
   const std::vector<S>& src,
   std::vector<T>& dst)
 {
-  for (size_t n = 0; n < indices.size(); ++n) {
-    const int m = indices[n];
+  for (int n = 0; n < number_to_dump; ++n) {
     for (int i = 0; i < 3; ++i) {
       double value = 0.0;
       if (rotate) {
         for (int j = 0; j < 3; ++j) {
-          value += transform[i * 3 + j] * src[m + number_of_atoms * j];
+          value += transform[i * 3 + j] * src[n + number_to_dump * j];
         }
       } else {
-        value = src[m + number_of_atoms * i];
+        value = src[n + number_to_dump * i];
       }
       dst[n * 3 + i] = static_cast<T>(value * scale);
     }
@@ -142,19 +140,17 @@ static void pack_vector(
 
 template <typename T, typename S>
 static void pack_tensor(
-  const std::vector<int>& indices,
-  const int number_of_atoms,
+  const int number_to_dump,
   const bool rotate,
   const double transform[9],
   const int component[9],
   const std::vector<S>& src,
   std::vector<T>& dst)
 {
-  for (size_t n = 0; n < indices.size(); ++n) {
-    const int m = indices[n];
+  for (int n = 0; n < number_to_dump; ++n) {
     double tensor[9];
     for (int c = 0; c < 9; ++c) {
-      tensor[c] = src[m + number_of_atoms * component[c]];
+      tensor[c] = src[n + number_to_dump * component[c]];
     }
     if (rotate) {
       // A rank-2 tensor follows the cell as R T R^T, which holds for any orthogonal R and so
@@ -185,29 +181,49 @@ static void pack_tensor(
   }
 }
 
+// Selecting a group on the device, so that only its values cross to the host. The source keeps the
+// whole-system layout src[atom + number_of_atoms * component] and the result is compact,
+// dst[n + number_to_dump * component], which is the layout the packing helpers expect.
+template <typename T>
+static __global__ void gather_dumped_atoms(
+  const int number_to_dump,
+  const int number_of_atoms,
+  const int components,
+  const int* indices,
+  const T* source,
+  T* destination)
+{
+  const int n = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n < number_to_dump) {
+    const int m = indices[n];
+    for (int d = 0; d < components; ++d) {
+      destination[n + number_to_dump * d] = source[m + number_of_atoms * d];
+    }
+  }
+}
+
 // The file holds floats or doubles depending on the precision option, so every pack goes through
 // one of these, which pick the buffer and instantiate the helper for its element type.
 
 template <typename S>
 static void pack_scalar_by_precision(
   const int precision,
-  const std::vector<int>& indices,
+  const int number_to_dump,
   const std::vector<S>& src,
   std::vector<float>& pack_float,
   std::vector<double>& pack_double)
 {
   if (precision == 1) {
-    pack_scalar(indices, src, pack_float);
+    pack_scalar(number_to_dump, src, pack_float);
   } else {
-    pack_scalar(indices, src, pack_double);
+    pack_scalar(number_to_dump, src, pack_double);
   }
 }
 
 template <typename S>
 static void pack_vector_by_precision(
   const int precision,
-  const std::vector<int>& indices,
-  const int number_of_atoms,
+  const int number_to_dump,
   const bool rotate,
   const double transform[9],
   const double scale,
@@ -216,17 +232,16 @@ static void pack_vector_by_precision(
   std::vector<double>& pack_double)
 {
   if (precision == 1) {
-    pack_vector(indices, number_of_atoms, rotate, transform, scale, src, pack_float);
+    pack_vector(number_to_dump, rotate, transform, scale, src, pack_float);
   } else {
-    pack_vector(indices, number_of_atoms, rotate, transform, scale, src, pack_double);
+    pack_vector(number_to_dump, rotate, transform, scale, src, pack_double);
   }
 }
 
 template <typename S>
 static void pack_tensor_by_precision(
   const int precision,
-  const std::vector<int>& indices,
-  const int number_of_atoms,
+  const int number_to_dump,
   const bool rotate,
   const double transform[9],
   const int component[9],
@@ -235,9 +250,9 @@ static void pack_tensor_by_precision(
   std::vector<double>& pack_double)
 {
   if (precision == 1) {
-    pack_tensor(indices, number_of_atoms, rotate, transform, component, src, pack_float);
+    pack_tensor(number_to_dump, rotate, transform, component, src, pack_float);
   } else {
-    pack_tensor(indices, number_of_atoms, rotate, transform, component, src, pack_double);
+    pack_tensor(number_to_dump, rotate, transform, component, src, pack_double);
   }
 }
 
@@ -421,31 +436,40 @@ void DUMP_NETCDF::preprocess(
     }
   }
   cpu_type_to_dump_.resize(number_of_atoms_to_dump_);
+  number_of_atoms_ = atom.number_of_atoms;
 
-  // one variable of one frame at a time, so nine components per atom is the widest case
-  const size_t pack_values = size_t(number_of_atoms_to_dump_) * 9;
-  if (precision_ == 1) {
-    pack_float_.resize(pack_values);
-  } else {
-    pack_double_.resize(pack_values);
-  }
-
-  // host copies of the arrays Atom does not already keep on the host, sized for the whole
-  // system since that is what is copied back from the device
-  if (quantities_.has_force_) {
-    cpu_force_per_atom_.resize(atom.number_of_atoms * 3);
-  }
-  if (quantities_.has_potential_) {
-    cpu_potential_per_atom_.resize(atom.number_of_atoms);
-  }
-  if (quantities_.has_unwrapped_position_) {
-    cpu_unwrapped_position_.resize(atom.number_of_atoms * 3);
-  }
-  if (quantities_.has_virial_) {
-    cpu_virial_per_atom_.resize(atom.number_of_atoms * 9);
+  // One variable of one frame at a time, so the buffers are sized by the widest quantity that was
+  // actually asked for. Sizing them for nine components unconditionally would cost a large system
+  // hundreds of megabytes to write positions alone.
+  const int double_components = quantities_.has_virial_ ? 9 : 3; // positions are always written
+  int float_components = 0;
+  if (quantities_.has_charge_) {
+    float_components = 1;
   }
   if (quantities_.has_bec_) {
-    cpu_bec_.resize(atom.number_of_atoms * 9);
+    float_components = 9;
+  }
+  const size_t widest = size_t(std::max(double_components, float_components));
+  if (precision_ == 1) {
+    pack_float_.resize(size_t(number_of_atoms_to_dump_) * widest);
+  } else {
+    pack_double_.resize(size_t(number_of_atoms_to_dump_) * widest);
+  }
+
+  // Staging for one quantity of one frame, holding only the atoms that are written. When a group
+  // is selected the values are gathered into the matching device buffer first, so that the copy
+  // across the bus is the size of the group rather than of the system.
+  const size_t staged_doubles = size_t(number_of_atoms_to_dump_) * double_components;
+  const size_t staged_floats = size_t(number_of_atoms_to_dump_) * float_components;
+  host_double_.resize(staged_doubles);
+  host_float_.resize(staged_floats);
+  if (grouping_method_ >= 0) {
+    gather_double_.resize(staged_doubles);
+    if (staged_floats > 0) {
+      gather_float_.resize(staged_floats);
+    }
+    gpu_dump_indices_.resize(number_of_atoms_to_dump_);
+    gpu_dump_indices_.copy_from_host(dump_indices_.data());
   }
 
   // An existing file is extended rather than replaced, as dump_xyz does. Whether the file is
@@ -636,7 +660,11 @@ void DUMP_NETCDF::create_file(const std::vector<Group>& groups, const Atom& atom
 
   // The constant quantities, written once now rather than once per frame
   if (quantities_.has_mass_) {
-    pack_scalar_by_precision(precision_, dump_indices_, atom.cpu_mass, pack_float_, pack_double_);
+    for (int n = 0; n < number_of_atoms_to_dump_; ++n) {
+      host_double_[n] = atom.cpu_mass[dump_indices_[n]];
+    }
+    pack_scalar_by_precision(
+      precision_, number_of_atoms_to_dump_, host_double_, pack_float_, pack_double_);
     const size_t mass_start[1] = {0};
     const size_t mass_count[1] = {size_t(number_of_atoms_to_dump_)};
     put_packed(mass_var, mass_start, mass_count);
@@ -657,6 +685,29 @@ void DUMP_NETCDF::create_file(const std::vector<Group>& groups, const Atom& atom
   }
 
   lenp = 0;
+}
+
+// Brings one quantity to the host, holding only the atoms that are written. Without a group the
+// whole array is already exactly that, so it is copied as it stands; with one, the group is
+// gathered on the device first so that only its values cross the bus.
+template <typename T>
+void DUMP_NETCDF::stage(
+  GPU_Vector<T>& source, const int components, GPU_Vector<T>& scratch, std::vector<T>& host)
+{
+  const size_t values = size_t(number_of_atoms_to_dump_) * components;
+  if (grouping_method_ < 0) {
+    source.copy_to_host(host.data(), values);
+    return;
+  }
+  gather_dumped_atoms<<<(number_of_atoms_to_dump_ - 1) / 128 + 1, 128>>>(
+    number_of_atoms_to_dump_,
+    number_of_atoms_,
+    components,
+    gpu_dump_indices_.data(),
+    source.data(),
+    scratch.data());
+  GPU_CHECK_KERNEL
+  scratch.copy_to_host(host.data(), values);
 }
 
 void DUMP_NETCDF::put_packed(const int var, const size_t* start, const size_t* count)
@@ -837,9 +888,8 @@ static bool build_netcdf_transform(
   return transform_vectors;
 }
 
-void DUMP_NETCDF::write(const double global_time, const Box& box, const Atom& atom)
+void DUMP_NETCDF::write(const double global_time, const Box& box, Atom& atom, Force& force)
 {
-  const int number_of_atoms = atom.number_of_atoms;
   const int number_to_dump = number_of_atoms_to_dump_;
 
   double cell_lengths[3];
@@ -870,19 +920,22 @@ void DUMP_NETCDF::write(const double global_time, const Box& box, const Atom& at
   size_t tensor_start[4] = {lenp, 0, 0, 0};
   size_t tensor_count[4] = {1, size_t(number_to_dump), 3, 3};
 
+  // The types live on the host already, so they are selected there.
   for (int n = 0; n < number_to_dump; ++n) {
     cpu_type_to_dump_[n] = atom.cpu_type[dump_indices_[n]];
   }
   NC_CHECK(nc_put_vara_int(ncid, type_var, atom_start, atom_count, cpu_type_to_dump_.data()));
 
+  // Each quantity is staged, packed and written before the next one starts, which is what lets a
+  // single staging buffer per element type serve all of them.
+  stage(atom.position_per_atom, 3, gather_double_, host_double_);
   pack_vector_by_precision(
     precision_,
-    dump_indices_,
-    number_of_atoms,
+    number_to_dump,
     rotate,
     cell_transform,
     1.0,
-    atom.cpu_position_per_atom,
+    host_double_,
     pack_float_,
     pack_double_);
   put_packed(coordinates_var, vector_start, vector_count);
@@ -890,75 +943,78 @@ void DUMP_NETCDF::write(const double global_time, const Box& box, const Atom& at
   if (quantities_.has_velocity_) {
     const double natural_to_A_per_ps =
       1.0 / TIME_UNIT_CONVERSION * 1000.0; // * 1000 from A/fs to A/ps
+    stage(atom.velocity_per_atom, 3, gather_double_, host_double_);
     pack_vector_by_precision(
       precision_,
-      dump_indices_,
-      number_of_atoms,
+      number_to_dump,
       rotate,
       cell_transform,
       natural_to_A_per_ps,
-      atom.cpu_velocity_per_atom,
+      host_double_,
       pack_float_,
       pack_double_);
     put_packed(velocities_var, vector_start, vector_count);
   }
   if (quantities_.has_force_) {
+    stage(atom.force_per_atom, 3, gather_double_, host_double_);
     pack_vector_by_precision(
       precision_,
-      dump_indices_,
-      number_of_atoms,
+      number_to_dump,
       rotate,
       cell_transform,
       EV_TO_KCAL_PER_MOL,
-      cpu_force_per_atom_,
+      host_double_,
       pack_float_,
       pack_double_);
     put_packed(forces_var, vector_start, vector_count);
   }
   if (quantities_.has_unwrapped_position_) {
+    stage(atom.unwrapped_position, 3, gather_double_, host_double_);
     pack_vector_by_precision(
       precision_,
-      dump_indices_,
-      number_of_atoms,
+      number_to_dump,
       rotate,
       cell_transform,
       1.0,
-      cpu_unwrapped_position_,
+      host_double_,
       pack_float_,
       pack_double_);
     put_packed(unwrapped_coordinates_var, vector_start, vector_count);
   }
   if (quantities_.has_potential_) {
-    pack_scalar_by_precision(
-      precision_, dump_indices_, cpu_potential_per_atom_, pack_float_, pack_double_);
+    stage(atom.potential_per_atom, 1, gather_double_, host_double_);
+    pack_scalar_by_precision(precision_, number_to_dump, host_double_, pack_float_, pack_double_);
     put_packed(potential_var, atom_start, atom_count);
   }
   if (quantities_.has_charge_) {
-    pack_scalar_by_precision(precision_, dump_indices_, atom.cpu_charge, pack_float_, pack_double_);
+    GPU_Vector<float>& charge =
+      is_nep_charge_ ? force.potentials[0]->get_charge_reference() : atom.charge;
+    stage(charge, 1, gather_float_, host_float_);
+    pack_scalar_by_precision(precision_, number_to_dump, host_float_, pack_float_, pack_double_);
     put_packed(charge_var, atom_start, atom_count);
   }
   if (quantities_.has_bec_) {
+    stage(force.potentials[0]->get_bec_reference(), 9, gather_float_, host_float_);
     pack_tensor_by_precision(
       precision_,
-      dump_indices_,
-      number_of_atoms,
+      number_to_dump,
       rotate,
       cell_transform,
       ROW_MAJOR_COMPONENT,
-      cpu_bec_,
+      host_float_,
       pack_float_,
       pack_double_);
     put_packed(bec_var, tensor_start, tensor_count);
   }
   if (quantities_.has_virial_) {
+    stage(atom.virial_per_atom, 9, gather_double_, host_double_);
     pack_tensor_by_precision(
       precision_,
-      dump_indices_,
-      number_of_atoms,
+      number_to_dump,
       rotate,
       cell_transform,
       VIRIAL_COMPONENT,
-      cpu_virial_per_atom_,
+      host_double_,
       pack_float_,
       pack_double_);
     put_packed(virial_var, tensor_start, tensor_count);
@@ -1005,38 +1061,7 @@ void DUMP_NETCDF::process(
   if ((step + 1) % interval_ != 0)
     return;
 
-  // Copy back what was asked for, in full. Selecting the group happens on the host while
-  // packing, through dump_indices_, which is one path for the grouped and the whole-system case.
-  atom.position_per_atom.copy_to_host(atom.cpu_position_per_atom.data());
-  if (quantities_.has_velocity_) {
-    atom.velocity_per_atom.copy_to_host(atom.cpu_velocity_per_atom.data());
-  }
-  if (quantities_.has_force_) {
-    atom.force_per_atom.copy_to_host(cpu_force_per_atom_.data());
-  }
-  if (quantities_.has_potential_) {
-    atom.potential_per_atom.copy_to_host(cpu_potential_per_atom_.data());
-  }
-  if (quantities_.has_unwrapped_position_) {
-    atom.unwrapped_position.copy_to_host(cpu_unwrapped_position_.data());
-  }
-  if (quantities_.has_virial_) {
-    atom.virial_per_atom.copy_to_host(cpu_virial_per_atom_.data());
-  }
-  if (quantities_.has_charge_) {
-    if (is_nep_charge_) {
-      GPU_Vector<float>& nep_charge = force.potentials[0]->get_charge_reference();
-      nep_charge.copy_to_host(atom.cpu_charge.data());
-    } else {
-      atom.charge.copy_to_host(atom.cpu_charge.data());
-    }
-  }
-  if (quantities_.has_bec_) {
-    GPU_Vector<float>& gpu_bec = force.potentials[0]->get_bec_reference();
-    gpu_bec.copy_to_host(cpu_bec_.data());
-  }
-
-  write(global_time, box, atom);
+  write(global_time, box, atom, force);
 }
 
 #endif

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -14,10 +14,11 @@
 */
 
 /*----------------------------------------------------------------------------80
-Write atom types, positions, and optional velocities to NetCDF trajectory
-files. The layout is based on the AMBER 1.0 trajectory conventions, with
-GPUMD extensions for atom types, group metadata, selectable precision, and
-optional NetCDF4 deflate compression.
+Write atom types, positions, and the optional per-atom quantities shared with
+dump_xyz to NetCDF trajectory files. The layout is based on the AMBER 1.0
+trajectory conventions, with GPUMD extensions for atom types, the quantities
+AMBER does not define, group metadata, selectable precision, and optional
+NetCDF4 deflate compression.
 
 Contributing authors: Alexander Gabourie (Stanford University)
                       Liang Ting (The Chinese University of Hong Kong)
@@ -31,6 +32,7 @@ https://ambermd.org/netcdf/nctraj.pdf
 #ifdef USE_NETCDF
 
 #include "dump_netcdf.cuh"
+#include "force/force.cuh"
 #include "model/atom.cuh"
 #include "model/box.cuh"
 #include "model/group.cuh"
@@ -75,19 +77,192 @@ const char TYPE_STR[] = "type";
 const char CELL_LENGTHS_STR[] = "cell_lengths";
 const char CELL_ANGLES_STR[] = "cell_angles";
 const char UNITS_STR[] = "units";
+const char GROUPING_METHOD_STR[] = "grouping_method";
+const char FORCES_STR[] = "forces";
+const char UNWRAPPED_COORDINATES_STR[] = "unwrapped_coordinates";
+const char POTENTIAL_STR[] = "potential_energy";
+const char CHARGE_STR[] = "charge";
+const char BEC_STR[] = "bec";
+const char VIRIAL_STR[] = "virial";
+const char MASS_STR[] = "mass";
+const char GROUP_LABELS_STR[] = "group_labels";
+
+// GPUMD keeps the per-atom virial in its own component order; this maps it to the row-major
+// order the file uses, as Dump_XYZ does. The BEC is already row-major.
+const int VIRIAL_COMPONENT[9] = {0, 3, 4, 6, 1, 5, 7, 8, 2};
+const int ROW_MAJOR_COMPONENT[9] = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+
 std::vector<std::string> DUMP_NETCDF::initialized_files_;
 std::vector<std::string> DUMP_NETCDF::active_files_;
 
-DUMP_NETCDF::DUMP_NETCDF(const char** param, int num_param, const std::vector<Group>& groups)
+// The three packing helpers below take one per-atom array laid out as src[atom + N * component],
+// select the atoms of the output through `indices`, apply the rotation into the restricted
+// NetCDF cell where the quantity calls for one, and write the result out atom-major in the
+// element type the file uses.
+
+template <typename T, typename S>
+static void
+pack_scalar(const std::vector<int>& indices, const std::vector<S>& src, std::vector<T>& dst)
 {
+  for (size_t n = 0; n < indices.size(); ++n) {
+    dst[n] = static_cast<T>(src[indices[n]]);
+  }
+}
+
+template <typename T, typename S>
+static void pack_vector(
+  const std::vector<int>& indices,
+  const int number_of_atoms,
+  const bool rotate,
+  const double transform[9],
+  const double scale,
+  const std::vector<S>& src,
+  std::vector<T>& dst)
+{
+  for (size_t n = 0; n < indices.size(); ++n) {
+    const int m = indices[n];
+    for (int i = 0; i < 3; ++i) {
+      double value = 0.0;
+      if (rotate) {
+        for (int j = 0; j < 3; ++j) {
+          value += transform[i * 3 + j] * src[m + number_of_atoms * j];
+        }
+      } else {
+        value = src[m + number_of_atoms * i];
+      }
+      dst[n * 3 + i] = static_cast<T>(value * scale);
+    }
+  }
+}
+
+template <typename T, typename S>
+static void pack_tensor(
+  const std::vector<int>& indices,
+  const int number_of_atoms,
+  const bool rotate,
+  const double transform[9],
+  const int component[9],
+  const std::vector<S>& src,
+  std::vector<T>& dst)
+{
+  for (size_t n = 0; n < indices.size(); ++n) {
+    const int m = indices[n];
+    double tensor[9];
+    for (int c = 0; c < 9; ++c) {
+      tensor[c] = src[m + number_of_atoms * component[c]];
+    }
+    if (rotate) {
+      // A rank-2 tensor follows the cell as R T R^T, which holds for any orthogonal R and so
+      // also when R is the reflection produced for a left-handed cell.
+      double temp[9];
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          double sum = 0.0;
+          for (int k = 0; k < 3; ++k) {
+            sum += transform[i * 3 + k] * tensor[k * 3 + j];
+          }
+          temp[i * 3 + j] = sum;
+        }
+      }
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          double sum = 0.0;
+          for (int k = 0; k < 3; ++k) {
+            sum += temp[i * 3 + k] * transform[j * 3 + k];
+          }
+          tensor[i * 3 + j] = sum;
+        }
+      }
+    }
+    for (int c = 0; c < 9; ++c) {
+      dst[n * 9 + c] = static_cast<T>(tensor[c]);
+    }
+  }
+}
+
+// The file holds floats or doubles depending on the precision option, so every pack goes through
+// one of these, which pick the buffer and instantiate the helper for its element type.
+
+template <typename S>
+static void pack_scalar_by_precision(
+  const int precision,
+  const std::vector<int>& indices,
+  const std::vector<S>& src,
+  std::vector<float>& pack_float,
+  std::vector<double>& pack_double)
+{
+  if (precision == 1) {
+    pack_scalar(indices, src, pack_float);
+  } else {
+    pack_scalar(indices, src, pack_double);
+  }
+}
+
+template <typename S>
+static void pack_vector_by_precision(
+  const int precision,
+  const std::vector<int>& indices,
+  const int number_of_atoms,
+  const bool rotate,
+  const double transform[9],
+  const double scale,
+  const std::vector<S>& src,
+  std::vector<float>& pack_float,
+  std::vector<double>& pack_double)
+{
+  if (precision == 1) {
+    pack_vector(indices, number_of_atoms, rotate, transform, scale, src, pack_float);
+  } else {
+    pack_vector(indices, number_of_atoms, rotate, transform, scale, src, pack_double);
+  }
+}
+
+template <typename S>
+static void pack_tensor_by_precision(
+  const int precision,
+  const std::vector<int>& indices,
+  const int number_of_atoms,
+  const bool rotate,
+  const double transform[9],
+  const int component[9],
+  const std::vector<S>& src,
+  std::vector<float>& pack_float,
+  std::vector<double>& pack_double)
+{
+  if (precision == 1) {
+    pack_tensor(indices, number_of_atoms, rotate, transform, component, src, pack_float);
+  } else {
+    pack_tensor(indices, number_of_atoms, rotate, transform, component, src, pack_double);
+  }
+}
+
+DUMP_NETCDF::DUMP_NETCDF(
+  const char** param, int num_param, const std::vector<Group>& groups, Atom& atom)
+{
+  is_nep_charge_ = check_is_nep_charge();
+
   parse(param, num_param, groups);
+
+  // The integrator only maintains the unwrapped positions while this array is non-empty, so
+  // asking for them has to allocate it. Unlike dump_xyz this is done only when the quantity was
+  // requested, so that a run that does not ask for it does not pay for the unwrapping.
+  if (quantities_.has_unwrapped_position_) {
+    if (atom.unwrapped_position.size() < atom.number_of_atoms * 3) {
+      atom.unwrapped_position.resize(atom.number_of_atoms * 3);
+      atom.unwrapped_position.copy_from_device(atom.position_per_atom.data());
+    }
+    if (atom.position_temp.size() < atom.number_of_atoms * 3) {
+      atom.position_temp.resize(atom.number_of_atoms * 3);
+    }
+  }
+
   property_name = "dump_netcdf";
 }
 
 void DUMP_NETCDF::parse(const char** param, int num_param, const std::vector<Group>& groups)
 {
   dump_ = true;
-  printf("Dump positions and optional velocities in NetCDF format.\n");
+  printf("Dump per-atom data in NetCDF format.\n");
 
   if (num_param < 3) {
     PRINT_INPUT_ERROR("dump_netcdf should have at least 2 parameters.\n");
@@ -115,8 +290,9 @@ void DUMP_NETCDF::parse(const char** param, int num_param, const std::vector<Gro
   filename_ = param[2];
   printf("    into file %s.\n", filename_.c_str());
 
+  number_of_grouping_methods_ = groups.size();
+
   bool group_seen = false;
-  bool velocity_seen = false;
   bool precision_seen = false;
   bool compression_seen = false;
   for (int k = 3; k < num_param; k++) {
@@ -135,13 +311,6 @@ void DUMP_NETCDF::parse(const char** param, int num_param, const std::vector<Gro
         PRINT_INPUT_ERROR("dump_netcdf cannot output an empty group.");
       }
       group_seen = true;
-    } else if (strcmp(param[k], "velocity") == 0) {
-      if (velocity_seen) {
-        PRINT_INPUT_ERROR("Quantity 'velocity' is specified more than once in dump_netcdf.\n");
-      }
-      has_velocity_ = 1;
-      velocity_seen = true;
-      printf("    with velocity data.\n");
     } else if (strcmp(param[k], "precision") == 0) {
       if (precision_seen) {
         PRINT_INPUT_ERROR("Option 'precision' is specified more than once in dump_netcdf.\n");
@@ -175,16 +344,34 @@ void DUMP_NETCDF::parse(const char** param, int num_param, const std::vector<Gro
         PRINT_INPUT_ERROR("Compression should be 'none' or 'deflate <0-9>'.\n");
       }
       compression_seen = true;
-    } else {
+    } else if (!parse_dump_quantity(param[k], quantities_, is_nep_charge_, groups, "dump_netcdf")) {
       PRINT_INPUT_ERROR("Unrecognized argument in dump_netcdf.\n");
+    }
+  }
+
+  // A canonical listing of what was requested, independent of the order the arguments came in.
+  // It goes into the file as the gpumd_quantities attribute and is what appending compares.
+  const std::pair<bool, const char*> quantity_names[] = {
+    {quantities_.has_velocity_, "velocity"},
+    {quantities_.has_force_, "force"},
+    {quantities_.has_potential_, "potential"},
+    {quantities_.has_unwrapped_position_, "unwrapped_position"},
+    {quantities_.has_mass_, "mass"},
+    {quantities_.has_charge_, "charge"},
+    {quantities_.has_bec_, "bec"},
+    {quantities_.has_virial_, "virial"},
+    {quantities_.has_group_, "group_labels"}};
+  for (const auto& quantity : quantity_names) {
+    if (quantity.first) {
+      if (!quantity_list_.empty()) {
+        quantity_list_ += " ";
+      }
+      quantity_list_ += quantity.second;
     }
   }
 
   if (!group_seen) {
     printf("    for the whole system.\n");
-  }
-  if (!has_velocity_) {
-    printf("    without velocity data.\n");
   }
   if (precision_ == 1) {
     printf("    using single precision for NetCDF output.\n");
@@ -210,31 +397,50 @@ void DUMP_NETCDF::preprocess(
   }
   active_files_.push_back(filename_);
 
+  // The atoms of the output, in the order they are written. Group membership does not change
+  // during a run, so this is built once and then serves both the grouped and the whole-system
+  // case, which lets every quantity share one packing path.
   if (grouping_method_ < 0) {
     number_of_atoms_to_dump_ = atom.number_of_atoms;
+    dump_indices_.resize(number_of_atoms_to_dump_);
+    for (int n = 0; n < number_of_atoms_to_dump_; ++n) {
+      dump_indices_[n] = n;
+    }
   } else {
     const Group& selected_group = group[grouping_method_];
     number_of_atoms_to_dump_ = selected_group.cpu_size[group_id_];
-    cpu_type_to_dump_.resize(number_of_atoms_to_dump_);
-    group_position_.resize(number_of_atoms_to_dump_ * 3);
-    cpu_group_position_.resize(number_of_atoms_to_dump_ * 3);
-    if (has_velocity_) {
-      group_velocity_.resize(number_of_atoms_to_dump_ * 3);
-      cpu_group_velocity_.resize(number_of_atoms_to_dump_ * 3);
+    const int group_offset = selected_group.cpu_size_sum[group_id_];
+    dump_indices_.resize(number_of_atoms_to_dump_);
+    for (int n = 0; n < number_of_atoms_to_dump_; ++n) {
+      dump_indices_[n] = selected_group.cpu_contents[group_offset + n];
     }
   }
+  cpu_type_to_dump_.resize(number_of_atoms_to_dump_);
 
-  const size_t frame_values = size_t(number_of_atoms_to_dump_) * 3;
+  // one variable of one frame at a time, so nine components per atom is the widest case
+  const size_t pack_values = size_t(number_of_atoms_to_dump_) * 9;
   if (precision_ == 1) {
-    cpu_position_float_.resize(frame_values);
-    if (has_velocity_) {
-      cpu_velocity_float_.resize(frame_values);
-    }
+    pack_float_.resize(pack_values);
   } else {
-    cpu_position_double_.resize(frame_values);
-    if (has_velocity_) {
-      cpu_velocity_double_.resize(frame_values);
-    }
+    pack_double_.resize(pack_values);
+  }
+
+  // host copies of the arrays Atom does not already keep on the host, sized for the whole
+  // system since that is what is copied back from the device
+  if (quantities_.has_force_) {
+    cpu_force_per_atom_.resize(atom.number_of_atoms * 3);
+  }
+  if (quantities_.has_potential_) {
+    cpu_potential_per_atom_.resize(atom.number_of_atoms);
+  }
+  if (quantities_.has_unwrapped_position_) {
+    cpu_unwrapped_position_.resize(atom.number_of_atoms * 3);
+  }
+  if (quantities_.has_virial_) {
+    cpu_virial_per_atom_.resize(atom.number_of_atoms * 9);
+  }
+  if (quantities_.has_bec_) {
+    cpu_bec_.resize(atom.number_of_atoms * 9);
   }
 
   const bool initialized =
@@ -246,12 +452,39 @@ void DUMP_NETCDF::preprocess(
     validate_file_definition();
     NC_CHECK(nc_inq_dimlen(ncid, frame_dim, &lenp));
   } else {
-    create_file();
+    create_file(group, atom);
     initialized_files_.push_back(filename_);
   }
 }
 
-void DUMP_NETCDF::create_file()
+// Defines one per-atom variable of the trajectory. `rank` is 2 for a scalar, 3 for a vector and
+// 4 for a rank-2 tensor, and `values_per_atom` the matching 1, 3 or 9, used to size the chunks.
+void DUMP_NETCDF::define_per_frame_variable(
+  const char* name, const int rank, const int values_per_atom, const char* units, int& var)
+{
+  const int dimids[4] = {frame_dim, atom_dim, spatial_dim, spatial_dim};
+  const nc_type type = precision_ == 1 ? NC_FLOAT : NC_DOUBLE;
+  NC_CHECK(nc_def_var(ncid, name, type, rank, dimids, &var));
+  if (units != nullptr) {
+    NC_CHECK(nc_put_att_text(ncid, var, UNITS_STR, strlen(units), units));
+  }
+  if (compression_level_ >= 0) {
+#if defined(NC_HAS_HDF5) && NC_HAS_HDF5
+    const size_t bytes_per_value = precision_ == 1 ? sizeof(float) : sizeof(double);
+    const size_t target_chunk_bytes = 1024 * 1024;
+    const size_t max_chunk_atoms =
+      std::max<size_t>(1, target_chunk_bytes / (bytes_per_value * values_per_atom));
+    size_t chunks[4] = {1, std::min<size_t>(number_of_atoms_to_dump_, max_chunk_atoms), 3, 3};
+    NC_CHECK(nc_def_var_chunking(ncid, var, NC_CHUNKED, chunks));
+    NC_CHECK(nc_def_var_deflate(ncid, var, 1, 1, compression_level_));
+#endif // NC_HAS_HDF5
+#if !(defined(NC_HAS_HDF5) && NC_HAS_HDF5)
+    (void)values_per_atom;
+#endif
+  }
+}
+
+void DUMP_NETCDF::create_file(const std::vector<Group>& groups, const Atom& atom)
 {
   const int creation_mode = compression_level_ >= 0 ? NC_NETCDF4 : NC_64BIT_OFFSET;
   const int create_status = nc_create(filename_.c_str(), creation_mode, &ncid);
@@ -273,7 +506,8 @@ void DUMP_NETCDF::create_file()
   NC_CHECK(nc_put_att_text(ncid, NC_GLOBAL, "ConventionVersion", 3, "1.0"));
   NC_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "gpumd_grouping_method", NC_INT, 1, &grouping_method_));
   NC_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "gpumd_group_id", NC_INT, 1, &group_id_));
-  NC_CHECK(nc_put_att_int(ncid, NC_GLOBAL, "gpumd_has_velocity", NC_INT, 1, &has_velocity_));
+  NC_CHECK(nc_put_att_text(
+    ncid, NC_GLOBAL, "gpumd_quantities", quantity_list_.size(), quantity_list_.c_str()));
   NC_CHECK(
     nc_put_att_int(ncid, NC_GLOBAL, "gpumd_compression_level", NC_INT, 1, &compression_level_));
 
@@ -285,6 +519,10 @@ void DUMP_NETCDF::create_file()
   NC_CHECK(nc_def_dim(ncid, CELL_SPATIAL_STR, 3, &cell_spatial_dim)); // unitcell lengths
   NC_CHECK(nc_def_dim(ncid, CELL_ANGULAR_STR, 3, &cell_angular_dim)); // unitcell angles
   NC_CHECK(nc_def_dim(ncid, LABEL_STR, 10, &label_dim));              // needed for cell_angular
+  if (quantities_.has_group_) {
+    NC_CHECK(
+      nc_def_dim(ncid, GROUPING_METHOD_STR, number_of_grouping_methods_, &grouping_method_dim));
+  }
 
   // Label variables
   int dimids[3];
@@ -304,54 +542,65 @@ void DUMP_NETCDF::create_file()
   dimids[1] = cell_angular_dim;
   NC_CHECK(nc_def_var(ncid, CELL_ANGLES_STR, NC_DOUBLE, 2, dimids, &cell_angles_var));
 
-  // More extensive data variables (type, coordinates, velocities)
+  // Units of the cell and time variables
+  NC_CHECK(nc_put_att_text(ncid, time_var, UNITS_STR, 10, "picosecond"));
+  NC_CHECK(nc_put_att_text(ncid, cell_lengths_var, UNITS_STR, 8, "angstrom"));
+  NC_CHECK(nc_put_att_text(ncid, cell_angles_var, UNITS_STR, 6, "degree"));
+
+  // Per-atom data variables. The type is written per frame, as it always has been; the
+  // quantities that cannot change during a run are defined further down without a frame
+  // dimension, so that they are stored once rather than repeated every frame.
   dimids[0] = frame_dim;
   dimids[1] = atom_dim;
-  dimids[2] = spatial_dim;
-
-  if (precision_ == 1) // single precision
-  {
-    NC_CHECK(nc_def_var(ncid, COORDINATES_STR, NC_FLOAT, 3, dimids, &coordinates_var));
-    if (has_velocity_) {
-      NC_CHECK(nc_def_var(ncid, VELOCITIES_STR, NC_FLOAT, 3, dimids, &velocities_var));
-    }
-  } else {
-    NC_CHECK(nc_def_var(ncid, COORDINATES_STR, NC_DOUBLE, 3, dimids, &coordinates_var));
-    if (has_velocity_) {
-      NC_CHECK(nc_def_var(ncid, VELOCITIES_STR, NC_DOUBLE, 3, dimids, &velocities_var));
-    }
-  }
   NC_CHECK(nc_def_var(ncid, TYPE_STR, NC_INT, 2, dimids, &type_var));
-
   if (compression_level_ >= 0) {
 #if defined(NC_HAS_HDF5) && NC_HAS_HDF5
-    const size_t bytes_per_value = precision_ == 1 ? sizeof(float) : sizeof(double);
-    const size_t target_chunk_bytes = 1024 * 1024;
-    const size_t max_chunk_atoms = std::max<size_t>(1, target_chunk_bytes / (bytes_per_value * 3));
-    size_t chunks[3] = {1, std::min<size_t>(number_of_atoms_to_dump_, max_chunk_atoms), 3};
-    NC_CHECK(nc_def_var_chunking(ncid, coordinates_var, NC_CHUNKED, chunks));
-    NC_CHECK(nc_def_var_deflate(ncid, coordinates_var, 1, 1, compression_level_));
-    if (has_velocity_) {
-      NC_CHECK(nc_def_var_chunking(ncid, velocities_var, NC_CHUNKED, chunks));
-      NC_CHECK(nc_def_var_deflate(ncid, velocities_var, 1, 1, compression_level_));
-    }
     size_t type_chunks[2] = {
-      1, std::min<size_t>(number_of_atoms_to_dump_, target_chunk_bytes / sizeof(int))};
+      1, std::min<size_t>(number_of_atoms_to_dump_, (1024 * 1024) / sizeof(int))};
     NC_CHECK(nc_def_var_chunking(ncid, type_var, NC_CHUNKED, type_chunks));
     NC_CHECK(nc_def_var_deflate(ncid, type_var, 1, 1, compression_level_));
 #endif // NC_HAS_HDF5
   }
 
-  // Units
-  NC_CHECK(nc_put_att_text(ncid, time_var, UNITS_STR, 10, "picosecond"));
-  NC_CHECK(nc_put_att_text(ncid, cell_lengths_var, UNITS_STR, 8, "angstrom"));
-  NC_CHECK(nc_put_att_text(ncid, coordinates_var, UNITS_STR, 8, "angstrom"));
-  NC_CHECK(nc_put_att_text(ncid, cell_angles_var, UNITS_STR, 6, "degree"));
-
-  if (has_velocity_) {
-    NC_CHECK(nc_put_att_text(
-      ncid, velocities_var, UNITS_STR, 19, "angstrom/picosecond")); // AMBER conventions
+  define_per_frame_variable(COORDINATES_STR, 3, 3, "angstrom", coordinates_var);
+  if (quantities_.has_velocity_) {
+    // AMBER conventions
+    define_per_frame_variable(VELOCITIES_STR, 3, 3, "angstrom/picosecond", velocities_var);
   }
+  if (quantities_.has_force_) {
+    define_per_frame_variable(FORCES_STR, 3, 3, "eV/angstrom", forces_var);
+  }
+  if (quantities_.has_unwrapped_position_) {
+    define_per_frame_variable(
+      UNWRAPPED_COORDINATES_STR, 3, 3, "angstrom", unwrapped_coordinates_var);
+  }
+  if (quantities_.has_potential_) {
+    define_per_frame_variable(POTENTIAL_STR, 2, 1, "eV", potential_var);
+  }
+  if (quantities_.has_charge_) {
+    define_per_frame_variable(CHARGE_STR, 2, 1, "e", charge_var);
+  }
+  if (quantities_.has_bec_) {
+    define_per_frame_variable(BEC_STR, 4, 9, "e", bec_var);
+  }
+  if (quantities_.has_virial_) {
+    define_per_frame_variable(VIRIAL_STR, 4, 9, "eV", virial_var);
+  }
+
+  // Quantities that are constant over the run. They are written once and left uncompressed,
+  // being one copy rather than one per frame.
+  const nc_type per_atom_type = precision_ == 1 ? NC_FLOAT : NC_DOUBLE;
+  if (quantities_.has_mass_) {
+    dimids[0] = atom_dim;
+    NC_CHECK(nc_def_var(ncid, MASS_STR, per_atom_type, 1, dimids, &mass_var));
+    NC_CHECK(nc_put_att_text(ncid, mass_var, UNITS_STR, 3, "amu"));
+  }
+  if (quantities_.has_group_) {
+    dimids[0] = atom_dim;
+    dimids[1] = grouping_method_dim;
+    NC_CHECK(nc_def_var(ncid, GROUP_LABELS_STR, NC_INT, 2, dimids, &group_labels_var));
+  }
+
   // Definitions are complete -> leave define mode
   NC_CHECK(nc_enddef(ncid));
 
@@ -369,7 +618,39 @@ void DUMP_NETCDF::create_file()
   startp[0] = 2;
   countp[1] = 5;
   NC_CHECK(nc_put_vara_text(ncid, cell_angular_var, startp, countp, "gamma"));
+
+  // The constant quantities, written once now rather than once per frame
+  if (quantities_.has_mass_) {
+    pack_scalar_by_precision(precision_, dump_indices_, atom.cpu_mass, pack_float_, pack_double_);
+    const size_t mass_start[1] = {0};
+    const size_t mass_count[1] = {size_t(number_of_atoms_to_dump_)};
+    put_packed(mass_var, mass_start, mass_count);
+  }
+  if (quantities_.has_group_) {
+    cpu_group_labels_.resize(size_t(number_of_atoms_to_dump_) * number_of_grouping_methods_);
+    for (int n = 0; n < number_of_atoms_to_dump_; ++n) {
+      for (int m = 0; m < number_of_grouping_methods_; ++m) {
+        cpu_group_labels_[n * number_of_grouping_methods_ + m] =
+          groups[m].cpu_label[dump_indices_[n]];
+      }
+    }
+    const size_t label_start[2] = {0, 0};
+    const size_t label_count[2] = {
+      size_t(number_of_atoms_to_dump_), size_t(number_of_grouping_methods_)};
+    NC_CHECK(
+      nc_put_vara_int(ncid, group_labels_var, label_start, label_count, cpu_group_labels_.data()));
+  }
+
   lenp = 0;
+}
+
+void DUMP_NETCDF::put_packed(const int var, const size_t* start, const size_t* count)
+{
+  if (precision_ == 1) {
+    NC_CHECK(nc_put_vara_float(ncid, var, start, count, pack_float_.data()));
+  } else {
+    NC_CHECK(nc_put_vara_double(ncid, var, start, count, pack_double_.data()));
+  }
 }
 
 void DUMP_NETCDF::load_file_definition()
@@ -407,23 +688,48 @@ void DUMP_NETCDF::validate_file_definition()
 
   int previous_grouping_method;
   int previous_group_id;
-  int previous_has_velocity;
   int previous_compression_level;
   NC_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "gpumd_grouping_method", &previous_grouping_method));
   NC_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "gpumd_group_id", &previous_group_id));
-  NC_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "gpumd_has_velocity", &previous_has_velocity));
   NC_CHECK(nc_get_att_int(ncid, NC_GLOBAL, "gpumd_compression_level", &previous_compression_level));
   if (previous_grouping_method != grouping_method_ || previous_group_id != group_id_) {
     PRINT_INPUT_ERROR("Cannot change the dump_netcdf group between run commands.\n");
   }
-  if (previous_has_velocity != has_velocity_) {
-    PRINT_INPUT_ERROR("Cannot change dump_netcdf velocity output between run commands.\n");
-  }
-  if (has_velocity_) {
-    NC_CHECK(nc_inq_varid(ncid, VELOCITIES_STR, &velocities_var));
-  }
   if (previous_compression_level != compression_level_) {
     PRINT_INPUT_ERROR("Cannot change dump_netcdf compression between run commands.\n");
+  }
+
+  // One attribute covers every quantity, so the whole set is compared at once rather than one
+  // flag at a time.
+  size_t previous_length = 0;
+  NC_CHECK(nc_inq_attlen(ncid, NC_GLOBAL, "gpumd_quantities", &previous_length));
+  std::string previous_quantities(previous_length, '\0');
+  NC_CHECK(nc_get_att_text(ncid, NC_GLOBAL, "gpumd_quantities", &previous_quantities[0]));
+  if (previous_quantities != quantity_list_) {
+    PRINT_INPUT_ERROR("Cannot change the dump_netcdf quantities between run commands.\n");
+  }
+
+  // The quantities match, so every variable they call for is in the file.
+  if (quantities_.has_velocity_) {
+    NC_CHECK(nc_inq_varid(ncid, VELOCITIES_STR, &velocities_var));
+  }
+  if (quantities_.has_force_) {
+    NC_CHECK(nc_inq_varid(ncid, FORCES_STR, &forces_var));
+  }
+  if (quantities_.has_unwrapped_position_) {
+    NC_CHECK(nc_inq_varid(ncid, UNWRAPPED_COORDINATES_STR, &unwrapped_coordinates_var));
+  }
+  if (quantities_.has_potential_) {
+    NC_CHECK(nc_inq_varid(ncid, POTENTIAL_STR, &potential_var));
+  }
+  if (quantities_.has_charge_) {
+    NC_CHECK(nc_inq_varid(ncid, CHARGE_STR, &charge_var));
+  }
+  if (quantities_.has_bec_) {
+    NC_CHECK(nc_inq_varid(ncid, BEC_STR, &bec_var));
+  }
+  if (quantities_.has_virial_) {
+    NC_CHECK(nc_inq_varid(ncid, VIRIAL_STR, &virial_var));
   }
 }
 
@@ -486,55 +792,15 @@ static bool build_netcdf_transform(
   return transform_vectors;
 }
 
-template <typename T>
-static void pack_netcdf_frame(
-  const int number_of_atoms,
-  const bool has_velocity,
-  const bool transform_vectors,
-  const double transform[9],
-  const double velocity_scale,
-  const std::vector<double>& position,
-  const std::vector<double>& velocity,
-  std::vector<T>& packed_position,
-  std::vector<T>& packed_velocity)
+void DUMP_NETCDF::write(const double global_time, const Box& box, const Atom& atom)
 {
-  for (int i = 0; i < number_of_atoms; ++i) {
-    for (int output_dim = 0; output_dim < 3; ++output_dim) {
-      double position_value = position[i + number_of_atoms * output_dim];
-      double velocity_value = has_velocity ? velocity[i + number_of_atoms * output_dim] : 0.0;
-      if (transform_vectors) {
-        position_value = 0.0;
-        velocity_value = 0.0;
-        for (int input_dim = 0; input_dim < 3; ++input_dim) {
-          const double coefficient = transform[output_dim * 3 + input_dim];
-          position_value += coefficient * position[i + number_of_atoms * input_dim];
-          if (has_velocity) {
-            velocity_value += coefficient * velocity[i + number_of_atoms * input_dim];
-          }
-        }
-      }
-      packed_position[i * 3 + output_dim] = static_cast<T>(position_value);
-      if (has_velocity) {
-        packed_velocity[i * 3 + output_dim] = static_cast<T>(velocity_value * velocity_scale);
-      }
-    }
-  }
-}
-
-void DUMP_NETCDF::write(
-  const double global_time,
-  const Box& box,
-  const std::vector<int>& cpu_type,
-  const std::vector<double>& cpu_position_per_atom,
-  const std::vector<double>& cpu_velocity_per_atom)
-{
-  const int number_of_atoms = number_of_atoms_to_dump_;
+  const int number_of_atoms = atom.number_of_atoms;
+  const int number_to_dump = number_of_atoms_to_dump_;
 
   double cell_lengths[3];
   double cell_angles[3];
   double cell_transform[9];
-  const bool transform_vectors =
-    build_netcdf_transform(box, cell_lengths, cell_angles, cell_transform);
+  const bool rotate = build_netcdf_transform(box, cell_lengths, cell_angles, cell_transform);
 
   // Set lengths to 0 if PBC is off
   if (!box.pbc_x)
@@ -552,50 +818,107 @@ void DUMP_NETCDF::write(
   NC_CHECK(nc_put_vara_double(ncid, cell_lengths_var, cell_start, cell_count, cell_lengths));
   NC_CHECK(nc_put_vara_double(ncid, cell_angles_var, cell_start, cell_count, cell_angles));
 
-  const double natural_to_A_per_ps =
-    1.0 / TIME_UNIT_CONVERSION * 1000.0; // * 1000 from A/fs to A/ps
   size_t atom_start[2] = {lenp, 0};
-  size_t atom_count[2] = {1, size_t(number_of_atoms)};
+  size_t atom_count[2] = {1, size_t(number_to_dump)};
   size_t vector_start[3] = {lenp, 0, 0};
-  size_t vector_count[3] = {1, size_t(number_of_atoms), 3};
-  NC_CHECK(nc_put_vara_int(ncid, type_var, atom_start, atom_count, cpu_type.data()));
+  size_t vector_count[3] = {1, size_t(number_to_dump), 3};
+  size_t tensor_start[4] = {lenp, 0, 0, 0};
+  size_t tensor_count[4] = {1, size_t(number_to_dump), 3, 3};
 
-  if (precision_ == 1) // single precision
-  {
-    pack_netcdf_frame(
-      number_of_atoms,
-      has_velocity_,
-      transform_vectors,
-      cell_transform,
-      natural_to_A_per_ps,
-      cpu_position_per_atom,
-      cpu_velocity_per_atom,
-      cpu_position_float_,
-      cpu_velocity_float_);
-    NC_CHECK(nc_put_vara_float(
-      ncid, coordinates_var, vector_start, vector_count, cpu_position_float_.data()));
-    if (has_velocity_) {
-      NC_CHECK(nc_put_vara_float(
-        ncid, velocities_var, vector_start, vector_count, cpu_velocity_float_.data()));
-    }
-  } else {
-    pack_netcdf_frame(
-      number_of_atoms,
-      has_velocity_,
-      transform_vectors,
-      cell_transform,
-      natural_to_A_per_ps,
-      cpu_position_per_atom,
-      cpu_velocity_per_atom,
-      cpu_position_double_,
-      cpu_velocity_double_);
-    NC_CHECK(nc_put_vara_double(
-      ncid, coordinates_var, vector_start, vector_count, cpu_position_double_.data()));
-    if (has_velocity_) {
-      NC_CHECK(nc_put_vara_double(
-        ncid, velocities_var, vector_start, vector_count, cpu_velocity_double_.data()));
-    }
+  for (int n = 0; n < number_to_dump; ++n) {
+    cpu_type_to_dump_[n] = atom.cpu_type[dump_indices_[n]];
   }
+  NC_CHECK(nc_put_vara_int(ncid, type_var, atom_start, atom_count, cpu_type_to_dump_.data()));
+
+  pack_vector_by_precision(
+    precision_,
+    dump_indices_,
+    number_of_atoms,
+    rotate,
+    cell_transform,
+    1.0,
+    atom.cpu_position_per_atom,
+    pack_float_,
+    pack_double_);
+  put_packed(coordinates_var, vector_start, vector_count);
+
+  if (quantities_.has_velocity_) {
+    const double natural_to_A_per_ps =
+      1.0 / TIME_UNIT_CONVERSION * 1000.0; // * 1000 from A/fs to A/ps
+    pack_vector_by_precision(
+      precision_,
+      dump_indices_,
+      number_of_atoms,
+      rotate,
+      cell_transform,
+      natural_to_A_per_ps,
+      atom.cpu_velocity_per_atom,
+      pack_float_,
+      pack_double_);
+    put_packed(velocities_var, vector_start, vector_count);
+  }
+  if (quantities_.has_force_) {
+    pack_vector_by_precision(
+      precision_,
+      dump_indices_,
+      number_of_atoms,
+      rotate,
+      cell_transform,
+      1.0,
+      cpu_force_per_atom_,
+      pack_float_,
+      pack_double_);
+    put_packed(forces_var, vector_start, vector_count);
+  }
+  if (quantities_.has_unwrapped_position_) {
+    pack_vector_by_precision(
+      precision_,
+      dump_indices_,
+      number_of_atoms,
+      rotate,
+      cell_transform,
+      1.0,
+      cpu_unwrapped_position_,
+      pack_float_,
+      pack_double_);
+    put_packed(unwrapped_coordinates_var, vector_start, vector_count);
+  }
+  if (quantities_.has_potential_) {
+    pack_scalar_by_precision(
+      precision_, dump_indices_, cpu_potential_per_atom_, pack_float_, pack_double_);
+    put_packed(potential_var, atom_start, atom_count);
+  }
+  if (quantities_.has_charge_) {
+    pack_scalar_by_precision(precision_, dump_indices_, atom.cpu_charge, pack_float_, pack_double_);
+    put_packed(charge_var, atom_start, atom_count);
+  }
+  if (quantities_.has_bec_) {
+    pack_tensor_by_precision(
+      precision_,
+      dump_indices_,
+      number_of_atoms,
+      rotate,
+      cell_transform,
+      ROW_MAJOR_COMPONENT,
+      cpu_bec_,
+      pack_float_,
+      pack_double_);
+    put_packed(bec_var, tensor_start, tensor_count);
+  }
+  if (quantities_.has_virial_) {
+    pack_tensor_by_precision(
+      precision_,
+      dump_indices_,
+      number_of_atoms,
+      rotate,
+      cell_transform,
+      VIRIAL_COMPONENT,
+      cpu_virial_per_atom_,
+      pack_float_,
+      pack_double_);
+    put_packed(virial_var, tensor_start, tensor_count);
+  }
+
   ++lenp;
 }
 
@@ -614,29 +937,6 @@ void DUMP_NETCDF::postprocess(
     const auto active_file = std::find(active_files_.begin(), active_files_.end(), filename_);
     if (active_file != active_files_.end()) {
       active_files_.erase(active_file);
-    }
-  }
-}
-
-static __global__ void gather_netcdf_group(
-  const int number_of_atoms_in_group,
-  const int number_of_atoms,
-  const int group_offset,
-  const int* group_contents,
-  const double* position,
-  const double* velocity,
-  double* group_position,
-  double* group_velocity)
-{
-  const int n = blockIdx.x * blockDim.x + threadIdx.x;
-  if (n < number_of_atoms_in_group) {
-    const int atom_index = group_contents[group_offset + n];
-    for (int d = 0; d < 3; ++d) {
-      group_position[n + number_of_atoms_in_group * d] = position[atom_index + number_of_atoms * d];
-      if (group_velocity != nullptr) {
-        group_velocity[n + number_of_atoms_in_group * d] =
-          velocity[atom_index + number_of_atoms * d];
-      }
     }
   }
 }
@@ -660,41 +960,38 @@ void DUMP_NETCDF::process(
   if ((step + 1) % interval_ != 0)
     return;
 
-  const std::vector<double>* cpu_position = &atom.cpu_position_per_atom;
-  const std::vector<double>* cpu_velocity = &atom.cpu_velocity_per_atom;
-  const std::vector<int>* cpu_type = &atom.cpu_type;
-  if (grouping_method_ < 0) {
-    atom.position_per_atom.copy_to_host(atom.cpu_position_per_atom.data());
-    if (has_velocity_) {
-      atom.velocity_per_atom.copy_to_host(atom.cpu_velocity_per_atom.data());
+  // Copy back what was asked for, in full. Selecting the group happens on the host while
+  // packing, through dump_indices_, which is one path for the grouped and the whole-system case.
+  atom.position_per_atom.copy_to_host(atom.cpu_position_per_atom.data());
+  if (quantities_.has_velocity_) {
+    atom.velocity_per_atom.copy_to_host(atom.cpu_velocity_per_atom.data());
+  }
+  if (quantities_.has_force_) {
+    atom.force_per_atom.copy_to_host(cpu_force_per_atom_.data());
+  }
+  if (quantities_.has_potential_) {
+    atom.potential_per_atom.copy_to_host(cpu_potential_per_atom_.data());
+  }
+  if (quantities_.has_unwrapped_position_) {
+    atom.unwrapped_position.copy_to_host(cpu_unwrapped_position_.data());
+  }
+  if (quantities_.has_virial_) {
+    atom.virial_per_atom.copy_to_host(cpu_virial_per_atom_.data());
+  }
+  if (quantities_.has_charge_) {
+    if (is_nep_charge_) {
+      GPU_Vector<float>& nep_charge = force.potentials[0]->get_charge_reference();
+      nep_charge.copy_to_host(atom.cpu_charge.data());
+    } else {
+      atom.charge.copy_to_host(atom.cpu_charge.data());
     }
-  } else {
-    const Group& selected_group = group[grouping_method_];
-    const int group_offset = selected_group.cpu_size_sum[group_id_];
-    gather_netcdf_group<<<(number_of_atoms_to_dump_ - 1) / 128 + 1, 128>>>(
-      number_of_atoms_to_dump_,
-      atom.number_of_atoms,
-      group_offset,
-      selected_group.contents.data(),
-      atom.position_per_atom.data(),
-      has_velocity_ ? atom.velocity_per_atom.data() : nullptr,
-      group_position_.data(),
-      has_velocity_ ? group_velocity_.data() : nullptr);
-    GPU_CHECK_KERNEL
-    group_position_.copy_to_host(cpu_group_position_.data());
-    if (has_velocity_) {
-      group_velocity_.copy_to_host(cpu_group_velocity_.data());
-    }
-    for (int n = 0; n < number_of_atoms_to_dump_; ++n) {
-      const int atom_index = selected_group.cpu_contents[group_offset + n];
-      cpu_type_to_dump_[n] = atom.cpu_type[atom_index];
-    }
-    cpu_position = &cpu_group_position_;
-    cpu_velocity = &cpu_group_velocity_;
-    cpu_type = &cpu_type_to_dump_;
+  }
+  if (quantities_.has_bec_) {
+    GPU_Vector<float>& gpu_bec = force.potentials[0]->get_bec_reference();
+    gpu_bec.copy_to_host(cpu_bec_.data());
   }
 
-  write(global_time, box, *cpu_type, *cpu_position, *cpu_velocity);
+  write(global_time, box, atom);
 }
 
 #endif

--- a/src/measure/dump_netcdf.cuh
+++ b/src/measure/dump_netcdf.cuh
@@ -70,6 +70,7 @@ private:
   int precision_ = 1;          // 1 = single precision, 2 = double
   int compression_level_ = -1; // -1 = classic NetCDF, 0-9 = NetCDF4 deflate
   int number_of_atoms_to_dump_ = 0;
+  int number_of_atoms_ = 0;
   int number_of_grouping_methods_ = 0;
   DumpQuantities quantities_;
   std::string filename_;
@@ -77,18 +78,23 @@ private:
   // compared against when appending
   std::string quantity_list_;
 
-  // maps an atom of the output to its index in the full system, so that the grouped and the
-  // whole-system cases share one packing path
+  // maps an atom of the output to its index in the full system. Used for the quantities that are
+  // host-resident anyway, namely the types, the masses and the group labels, and uploaded to the
+  // device to drive the gather for everything else.
   std::vector<int> dump_indices_;
 
-  // host copies of the per-atom arrays that Atom does not already keep on the host
-  std::vector<double> cpu_force_per_atom_;
-  std::vector<double> cpu_potential_per_atom_;
-  std::vector<double> cpu_unwrapped_position_;
-  std::vector<double> cpu_virial_per_atom_;
-  std::vector<float> cpu_bec_;
   std::vector<int> cpu_type_to_dump_;
   std::vector<int> cpu_group_labels_;
+
+  // Staging for one quantity of one frame, holding only the atoms that are written. When a group
+  // is selected its values are gathered into the device buffer first, so that the copy across the
+  // bus is the size of the group rather than of the system. One buffer per element type is enough,
+  // since the quantities are staged and written one at a time.
+  GPU_Vector<int> gpu_dump_indices_;
+  GPU_Vector<double> gather_double_;
+  GPU_Vector<float> gather_float_;
+  std::vector<double> host_double_;
+  std::vector<float> host_float_;
 
   // scratch for one variable of one frame, in the element type the file uses; only the one
   // matching precision_ is allocated
@@ -137,7 +143,10 @@ private:
   void validate_file_definition();
   void append_mismatch(const char* what);
   void put_packed(const int var, const size_t* start, const size_t* count);
-  void write(const double global_time, const Box& box, const Atom& atom);
+  template <typename T>
+  void
+  stage(GPU_Vector<T>& source, const int components, GPU_Vector<T>& scratch, std::vector<T>& host);
+  void write(const double global_time, const Box& box, Atom& atom, Force& force);
 };
 
 #endif

--- a/src/measure/dump_netcdf.cuh
+++ b/src/measure/dump_netcdf.cuh
@@ -96,7 +96,6 @@ private:
   std::vector<double> pack_double_;
 
   int ncid = -1; // NetCDF ID
-  static std::vector<std::string> initialized_files_;
   static std::vector<std::string> active_files_;
 
   // dimensions
@@ -136,6 +135,7 @@ private:
     const char* name, const int rank, const int values_per_atom, const char* units, int& var);
   void load_file_definition();
   void validate_file_definition();
+  void append_mismatch(const char* what);
   void put_packed(const int var, const size_t* start, const size_t* count);
   void write(const double global_time, const Box& box, const Atom& atom);
 };

--- a/src/measure/dump_netcdf.cuh
+++ b/src/measure/dump_netcdf.cuh
@@ -16,17 +16,19 @@
 #ifdef USE_NETCDF
 
 #pragma once
+#include "parse_utilities.cuh"
 #include "property.cuh"
 #include "utilities/gpu_vector.cuh"
 #include <string>
 #include <vector>
+class Atom;
 class Box;
 class Group;
 
 class DUMP_NETCDF : public Property
 {
 public:
-  DUMP_NETCDF(const char** param, int num_param, const std::vector<Group>& groups);
+  DUMP_NETCDF(const char** param, int num_param, const std::vector<Group>& groups, Atom& atom);
   void parse(const char** param, int num_param, const std::vector<Group>& groups);
   virtual void preprocess(
     const int number_of_steps,
@@ -38,18 +40,18 @@ public:
     Force& force);
 
   virtual void process(
-      const int number_of_steps,
-      int step,
-      const int fixed_group,
-      const int move_group,
-      const double global_time,
-      const double temperature,
-      Integrate& integrate,
-      Box& box,
-      std::vector<Group>& group,
-      GPU_Vector<double>& thermo,
-      Atom& atom,
-      Force& force);
+    const int number_of_steps,
+    int step,
+    const int fixed_group,
+    const int move_group,
+    const double global_time,
+    const double temperature,
+    Integrate& integrate,
+    Box& box,
+    std::vector<Group>& group,
+    GPU_Vector<double>& thermo,
+    Atom& atom,
+    Force& force);
 
   virtual void postprocess(
     Atom& atom,
@@ -61,24 +63,37 @@ public:
 
 private:
   bool dump_ = false;
+  bool is_nep_charge_ = false;
   int grouping_method_ = -1;
   int group_id_ = 0;
   int interval_ = 1;
-  int has_velocity_ = 0;
   int precision_ = 1;          // 1 = single precision, 2 = double
   int compression_level_ = -1; // -1 = classic NetCDF, 0-9 = NetCDF4 deflate
   int number_of_atoms_to_dump_ = 0;
+  int number_of_grouping_methods_ = 0;
+  DumpQuantities quantities_;
   std::string filename_;
+  // the requested quantities in a canonical order, stored in the file as gpumd_quantities and
+  // compared against when appending
+  std::string quantity_list_;
 
+  // maps an atom of the output to its index in the full system, so that the grouped and the
+  // whole-system cases share one packing path
+  std::vector<int> dump_indices_;
+
+  // host copies of the per-atom arrays that Atom does not already keep on the host
+  std::vector<double> cpu_force_per_atom_;
+  std::vector<double> cpu_potential_per_atom_;
+  std::vector<double> cpu_unwrapped_position_;
+  std::vector<double> cpu_virial_per_atom_;
+  std::vector<float> cpu_bec_;
   std::vector<int> cpu_type_to_dump_;
-  std::vector<double> cpu_group_position_;
-  std::vector<double> cpu_group_velocity_;
-  std::vector<float> cpu_position_float_;
-  std::vector<float> cpu_velocity_float_;
-  std::vector<double> cpu_position_double_;
-  std::vector<double> cpu_velocity_double_;
-  GPU_Vector<double> group_position_;
-  GPU_Vector<double> group_velocity_;
+  std::vector<int> cpu_group_labels_;
+
+  // scratch for one variable of one frame, in the element type the file uses; only the one
+  // matching precision_ is allocated
+  std::vector<float> pack_float_;
+  std::vector<double> pack_double_;
 
   int ncid = -1; // NetCDF ID
   static std::vector<std::string> initialized_files_;
@@ -91,6 +106,7 @@ private:
   int cell_spatial_dim;
   int cell_angular_dim;
   int label_dim;
+  int grouping_method_dim;
 
   // label variables
   int spatial_var;
@@ -102,20 +118,26 @@ private:
   int cell_lengths_var;
   int cell_angles_var;
   int coordinates_var;
-  int velocities_var;
   int type_var;
+  int velocities_var;
+  int forces_var;
+  int unwrapped_coordinates_var;
+  int potential_var;
+  int charge_var;
+  int bec_var;
+  int virial_var;
+  int mass_var;
+  int group_labels_var;
 
   size_t lenp; // frame number
 
-  void create_file();
+  void create_file(const std::vector<Group>& groups, const Atom& atom);
+  void define_per_frame_variable(
+    const char* name, const int rank, const int values_per_atom, const char* units, int& var);
   void load_file_definition();
   void validate_file_definition();
-  void write(
-    const double global_time,
-    const Box& box,
-    const std::vector<int>& cpu_type,
-    const std::vector<double>& cpu_position_per_atom,
-    const std::vector<double>& cpu_velocity_per_atom);
+  void put_packed(const int var, const size_t* start, const size_t* count);
+  void write(const double global_time, const Box& box, const Atom& atom);
 };
 
 #endif

--- a/src/measure/dump_xyz.cu
+++ b/src/measure/dump_xyz.cu
@@ -136,48 +136,7 @@ void Dump_XYZ::parse(const char** param, int num_param, const std::vector<Group>
       precision_seen = true;
       continue;
     }
-    if (strcmp(param[m], "velocity") == 0) {
-      quantities.has_velocity_ = true;
-      printf("    has velocity.\n");
-    } else if (strcmp(param[m], "force") == 0) {
-      quantities.has_force_ = true;
-      printf("    has force.\n");
-    } else if (strcmp(param[m], "potential") == 0) {
-      quantities.has_potential_ = true;
-      printf("    has potential.\n");
-    } else if (strcmp(param[m], "unwrapped_position") == 0) {
-      quantities.has_unwrapped_position_ = true;
-      printf("    has unwrapped position.\n");
-    } else if (strcmp(param[m], "mass") == 0) {
-      quantities.has_mass_ = true;
-      printf("    has mass.\n");
-    } else if (strcmp(param[m], "charge") == 0) {
-      quantities.has_charge_ = true;
-      if (is_nep_charge) {
-        printf("    has charge predicted by NEP-charge.\n");
-      } else {
-        printf("    has charge specified in model.xyz.\n");
-      }
-    } else if (strcmp(param[m], "bec") == 0) {
-      quantities.has_bec_ = true;
-      if (is_nep_charge) {
-        printf("    has BEC predicted by NEP-charge.\n");
-      } else {
-        PRINT_INPUT_ERROR("Cannot output BEC for a non-NEP-charge model.\n");
-      }
-    } else if (strcmp(param[m], "virial") == 0) {
-      quantities.has_virial_ = true;
-      printf("    has virial.\n");
-    } else if (strcmp(param[m], "group_labels") == 0) {
-      // One column is written per grouping method, so with none the Properties field would say
-      // group:I:0, which is not readable as extended XYZ.
-      if (groups.size() == 0) {
-        PRINT_INPUT_ERROR(
-          "Cannot output group labels without a grouping method defined in model.xyz.\n");
-      }
-      quantities.has_group_ = true;
-      printf("    has group labels.\n");
-    } else {
+    if (!parse_dump_quantity(param[m], quantities, is_nep_charge, groups, "dump_xyz")) {
       PRINT_INPUT_ERROR("Unrecognized argument in dump_xyz.\n");
     }
   }

--- a/src/measure/dump_xyz.cuh
+++ b/src/measure/dump_xyz.cuh
@@ -14,6 +14,7 @@
 */
 
 #pragma once
+#include "parse_utilities.cuh"
 #include "property.cuh"
 #include "utilities/gpu_vector.cuh"
 #include <string>
@@ -58,25 +59,13 @@ public:
     const double time_step,
     const double temperature);
 
-  struct Quantities {
-    bool has_velocity_ = false;
-    bool has_force_ = false;
-    bool has_potential_ = false;
-    bool has_unwrapped_position_ = false;
-    bool has_mass_ = false;
-    bool has_charge_ = false;
-    bool has_bec_ = false;
-    bool has_virial_ = false;
-    bool has_group_ = false;
-  };
-
 private:
   bool is_nep_charge = false;
   int grouping_method_ = -1;
   int group_id_ = -1;
   int dump_interval_ = 1;
   int precision_ = 1; // 1 = single precision, 2 = double
-  Quantities quantities;
+  DumpQuantities quantities;
   int separated_ = 0;
   std::string filename_;
   std::string fmt_;

--- a/src/measure/parse_utilities.cu
+++ b/src/measure/parse_utilities.cu
@@ -14,13 +14,14 @@
 */
 
 /*-----------------------------------------------------------------------------------------------100
-A function parsing the "group" option in some keywords
+Functions parsing the options and the per-atom quantities shared by several keywords
 --------------------------------------------------------------------------------------------------*/
 
 #include "model/group.cuh"
 #include "parse_utilities.cuh"
 #include "utilities/gpu_macro.cuh"
 #include "utilities/read_file.cuh"
+#include <cstdio>
 #include <cstring>
 
 void parse_group(
@@ -76,4 +77,74 @@ void parse_precision(const char** param, const int num_param, int& k, int& preci
     PRINT_INPUT_ERROR("Invalid precision.\n");
   }
   k++; // update index for next command
+}
+
+static void set_quantity(bool& flag, const char* token, const char* keyword)
+{
+  if (flag) {
+    char message[128];
+    snprintf(
+      message,
+      sizeof(message),
+      "Quantity '%s' is specified more than once in %s.\n",
+      token,
+      keyword);
+    PRINT_INPUT_ERROR(message);
+  }
+  flag = true;
+}
+
+bool parse_dump_quantity(
+  const char* token,
+  DumpQuantities& quantities,
+  const bool is_nep_charge,
+  const std::vector<Group>& groups,
+  const char* keyword)
+{
+  if (strcmp(token, "velocity") == 0) {
+    set_quantity(quantities.has_velocity_, token, keyword);
+    printf("    has velocity.\n");
+  } else if (strcmp(token, "force") == 0) {
+    set_quantity(quantities.has_force_, token, keyword);
+    printf("    has force.\n");
+  } else if (strcmp(token, "potential") == 0) {
+    set_quantity(quantities.has_potential_, token, keyword);
+    printf("    has potential.\n");
+  } else if (strcmp(token, "unwrapped_position") == 0) {
+    set_quantity(quantities.has_unwrapped_position_, token, keyword);
+    printf("    has unwrapped position.\n");
+  } else if (strcmp(token, "mass") == 0) {
+    set_quantity(quantities.has_mass_, token, keyword);
+    printf("    has mass.\n");
+  } else if (strcmp(token, "charge") == 0) {
+    set_quantity(quantities.has_charge_, token, keyword);
+    if (is_nep_charge) {
+      printf("    has charge predicted by NEP-charge.\n");
+    } else {
+      printf("    has charge specified in model.xyz.\n");
+    }
+  } else if (strcmp(token, "bec") == 0) {
+    set_quantity(quantities.has_bec_, token, keyword);
+    if (is_nep_charge) {
+      printf("    has BEC predicted by NEP-charge.\n");
+    } else {
+      PRINT_INPUT_ERROR("Cannot output BEC for a non-NEP-charge model.\n");
+    }
+  } else if (strcmp(token, "virial") == 0) {
+    set_quantity(quantities.has_virial_, token, keyword);
+    printf("    has virial.\n");
+  } else if (strcmp(token, "group_labels") == 0) {
+    // One column, or one NetCDF grouping_method slot, is written per grouping method. With none
+    // the extended XYZ Properties field would say group:I:0, and the NetCDF dimension would have
+    // length zero, which NC_UNLIMITED makes indistinguishable from an unlimited dimension.
+    if (groups.size() == 0) {
+      PRINT_INPUT_ERROR(
+        "Cannot output group labels without a grouping method defined in model.xyz.\n");
+    }
+    set_quantity(quantities.has_group_, token, keyword);
+    printf("    has group labels.\n");
+  } else {
+    return false;
+  }
+  return true;
 }

--- a/src/measure/parse_utilities.cuh
+++ b/src/measure/parse_utilities.cuh
@@ -27,3 +27,26 @@ void parse_group(
   int& group_id);
 
 void parse_precision(const char** param, const int num_param, int& k, int& precision);
+
+// The per-atom quantities that dump_xyz and dump_netcdf can write. Shared so that the two
+// keywords accept the same names and cannot drift apart.
+struct DumpQuantities {
+  bool has_velocity_ = false;
+  bool has_force_ = false;
+  bool has_potential_ = false;
+  bool has_unwrapped_position_ = false;
+  bool has_mass_ = false;
+  bool has_charge_ = false;
+  bool has_bec_ = false;
+  bool has_virial_ = false;
+  bool has_group_ = false;
+};
+
+// Returns false when the token is not a quantity at all, leaving the caller free to try its own
+// options before rejecting it. `keyword` only names the keyword in error messages.
+bool parse_dump_quantity(
+  const char* token,
+  DumpQuantities& quantities,
+  const bool is_nep_charge,
+  const std::vector<Group>& groups,
+  const char* keyword);

--- a/src/utilities/read_file.cu
+++ b/src/utilities/read_file.cu
@@ -137,7 +137,7 @@ bool check_need_peratom_virial()
           break;
         }
       }
-      if (tokens[0] == "dump_xyz") {
+      if (tokens[0] == "dump_xyz" || tokens[0] == "dump_netcdf") {
         for (const auto& token : tokens) {
           if (token == "virial") {
             need_peratom_virial = true;

--- a/tests_pytest/io_helpers.py
+++ b/tests_pytest/io_helpers.py
@@ -33,6 +33,9 @@ class CommandIOCase:
     # distinct groups (move, which GPUMD refuses to run without a separate fixed group). calorine's
     # GPUNEP has no built-in way to attach groupings through run_custom_md, so this rewrites
     # model.xyz after GPUNEP's automatic write via calorine.gpumd.write_xyz's groupings param.
+    groupings: List = None  # passed straight to calorine.gpumd.write_xyz for the cases n_groups
+    # cannot express, currently only a grouping method with an empty group. Takes precedence over
+    # n_groups.
     ensemble: str = 'nve'
     ensemble_params: tuple = ()
     prelude_lines: List[Tuple] = field(default_factory=list)  # lines that must precede
@@ -90,7 +93,9 @@ def run_command_io_case(tmp_path, atoms, model_path, model_type, gpumd_command, 
 
     calc.run_custom_md(params, only_prepare=True)
 
-    if case.n_groups == 1:
+    if case.groupings is not None:
+        write_xyz(str(tmp_path / 'model.xyz'), atoms, groupings=case.groupings)
+    elif case.n_groups == 1:
         write_xyz(str(tmp_path / 'model.xyz'), atoms, groupings=[[list(range(len(atoms)))]])
     elif case.n_groups == 2:
         half = len(atoms) // 2

--- a/tests_pytest/test_io_dump_commands.py
+++ b/tests_pytest/test_io_dump_commands.py
@@ -638,6 +638,49 @@ def test_dump_netcdf_existing_file_that_is_not_netcdf_is_rejected(
         'the file that could not be opened was modified')
 
 
+def test_dump_netcdf_appending_to_a_file_without_recorded_quantities_is_rejected(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """The quantities a file holds are compared through the gpumd_quantities attribute, and a
+    file that does not carry it cannot be compared against at all. Such a file still opens, and
+    still has every dimension and variable the append path looks up, so without an explicit check
+    the run dies on a bare "NetCDF: Attribute not found" naming neither the file nor the remedy.
+
+    The check has to sit at the comparison rather than where the file is opened, so that it does
+    not preempt the more specific checks before it. The second half of this test is what pins that
+    down: the same file with a different atom count must still report the atom count."""
+    netcdf4 = pytest.importorskip('netCDF4')
+    output_path = tmp_path / 'unrecorded.nc'
+    case = CommandIOCase(
+        name='dump_netcdf_unrecorded_quantities',
+        run_in_lines=[('dump_netcdf', [1, 'unrecorded.nc', 'velocity'])],
+        expected_output_files=['unrecorded.nc'])
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+
+    # everything else about the file still matches, so the run reaches the quantity comparison
+    with netcdf4.Dataset(output_path, 'a') as dataset:
+        dataset.delncattr('gpumd_quantities')
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    output = result.stdout + result.stderr
+    _skip_without_netcdf(output)
+    assert result.returncode != 0, 'a file without recorded quantities should be refused'
+    assert 'unrecorded.nc' in output, output
+    assert 'does not record which quantities' in output, output
+
+    # the same file read by a run with a different number of atoms: the earlier, more specific
+    # check has to win, since claiming the quantities are unrecorded would describe the wrong
+    # difference
+    bigger = structure.repeat((2, 1, 1))
+    result = run_command_io_case(
+        tmp_path, bigger, model_path, model_type, gpumd_command, case)
+    output = result.stdout + result.stderr
+    _skip_without_netcdf(output)
+    assert result.returncode != 0, 'a differing atom count should be refused'
+    assert 'different number of atoms' in output, output
+
+
 def test_dump_netcdf_without_velocity(
         tmp_path, structure, model_path, model_type, gpumd_command):
     netcdf4 = pytest.importorskip('netCDF4')

--- a/tests_pytest/test_io_dump_commands.py
+++ b/tests_pytest/test_io_dump_commands.py
@@ -24,6 +24,11 @@ from test_parsing import read_thermo_out
 
 pytestmark = pytest.mark.fast
 
+# The AMBER convention specifies forces in kcal/mol/A while GPUMD works in eV/A, so the file
+# carries them converted. Repeated here rather than imported, so that a change to the factor in
+# dump_netcdf.cu has to be made deliberately in both places.
+EV_TO_KCAL_PER_MOL = 23.06054783061903
+
 
 def _check_thermo_format(path):
     data = read_thermo_out(path)
@@ -841,7 +846,8 @@ def test_dump_netcdf_rotates_general_cell(
         ('coordinates', reference.positions, 1.0, 1.0e-6),
         # dump_xyz writes velocities in A/fs and NetCDF in A/ps
         ('velocities', reference.arrays['vel'], 1000.0, 1.0e-5),
-        ('forces', reference.get_forces(), 1.0, 1.0e-6),
+        # dump_xyz writes forces in eV/A, the AMBER convention specifies kcal/mol/A
+        ('forces', reference.get_forces(), EV_TO_KCAL_PER_MOL, 1.0e-6),
         ('unwrapped_coordinates', reference.arrays['unwrapped_position'], 1.0, 1.0e-6),
     ]
     for name, reference_value, scale, tolerance in vectors:
@@ -865,7 +871,7 @@ def test_dump_netcdf_rotates_general_cell(
 # is left out because it needs a charge model, and is covered on its own below.
 NETCDF_QUANTITY_LAYOUT = {
     'velocity': ('velocities', ('frame', 'atom', 'spatial'), 'angstrom/picosecond'),
-    'force': ('forces', ('frame', 'atom', 'spatial'), 'eV/angstrom'),
+    'force': ('forces', ('frame', 'atom', 'spatial'), 'kilocalorie/mole/angstrom'),
     'unwrapped_position': ('unwrapped_coordinates', ('frame', 'atom', 'spatial'), 'angstrom'),
     'potential': ('potential_energy', ('frame', 'atom'), 'eV'),
     'charge': ('charge', ('frame', 'atom'), 'e'),
@@ -934,6 +940,39 @@ def test_dump_netcdf_writes_only_the_requested_quantities(
             'type', 'coordinates', 'forces'}
         assert 'grouping_method' not in dataset.dimensions
         assert dataset.getncattr('gpumd_quantities') == 'force'
+
+
+def test_dump_netcdf_is_readable_by_mdanalysis(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """The file declares Conventions=AMBER, so readers that believe it are entitled to AMBER units
+    for the variables AMBER defines. MDAnalysis enforces that in NCDFReader.__init__ and raises
+    rather than converting, so a single mislabelled variable makes the whole trajectory
+    unopenable, positions included -- not merely the quantity in question unreadable.
+
+    `force` is the variable that has to be converted, since GPUMD works in eV/A and the convention
+    specifies kcal/mol/A. This asks for the AMBER-defined quantities together, so relabelling any
+    of them is caught here."""
+    mda = pytest.importorskip('MDAnalysis')
+    pytest.importorskip('netCDF4')
+    case = CommandIOCase(
+        name='dump_netcdf_mdanalysis',
+        run_in_lines=[('dump_netcdf', [1, 'amber.nc', 'velocity', 'force'])],
+        expected_output_files=['amber.nc'])
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+
+    universe = mda.Universe(str(tmp_path / 'amber.nc'), format='NCDF')
+    assert len(universe.atoms) == len(structure)
+    assert len(universe.trajectory) == BASE_N_STEPS
+    frame = universe.trajectory[0]
+    assert frame.has_forces, 'MDAnalysis did not expose the forces'
+    assert np.all(np.isfinite(frame.forces))
+    assert np.all(np.isfinite(frame.positions))
+    # kcal/(mol*Angstrom) is MDAnalysis's own base force unit, so it passes the values through
+    # unchanged; the numeric value of the conversion is pinned by the general-cell test above
+    assert universe.trajectory.units['force'] == 'kcal/(mol*Angstrom)'
+    assert np.max(np.abs(frame.forces)) > 0
 
 
 def test_dump_netcdf_bec(tmp_path, structure, model_path, model_type, gpumd_command):

--- a/tests_pytest/test_io_dump_commands.py
+++ b/tests_pytest/test_io_dump_commands.py
@@ -503,10 +503,18 @@ def test_removed_commands_are_rejected(
         f'{keyword}: error message does not point at dump_xyz\nstdout:\n{result.stdout}')
 
 
-def _check_netcdf_result(result):
-    output = result.stdout + result.stderr
+def _skip_without_netcdf(output):
+    """Every dump_netcdf case has to tolerate a gpumd built without -DUSE_NETCDF, where the
+    keyword is refused in run.cu before DUMP_NETCDF::parse is ever reached. The rejection tests
+    need this as much as the passing ones, since without it they would pass for the wrong
+    reason -- a non-zero exit that says nothing about the arguments under test."""
     if 'dump_netcdf is available only when USE_NETCDF flag is set' in output:
         pytest.skip('gpumd binary was built without USE_NETCDF')
+
+
+def _check_netcdf_result(result):
+    output = result.stdout + result.stderr
+    _skip_without_netcdf(output)
     assert result.returncode == 0, (
         f'dump_netcdf: gpumd exited {result.returncode}\nstdout:\n{result.stdout}\n'
         f'stderr:\n{result.stderr}')
@@ -520,9 +528,9 @@ def test_dump_netcdf_default_overwrite_and_append(
     case = CommandIOCase(
         name='dump_netcdf',
         run_in_lines=[
-            ('dump_netcdf', [-1, 0, 1, 1, 'sed.nc']),
+            ('dump_netcdf', [1, 'sed.nc', 'velocity']),
             ('run', BASE_N_STEPS),
-            ('dump_netcdf', [-1, 0, 1, 1, 'sed.nc']),
+            ('dump_netcdf', [1, 'sed.nc', 'velocity']),
         ],
         expected_output_files=['sed.nc'],
     )
@@ -546,7 +554,7 @@ def test_dump_netcdf_without_velocity(
     netcdf4 = pytest.importorskip('netCDF4')
     case = CommandIOCase(
         name='dump_netcdf_positions',
-        run_in_lines=[('dump_netcdf', [-1, 0, 1, 0, 'positions.nc'])],
+        run_in_lines=[('dump_netcdf', [1, 'positions.nc'])],
         expected_output_files=['positions.nc'],
     )
     result = run_command_io_case(
@@ -566,7 +574,7 @@ def test_dump_netcdf_group_double_deflate(
     case = CommandIOCase(
         name='dump_netcdf_group',
         run_in_lines=[('dump_netcdf', [
-            0, 1, 1, 1, 'group.nc',
+            1, 'group.nc', 'group', 0, 1, 'velocity',
             'precision', 'double', 'compression', 'deflate', 1,
         ])],
         expected_output_files=['group.nc'],
@@ -601,8 +609,8 @@ def test_dump_netcdf_multiple_groups_in_one_run(
     case = CommandIOCase(
         name='dump_netcdf_multiple_groups',
         run_in_lines=[
-            ('dump_netcdf', [0, 0, intervals[0], 1, filenames[0]]),
-            ('dump_netcdf', [0, 1, intervals[1], 1, filenames[1]]),
+            ('dump_netcdf', [intervals[0], filenames[0], 'group', 0, 0, 'velocity']),
+            ('dump_netcdf', [intervals[1], filenames[1], 'group', 0, 1, 'velocity']),
         ],
         expected_output_files=list(filenames),
         n_groups=2,
@@ -632,16 +640,15 @@ def test_dump_netcdf_rejects_duplicate_filename_in_one_run(
     case = CommandIOCase(
         name='dump_netcdf_duplicate_filename',
         run_in_lines=[
-            ('dump_netcdf', [0, 0, 1, 1, 'duplicate.nc']),
-            ('dump_netcdf', [0, 1, 1, 1, 'duplicate.nc']),
+            ('dump_netcdf', [1, 'duplicate.nc', 'group', 0, 0, 'velocity']),
+            ('dump_netcdf', [1, 'duplicate.nc', 'group', 0, 1, 'velocity']),
         ],
         n_groups=2,
     )
     result = run_command_io_case(
         tmp_path, structure, model_path, model_type, gpumd_command, case)
     output = result.stdout + result.stderr
-    if 'dump_netcdf is available only when USE_NETCDF flag is set' in output:
-        pytest.skip('gpumd binary was built without USE_NETCDF')
+    _skip_without_netcdf(output)
     assert result.returncode != 0
     assert 'dump_netcdf filenames must be unique within one run.' in output
 
@@ -659,7 +666,7 @@ def test_dump_netcdf_rotates_general_cell(
         run_in_lines=[
             ('dump_xyz', [1, 'reference.xyz', 'velocity']),
             ('dump_netcdf', [
-                -1, 0, 1, 1, 'general-cell.nc', 'precision', 'double',
+                1, 'general-cell.nc', 'velocity', 'precision', 'double',
             ]),
         ],
         expected_output_files=['reference.xyz', 'general-cell.nc'],
@@ -686,6 +693,93 @@ def test_dump_netcdf_rotates_general_cell(
         netcdf_velocities,
         reference.arrays['vel'] @ rotation_transpose * 1000.0,
         atol=1.0e-5)
+
+
+INVALID_DUMP_NETCDF_ARGUMENTS = [
+    ([1, 'f.nc', 'velocities'], 'Unrecognized argument'),
+    ([1, 'f.nc', 'group', 0, 0, 'group', 0, 0], 'more than once'),
+    ([1, 'f.nc', 'velocity', 'velocity'], 'more than once'),
+    ([1, 'f.nc', 'precision', 'double', 'precision', 'single'], 'more than once'),
+    ([1, 'f.nc', 'compression', 'none', 'compression', 'none'], 'more than once'),
+    ([1, 'f.nc', 'precision', 'triple'], 'Invalid precision'),
+    # the old syntax used -1 to mean the whole system, which is now spelled by omitting the option
+    ([1, 'f.nc', 'group', -1, 0], 'Grouping method'),
+    ([1, 'f.nc', 'group', 0], 'Not enough arguments'),
+    ([1, 'f.nc', 'compression', 'deflate'], 'deflate level is required'),
+    ([1, 'f.nc', 'compression', 'deflate', 10], 'between 0 and 9'),
+    ([1, 'f.nc', 'compression', 'gzip'], "'none' or 'deflate"),
+    ([1], 'at least 2 parameters'),
+    ([0, 'f.nc'], 'dump interval'),
+]
+
+
+@pytest.mark.parametrize('args, expected_message', INVALID_DUMP_NETCDF_ARGUMENTS)
+def test_invalid_dump_netcdf_arguments_are_rejected(
+        tmp_path, structure, model_path, model_type, gpumd_command, args, expected_message):
+    """The dump_xyz rejection table applied to dump_netcdf. As there, the asserted substring
+    matters as much as the exit code, since a test that passes because gpumd died for an unrelated
+    reason is worse than no test."""
+    case = CommandIOCase(
+        name='dump_netcdf_invalid', run_in_lines=[('dump_netcdf', args)],
+        expected_output_files=[], n_groups=1)
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    output = result.stdout + result.stderr
+    _skip_without_netcdf(output)
+    assert result.returncode != 0, f'dump_netcdf {args} unexpectedly succeeded'
+    assert expected_message in output, (
+        f'dump_netcdf {args} did not report {expected_message!r}\nstdout:\n{result.stdout}')
+
+
+def test_dump_netcdf_old_positional_form_is_rejected(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """An input file written for the old positional form must be told what to write instead.
+
+    Without the check this is not silent, but it is misleading: removing it and rerunning this
+    case reports "dump interval should > 0", because the old grouping method is read as the
+    interval. A positive grouping method fares no better, as the old group id then becomes the
+    file name and the old interval an unrecognized argument. The point of the check is the
+    message, so the message is what is asserted."""
+    case = CommandIOCase(
+        name='dump_netcdf_old_form',
+        run_in_lines=[('dump_netcdf', [-1, 0, 1, 1, 'movie.nc'])],
+        expected_output_files=[])
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    output = result.stdout + result.stderr
+    _skip_without_netcdf(output)
+    assert result.returncode != 0, 'the old positional form should be refused'
+    assert 'no longer takes' in output, output
+    assert 'dump_netcdf <interval> <filename>' in output, output
+
+
+def test_dump_netcdf_rejects_an_empty_group(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """An empty group must be refused rather than written, and this is the case where leaving the
+    check out would be silent rather than loud. NC_UNLIMITED is 0, so defining the atom dimension
+    with a length of zero does not fail. Removing the check and rerunning this case confirms both
+    halves of that: with `compression deflate 1` gpumd exits 0 and writes a NETCDF4 file whose
+    `atom` dimension is a second unlimited dimension of length zero and whose coordinates have
+    shape (frames, 0, 3), and without compression the run gets as far as the first frame before
+    dying with "NC_UNLIMITED size already in use", because the classic format allows only one
+    unlimited dimension. parse_group checks the bounds but not the size, so dump_netcdf checks
+    after calling it.
+
+    The grouping puts every atom in group 1, which leaves group 0 of the same grouping method
+    empty while keeping it in bounds -- GPUMD takes the number of groups from the largest label
+    it sees."""
+    case = CommandIOCase(
+        name='dump_netcdf_empty_group',
+        run_in_lines=[('dump_netcdf', [1, 'empty.nc', 'group', 0, 0])],
+        expected_output_files=[],
+        groupings=[[[], list(range(len(structure)))]])
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    output = result.stdout + result.stderr
+    _skip_without_netcdf(output)
+    assert result.returncode != 0, 'an empty group should be refused'
+    assert 'cannot output an empty group' in output, output
+    assert not (tmp_path / 'empty.nc').exists(), 'a file was written for an empty group'
 
 
 def test_dump_observer(tmp_path, structure, model_path, model_type, gpumd_command):

--- a/tests_pytest/test_io_dump_commands.py
+++ b/tests_pytest/test_io_dump_commands.py
@@ -656,19 +656,30 @@ def test_dump_netcdf_rejects_duplicate_filename_in_one_run(
 
 def test_dump_netcdf_rotates_general_cell(
         tmp_path, structure, model_path, model_type, gpumd_command):
+    """AMBER NetCDF stores only cell lengths and angles, so a general GPUMD cell is written in a
+    restricted orientation and everything directional has to be rotated with it. Positions,
+    velocities, forces and unwrapped positions follow as vectors, the per-atom virial and the BEC
+    as rank-2 tensors.
+
+    The dump_xyz file written by the same run is the reference, so the two describe the same
+    trajectory and the rotation is the only thing between them. Getting the tensor rule wrong --
+    rotating one-sidedly, or transposing -- is silent otherwise, since the values stay the same
+    size and the file still reads back."""
     netcdf4 = pytest.importorskip('netCDF4')
     rotated_structure = structure.copy()
     general_cell = rotated_structure.cell.array.copy()
     general_cell[0] += 0.05 * general_cell[2]
     rotated_structure.set_cell(general_cell, scale_atoms=True)
     rotated_structure.rotate(17.0, 'y', center=(0.0, 0.0, 0.0), rotate_cell=True)
+
+    quantities = ['velocity', 'force', 'unwrapped_position', 'virial']
+    if model_type != 'nep':
+        quantities.append('bec')
     case = CommandIOCase(
         name='dump_netcdf_general_cell',
         run_in_lines=[
-            ('dump_xyz', [1, 'reference.xyz', 'velocity']),
-            ('dump_netcdf', [
-                1, 'general-cell.nc', 'velocity', 'precision', 'double',
-            ]),
+            ('dump_xyz', [1, 'reference.xyz'] + quantities + ['precision', 'double']),
+            ('dump_netcdf', [1, 'general-cell.nc'] + quantities + ['precision', 'double']),
         ],
         expected_output_files=['reference.xyz', 'general-cell.nc'],
     )
@@ -677,27 +688,223 @@ def test_dump_netcdf_rotates_general_cell(
     _check_netcdf_result(result)
 
     reference = read(tmp_path / 'reference.xyz', index=0)
+    netcdf_values = {}
     with netcdf4.Dataset(tmp_path / 'general-cell.nc') as dataset:
         lengths = dataset.variables['cell_lengths'][0]
         angles = dataset.variables['cell_angles'][0]
         netcdf_cell = Cell.fromcellpar(np.concatenate((lengths, angles))).array
-        netcdf_positions = dataset.variables['coordinates'][0]
-        netcdf_velocities = dataset.variables['velocities'][0]
+        for name in ('coordinates', 'velocities', 'forces', 'unwrapped_coordinates', 'virial'):
+            netcdf_values[name] = np.array(dataset.variables[name][0])
+        if 'bec' in quantities:
+            netcdf_values['bec'] = np.array(dataset.variables['bec'][0])
 
     reference_cell = reference.cell.array
+    # v_netcdf = v_reference @ rotation_transpose, so the rotation itself is its transpose
     rotation_transpose = np.linalg.solve(reference_cell, netcdf_cell)
+    rotation = rotation_transpose.T
     assert not np.allclose(reference_cell, netcdf_cell)
     assert not np.allclose(angles, (90.0, 90.0, 90.0))
-    np.testing.assert_allclose(
-        netcdf_positions, reference.positions @ rotation_transpose, atol=1.0e-6)
-    np.testing.assert_allclose(
-        netcdf_velocities,
-        reference.arrays['vel'] @ rotation_transpose * 1000.0,
-        atol=1.0e-5)
+    np.testing.assert_allclose(rotation @ rotation.T, np.eye(3), atol=1.0e-10)
+
+    vectors = [
+        ('coordinates', reference.positions, 1.0, 1.0e-6),
+        # dump_xyz writes velocities in A/fs and NetCDF in A/ps
+        ('velocities', reference.arrays['vel'], 1000.0, 1.0e-5),
+        ('forces', reference.get_forces(), 1.0, 1.0e-6),
+        ('unwrapped_coordinates', reference.arrays['unwrapped_position'], 1.0, 1.0e-6),
+    ]
+    for name, reference_value, scale, tolerance in vectors:
+        np.testing.assert_allclose(
+            netcdf_values[name], reference_value @ rotation_transpose * scale, atol=tolerance,
+            err_msg=f'{name} is not the reference rotated into the NetCDF cell')
+
+    for name in ('virial', 'bec'):
+        if name not in netcdf_values:
+            continue
+        reference_tensor = reference.arrays[name].reshape(-1, 3, 3)
+        expected = np.einsum('ij,ajk,lk->ail', rotation, reference_tensor, rotation)
+        assert not np.allclose(netcdf_values[name], reference_tensor, atol=1.0e-6), (
+            f'{name} is unchanged by the rotation, so this comparison proves nothing')
+        np.testing.assert_allclose(
+            netcdf_values[name], expected, atol=1.0e-6,
+            err_msg=f'{name} does not follow the cell as R T R^T')
+
+
+# quantity keyword -> (variable, dimensions, units), as the documentation tabulates them. `bec`
+# is left out because it needs a charge model, and is covered on its own below.
+NETCDF_QUANTITY_LAYOUT = {
+    'velocity': ('velocities', ('frame', 'atom', 'spatial'), 'angstrom/picosecond'),
+    'force': ('forces', ('frame', 'atom', 'spatial'), 'eV/angstrom'),
+    'unwrapped_position': ('unwrapped_coordinates', ('frame', 'atom', 'spatial'), 'angstrom'),
+    'potential': ('potential_energy', ('frame', 'atom'), 'eV'),
+    'charge': ('charge', ('frame', 'atom'), 'e'),
+    'virial': ('virial', ('frame', 'atom', 'spatial', 'spatial'), 'eV'),
+    'mass': ('mass', ('atom',), 'amu'),
+    'group_labels': ('group_labels', ('atom', 'grouping_method'), None),
+}
+
+
+def test_dump_netcdf_quantity_layout(tmp_path, structure, model_path, model_type, gpumd_command):
+    """Each quantity has to land in the variable, with the dimensions and units, that the
+    documentation promises, since that layout is the whole interface to the file. The mass and
+    the group labels are constant over a run and carry no frame dimension."""
+    netcdf4 = pytest.importorskip('netCDF4')
+    quantities = list(NETCDF_QUANTITY_LAYOUT)
+    case = CommandIOCase(
+        name='dump_netcdf_quantities',
+        run_in_lines=[
+            ('dump_netcdf', [1, 'all.nc'] + quantities + ['precision', 'double']),
+            # the same set in the opposite order, to pin down that neither the file layout nor
+            # the recorded quantity list follows the order the arguments came in
+            ('dump_netcdf', [1, 'reversed.nc'] + quantities[::-1] + ['precision', 'double']),
+        ],
+        expected_output_files=['all.nc', 'reversed.nc'], n_groups=2)
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+
+    with netcdf4.Dataset(tmp_path / 'all.nc') as dataset:
+        for quantity, (name, dimensions, units) in NETCDF_QUANTITY_LAYOUT.items():
+            assert name in dataset.variables, f'{quantity} did not produce a {name} variable'
+            variable = dataset.variables[name]
+            assert variable.dimensions == dimensions, quantity
+            expected_dtype = np.dtype('int32') if units is None else np.dtype('float64')
+            assert variable.dtype == expected_dtype, quantity
+            if units is None:
+                assert not hasattr(variable, 'units'), quantity
+            else:
+                assert variable.units == units, quantity
+        assert len(dataset.dimensions['grouping_method']) == 1
+        assert len(dataset.dimensions['atom']) == len(structure)
+        recorded = dataset.getncattr('gpumd_quantities')
+        assert sorted(recorded.split()) == sorted(quantities)
+
+    with netcdf4.Dataset(tmp_path / 'reversed.nc') as dataset:
+        assert dataset.getncattr('gpumd_quantities') == recorded
+
+
+def test_dump_netcdf_writes_only_the_requested_quantities(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """A quantity that was not asked for must not be in the file at all."""
+    netcdf4 = pytest.importorskip('netCDF4')
+    case = CommandIOCase(
+        name='dump_netcdf_one_quantity',
+        run_in_lines=[('dump_netcdf', [1, 'force.nc', 'force'])],
+        expected_output_files=['force.nc'])
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+
+    with netcdf4.Dataset(tmp_path / 'force.nc') as dataset:
+        assert 'forces' in dataset.variables
+        # the positions and types are unconditional, everything else follows the arguments
+        assert set(dataset.variables) == {
+            'spatial', 'cell_spatial', 'cell_angular', 'time', 'cell_lengths', 'cell_angles',
+            'type', 'coordinates', 'forces'}
+        assert 'grouping_method' not in dataset.dimensions
+        assert dataset.getncattr('gpumd_quantities') == 'force'
+
+
+def test_dump_netcdf_bec(tmp_path, structure, model_path, model_type, gpumd_command):
+    """BEC is a rank-2 tensor per atom and needs a charge model, so it is checked apart from the
+    other quantities."""
+    netcdf4 = pytest.importorskip('netCDF4')
+    if model_type == 'nep':
+        pytest.skip('BEC requires a qNEP charge model')
+    case = CommandIOCase(
+        name='dump_netcdf_bec',
+        run_in_lines=[('dump_netcdf', [1, 'bec.nc', 'bec', 'precision', 'double'])],
+        expected_output_files=['bec.nc'])
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+
+    with netcdf4.Dataset(tmp_path / 'bec.nc') as dataset:
+        variable = dataset.variables['bec']
+        assert variable.dimensions == ('frame', 'atom', 'spatial', 'spatial')
+        assert variable.units == 'e'
+        assert variable.shape == (BASE_N_STEPS, len(structure), 3, 3)
+        assert np.all(np.isfinite(np.array(variable[0])))
+
+
+def test_dump_netcdf_bec_without_a_charge_model_is_rejected(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """BEC is only defined for a qNEP model trained against it, so asking for it otherwise has to
+    be refused rather than writing zeros."""
+    if model_type != 'nep':
+        pytest.skip('this is about the models that cannot produce BEC')
+    case = CommandIOCase(
+        name='dump_netcdf_bec_no_charge_model',
+        run_in_lines=[('dump_netcdf', [1, 'bec.nc', 'bec'])],
+        expected_output_files=[])
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    output = result.stdout + result.stderr
+    _skip_without_netcdf(output)
+    assert result.returncode != 0, 'bec without a charge model should be refused'
+    assert 'BEC' in output, output
+
+
+def test_dump_netcdf_group_labels_without_a_grouping_method_is_rejected(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """With no grouping method the grouping_method dimension would have length zero, which
+    NC_UNLIMITED makes indistinguishable from an unlimited dimension, the same trap the
+    empty-group check guards against."""
+    case = CommandIOCase(
+        name='dump_netcdf_group_labels_no_groups',
+        run_in_lines=[('dump_netcdf', [1, 'labels.nc', 'group_labels'])],
+        expected_output_files=[], n_groups=0)
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    output = result.stdout + result.stderr
+    _skip_without_netcdf(output)
+    assert result.returncode != 0, 'group_labels without a grouping method should be refused'
+    assert 'grouping method' in output, output
+
+
+def _netcdf_per_atom_virial(directory, structure, model_path, model_type, gpumd_command, kspace):
+    """Runs one qNEP single point with the given reciprocal-space method and returns the per-atom
+    virial from the NetCDF file as an (natoms, 9) array."""
+    netcdf4 = pytest.importorskip('netCDF4')
+    directory.mkdir()
+    case = CommandIOCase(
+        name=f'dump_netcdf_virial_{kspace}',
+        prelude_lines=[('kspace', kspace)],
+        run_in_lines=[('dump_netcdf', [1, 'virial.nc', 'virial', 'precision', 'double'])],
+        expected_output_files=['virial.nc'])
+    result = run_command_io_case(
+        directory, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+    with netcdf4.Dataset(directory / 'virial.nc') as dataset:
+        return np.array(dataset.variables['virial'][0]).reshape(len(structure), 9)
+
+
+def test_dump_netcdf_per_atom_virial_agrees_between_pppm_and_ewald(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """The dump_netcdf counterpart of the dump_xyz test above, guarding the same scan in
+    check_need_peratom_virial in utilities/read_file.cu, which now has to recognize dump_netcdf
+    lines as well as dump_xyz ones.
+
+    The flag it sets gates only the PPPM reciprocal-space contribution, so the two methods have to
+    be compared against each other: with dump_netcdf missing from the scan, the PPPM virial
+    silently loses its k-space part while Ewald keeps it, and the file still looks perfectly
+    well-formed."""
+    if model_type == 'nep':
+        pytest.skip('a charge model is needed for there to be a reciprocal-space contribution')
+
+    pppm = _netcdf_per_atom_virial(
+        tmp_path / 'pppm', structure, model_path, model_type, gpumd_command, 'pppm')
+    ewald = _netcdf_per_atom_virial(
+        tmp_path / 'ewald', structure, model_path, model_type, gpumd_command, 'ewald')
+
+    assert pppm.shape == ewald.shape == (len(structure), 9)
+    assert np.max(np.abs(ewald)) > 0, 'the reference virial is identically zero, nothing to compare'
+    np.testing.assert_allclose(pppm, ewald, rtol=1e-2, atol=5e-3)
 
 
 INVALID_DUMP_NETCDF_ARGUMENTS = [
     ([1, 'f.nc', 'velocities'], 'Unrecognized argument'),
+    ([1, 'f.nc', 'force', 'force'], 'more than once'),
     ([1, 'f.nc', 'group', 0, 0, 'group', 0, 0], 'more than once'),
     ([1, 'f.nc', 'velocity', 'velocity'], 'more than once'),
     ([1, 'f.nc', 'precision', 'double', 'precision', 'single'], 'more than once'),

--- a/tests_pytest/test_io_dump_commands.py
+++ b/tests_pytest/test_io_dump_commands.py
@@ -437,6 +437,7 @@ INVALID_DUMP_XYZ_ARGUMENTS = [
     ([1, 'f.xyz', 'forcee'], 'Unrecognized argument'),
     ([1, 'f.xyz', 'group', 0, 0, 'group', 0, 0], 'more than once'),
     ([1, 'f.xyz', 'precision', 'double', 'precision', 'single'], 'more than once'),
+    ([1, 'f.xyz', 'force', 'force'], 'more than once'),
     ([1, 'f.xyz', 'precision', 'triple'], 'Invalid precision'),
     # a bare `group` is how the quantity now called `group_labels` used to be spelled
     ([1, 'f.xyz', 'velocity', 'group'], 'group_labels'),

--- a/tests_pytest/test_io_dump_commands.py
+++ b/tests_pytest/test_io_dump_commands.py
@@ -521,11 +521,11 @@ def _check_netcdf_result(result):
         f'stderr:\n{result.stderr}')
 
 
-def test_dump_netcdf_default_overwrite_and_append(
+def test_dump_netcdf_appends_across_run_commands(
         tmp_path, structure, model_path, model_type, gpumd_command):
+    """Two dump_netcdf commands writing the same file in one execution extend it, since the
+    keyword does not propagate and each run needs its own command."""
     netcdf4 = pytest.importorskip('netCDF4')
-    output_path = tmp_path / 'sed.nc'
-    output_path.write_bytes(b'an existing file that must be overwritten')
     case = CommandIOCase(
         name='dump_netcdf',
         run_in_lines=[
@@ -539,7 +539,7 @@ def test_dump_netcdf_default_overwrite_and_append(
         tmp_path, structure, model_path, model_type, gpumd_command, case)
     _check_netcdf_result(result)
 
-    with netcdf4.Dataset(output_path) as dataset:
+    with netcdf4.Dataset(tmp_path / 'sed.nc') as dataset:
         assert dataset.data_model == 'NETCDF3_64BIT_OFFSET'
         assert len(dataset.dimensions['frame']) == 2 * BASE_N_STEPS
         assert len(dataset.dimensions['atom']) == len(structure)
@@ -548,6 +548,94 @@ def test_dump_netcdf_default_overwrite_and_append(
         assert dataset.variables['type'].dimensions == ('frame', 'atom')
         assert dataset.variables['type'].shape == (2 * BASE_N_STEPS, len(structure))
         assert dataset.getncattr('gpumd_compression_level') == -1
+
+
+@pytest.mark.filterwarnings('ignore:.*already contains files from an earlier calculation')
+def test_dump_netcdf_appends_across_executions(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """Rerunning gpumd in a directory that already holds the file extends it rather than replacing
+    it, as dump_xyz does. The frames written the first time have to survive untouched, which is
+    what separates appending from starting over."""
+    netcdf4 = pytest.importorskip('netCDF4')
+    case = CommandIOCase(
+        name='dump_netcdf_rerun',
+        run_in_lines=[('dump_netcdf', [1, 'rerun.nc', 'velocity', 'precision', 'double'])],
+        expected_output_files=['rerun.nc'])
+
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+    with netcdf4.Dataset(tmp_path / 'rerun.nc') as dataset:
+        assert len(dataset.dimensions['frame']) == BASE_N_STEPS
+        first_run = np.array(dataset.variables['coordinates'][:])
+
+    # the same case again in the same directory, which rewrites run.in and model.xyz and leaves
+    # the trajectory in place
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+    with netcdf4.Dataset(tmp_path / 'rerun.nc') as dataset:
+        assert len(dataset.dimensions['frame']) == 2 * BASE_N_STEPS, (
+            'the second execution did not append to the existing file')
+        both_runs = np.array(dataset.variables['coordinates'][:])
+    np.testing.assert_array_equal(
+        both_runs[:BASE_N_STEPS], first_run,
+        err_msg='appending disturbed the frames written by the first execution')
+
+
+@pytest.mark.filterwarnings('ignore:.*already contains files from an earlier calculation')
+def test_dump_netcdf_appending_with_changed_quantities_is_rejected(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """A NetCDF layout is fixed when the file is created, so a rerun that asks for a different set
+    of quantities cannot be appended. It has to stop with a message naming the file, since silently
+    replacing the trajectory would lose the earlier one."""
+    netcdf4 = pytest.importorskip('netCDF4')
+    first = CommandIOCase(
+        name='dump_netcdf_layout_first',
+        run_in_lines=[('dump_netcdf', [1, 'layout.nc', 'velocity'])],
+        expected_output_files=['layout.nc'])
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, first)
+    _check_netcdf_result(result)
+
+    second = CommandIOCase(
+        name='dump_netcdf_layout_second',
+        run_in_lines=[('dump_netcdf', [1, 'layout.nc', 'velocity', 'force'])],
+        expected_output_files=[])
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, second)
+    output = result.stdout + result.stderr
+    _skip_without_netcdf(output)
+    assert result.returncode != 0, 'appending with a different quantity set should be refused'
+    assert 'layout.nc' in output, output
+    assert 'set of quantities' in output, output
+
+    # the trajectory that was already there must still be intact
+    with netcdf4.Dataset(tmp_path / 'layout.nc') as dataset:
+        assert len(dataset.dimensions['frame']) == BASE_N_STEPS
+        assert 'forces' not in dataset.variables
+
+
+def test_dump_netcdf_existing_file_that_is_not_netcdf_is_rejected(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """Appending means opening whatever is already there, so a file of that name that is not a
+    NetCDF file at all has to be reported clearly rather than through a bare NetCDF error."""
+    output_path = tmp_path / 'junk.nc'
+    case = CommandIOCase(
+        name='dump_netcdf_not_netcdf',
+        run_in_lines=[('dump_netcdf', [1, 'junk.nc', 'velocity'])],
+        expected_output_files=[])
+    # written after the case is built but before the run, since run_command_io_case only writes
+    # run.in and model.xyz
+    output_path.write_bytes(b'an existing file that is not a NetCDF file')
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    output = result.stdout + result.stderr
+    _skip_without_netcdf(output)
+    assert result.returncode != 0, 'a non-NetCDF file of that name should be refused'
+    assert 'junk.nc' in output, output
+    assert output_path.read_bytes() == b'an existing file that is not a NetCDF file', (
+        'the file that could not be opened was modified')
 
 
 def test_dump_netcdf_without_velocity(

--- a/tests_pytest/test_io_dump_commands.py
+++ b/tests_pytest/test_io_dump_commands.py
@@ -771,6 +771,49 @@ def test_dump_netcdf_multiple_groups_in_one_run(
         trajectories[0][intervals[1] - 1::intervals[1]], trajectories[1])
 
 
+def test_dump_netcdf_group_agrees_with_the_whole_system(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """Grouped output is gathered on the device, so that only the group's values cross to the host,
+    while whole-system output is copied as it stands. That makes them two code paths through the
+    same packing, and this is what pins them together.
+
+    Both files come from one run, so they describe the same trajectory: the group file has to equal
+    the rows of the whole-system file belonging to that group, exactly rather than approximately,
+    since it is the same arithmetic on the same values. A gather that mis-indexes, or a stride
+    confusion between the system size and the group size, shows up here as wrong values while
+    every file still parses."""
+    netcdf4 = pytest.importorskip('netCDF4')
+    half = len(structure) // 2
+    quantities = ['velocity', 'force', 'virial']
+    case = CommandIOCase(
+        name='dump_netcdf_group_vs_whole',
+        run_in_lines=[
+            # group 1, not group 0: group 0 holds the first half of the atoms, so a gather that
+            # ignored the index list entirely would still produce the right answer for it
+            ('dump_netcdf', [1, 'group.nc', 'group', 0, 1] + quantities
+             + ['precision', 'double']),
+            ('dump_netcdf', [1, 'whole.nc'] + quantities + ['precision', 'double']),
+        ],
+        expected_output_files=['group.nc', 'whole.nc'], n_groups=2)
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+
+    with netcdf4.Dataset(tmp_path / 'group.nc') as group, \
+            netcdf4.Dataset(tmp_path / 'whole.nc') as whole:
+        # group 1 of the two-group model holds the atoms from `half` onwards
+        expected_size = len(structure) - half
+        assert len(group.dimensions['atom']) == expected_size
+        assert len(whole.dimensions['atom']) == len(structure)
+        for name in ('type', 'coordinates', 'velocities', 'forces', 'virial'):
+            gathered = np.array(group.variables[name][:])
+            complete = np.array(whole.variables[name][:])
+            assert gathered.shape[1] == expected_size, name
+            np.testing.assert_array_equal(
+                gathered, complete[:, half:],
+                err_msg=f'{name} gathered for the group differs from the whole-system rows')
+
+
 def test_dump_netcdf_rejects_duplicate_filename_in_one_run(
         tmp_path, structure, model_path, model_type, gpumd_command):
     pytest.importorskip('netCDF4')


### PR DESCRIPTION
Brings `dump_netcdf` in line with `dump_xyz`, in two parts.

## Arguments

The output interval and the file name are now the only positional arguments:

```
dump_netcdf <interval> <filename> [group <m> <id>] [precision single|double]
            [compression none|deflate <level>] {<quantity> ...}
```

- the grouping method and group ID move into a `group` option parsed by `parse_group`, replacing inline bounds checks
- `has_velocity` becomes the optional quantity `velocity`
- unrecognized arguments are rejected instead of ignored
- an input file written for the old positional form is detected and reported with the replacement spelled out
  
Options and quantities may be given in any order.

## Quantities

All nine per-atom quantities `dump_xyz` writes are now available, so an input line that works for one works for the other:

| quantity | variable | dimensions | GPUMD unit |
| --- | --- | --- | --- |
| `velocity` | `velocities` | `(frame, atom, spatial)` | Å/ps |
| `force` | `forces` | `(frame, atom, spatial)` | eV/Å | 
| `unwrapped_position` | `unwrapped_coordinates` | `(frame, atom, spatial)` | Å |
| `potential` | `potential_energy` | `(frame, atom)` | eV | 
| `charge` | `charge` | `(frame, atom)` | e | 
| `bec` | `bec` | `(frame, atom, spatial, spatial)` | e |
| `virial` | `virial` | `(frame, atom, spatial, spatial)` | eV |
| `mass` | `mass` | `(atom)` | amu |
| `group_labels` | `group_labels` | `(atom, grouping_method)` | -- |

Mass and group labels cannot change during a run and are written once, without a frame dimension.
The requested set is recorded as the `gpumd_quantities` attribute, which replaces `gpumd_has_velocity` and is what appending compares.

Quantities that carry direction follow the rotation into the restricted AMBER cell that positions and velocities already went through: vectors as `R v`, rank-2 tensors as `R T Rᵀ`.
Without this they would describe a different frame from the coordinates beside them.

Forces are written in the units the AMBER convention specifies, kcal/mol/Å, converted from eV/Å, as the velocities already were. Quantities the convention does not define keep GPUMD units, and the `units` attribute of each variable is specifying the unit.

The quantity parsing is shared with `dump_xyz` through `parse_utilities`, so the two keyword lists stay in step.
As a side effect a repeated quantity is now an error in `dump_xyz` too, as repeated `group` and `precision` already were.

`check_need_peratom_virial` also scans `dump_netcdf` lines now; without that, `dump_netcdf virial` would silently lose its PPPM reciprocal-space part.

Group selection moved from a CUDA kernel to the host, as in `dump_xyz`, so the grouped and whole-system cases share one packing path instead of needing a device buffer and a launch per quantity.

## Appending

An existing file is extended rather than replaced, matching `dump_xyz`, so rerunning GPUMD in the same directory continues the trajectory.
What decided between appending and creating was a static list of the names the process had written, which is empty at startup; that is replaced by a test of what is on disk, which covers both cases with one rule.

A NetCDF layout is fixed when the file is created, so a rerun whose atom count, precision, quantities, compression or group differ from the file stops instead of silently starting over.
The messages name the file, since removing or renaming it is what the user has to do next.
A file that does not record its quantities at all is reported the same way, at the comparison rather than at open, so that the more specific checks still speak first.

Note that `time` restarts at the beginning of each execution while `frame` keeps counting, so times in a file appended to across executions are not monotonic.

## Consolidation with dump_xyz

The two keywords have very similar purpose but differed in argument grammar, quantities supported, and the behavior on a rerun.
They now share all three.

The shared code lives in `parse_utilities`, which already held `parse_group` and `parse_precision` and now also holds the `DumpQuantities` struct and `parse_dump_quantity`.
Both keywords call all three.
A quantity added there appears in both at once, and neither can drift into accepting a name the other rejects. `dump_netcdf` also took over the append behavior and the host-side group selection that `dump_xyz` already had, so the grouped and whole-system cases go through one path.

For the user this means the two are close to interchangeable: apart from the file name, the same line works with either keyword, and the same trajectory can be written in text or binary form by changing one token.

One consequence for `dump_xyz`: a repeated quantity is now an error there too, as repeated `group` and `precision` already were.

Not shared, deliberately: each keyword keeps its own option loop, since `dump_xyz` has the trailing-star per-frame file name and `dump_netcdf` has `compression`; and the writing itself stays separate, one being self-describing text per frame and the other a fixed binary layout declared when the file is created.

## Notes

Tests follow the `dump_xyz` patterns, including a rejection table that asserts message text.
Every guard against a silent failure was confirmed by removing it and checking the matching test fails.

`dump_netcdf.cu` was not clang-format clean, so the mandated reformat reflows some lines unrelated to this change.