### PR TITLE
fix zero_total_charge bug for small box

### DIFF
--- a/src/force/nep_charge.cu
+++ b/src/force/nep_charge.cu
@@ -1621,7 +1621,7 @@ void NEP_Charge::compute_small_box(
   GPU_CHECK_KERNEL
 
   // enforce charge neutrality
-  zero_total_charge<<<N, 1024>>>(N, nep_data.charge.data());
+  zero_total_charge<<<1, 1024>>>(N, nep_data.charge.data());
   GPU_CHECK_KERNEL
 
   if (true) { // TODO


### PR DESCRIPTION
**Summary** (Briefly summarize the purpose of this pull request)

The execution configuration was mistakingly written as `<<< N, 1024>>>` instead of `<<< 1, 1024>>>`

**Modification** (Describe the main changes made in this pull request)

A single line in `nep_charge.cu`

**Licensing** (Please read and confirm before submitting this pull request)

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.

**Validation** (Describe how this pull request was tested)

Tested `examples/gpumd_static_qnep`

**Others**
