### PR TITLE
Add Eco PIMD 

### DIFF
--- a/doc/bibliography.rst
+++ b/doc/bibliography.rst
@@ -381,3 +381,9 @@ Bibliography
    | *Modular hybrid machine learning and physics-based potentials for scalable modeling of Van der Waals heterostructures*
    | J. Mech. Phys. Solids **210**, 106540 (2026)
    | DOI: `10.1016/j.jmps.2026.106540 <https://doi.org/10.1016/j.jmps.2026.106540>`_
+
+.. [Zeng2026]
+   | Zezhu Zeng and David E. Manolopoulos
+   | *Economised path integrals*
+   | arXiv:2607.06414 (2026)
+   | DOI: `10.48550/arXiv.2607.06414 <https://doi.org/10.48550/arXiv.2607.06414>`_

--- a/doc/gpumd/input_parameters/ensemble_pimd.rst
+++ b/doc/gpumd/input_parameters/ensemble_pimd.rst
@@ -18,11 +18,17 @@ It can be used in the following ways::
 
     ensemble pimd <num_beads> <T_1> <T_2> <T_coup> 
     ensemble pimd <num_beads> <T_1> <T_2> <T_coup> {<pressure_control_parameters>}
+    ensemble pimd <num_beads> <T_1> <T_2> <T_coup> {<pressure_control_parameters>} eco <omega_max>
 
 In both cases, :attr:`num_beads` is the number of beads in the ring polymer, which should be a positive even integer no larger than 128.
 The first case is similar to the NVT ensemble with :attr:`nvt_lan` as the Langevin thermostat is used for both the internal and the centroid modes [Ceriotti2010]_. 
 The second case is similar to the NPT ensemble with :attr:`npt_ber`, where a Berendsen barostat is added compared to the first case.
 Note that :attr:`pimd` (that is, not :attr:`rpmd` or :attr:`trpmd` described below) must be the first run that requires to set :attr:`num_beads` and one cannot change :attr:`num_beads` from run to run.
+
+Appending ``eco <omega_max>`` selects the economised path-integral internal-mode frequencies [Zeng2026]_.
+Here :attr:`omega_max` is the highest physical vibrational wavenumber to be reproduced, in units of cm\ :sup:`-1`.
+The dimensionless fitting range is recalculated from the instantaneous target temperature as :math:`x_{\max}=hc\omega_{\max}/(k_{\rm B}T)`, so Eco frequencies also follow a temperature ramp from :attr:`T_1` to :attr:`T_2`.
+If the ``eco`` option is omitted, GPUMD uses the original Trotter internal-mode frequencies.
 
 :attr:`rpmd`
 ^^^^^^^^^^^^
@@ -31,6 +37,7 @@ If the first parameter is :attr:`rpmd`, it means that the current run will use r
 It can be used as follows::
 
     ensemble rpmd <num_beads> 
+    ensemble rpmd <num_beads> eco <omega_max>
 
 This can be understood as the NVE version of :term:`PIMD`, where no thermostat is applied.
 
@@ -41,5 +48,7 @@ If the first parameter is :attr:`trpmd`, it means that the current run will use 
 It can be used as follows::
 
     ensemble trpmd <num_beads> 
+    ensemble trpmd <num_beads> eco <omega_max>
 
 This is similar to :term:`RPMD`, but the Langevin thermosat is applied to the internal modes.
+For both :attr:`rpmd` and :attr:`trpmd`, the optional Eco parameters should be the same as in the preceding :attr:`pimd` run.

--- a/doc/gpumd/input_parameters/ensemble_pimd.rst
+++ b/doc/gpumd/input_parameters/ensemble_pimd.rst
@@ -20,7 +20,7 @@ It can be used in the following ways::
     ensemble pimd <num_beads> <T_1> <T_2> <T_coup> {<pressure_control_parameters>}
     ensemble pimd <num_beads> <T_1> <T_2> <T_coup> {<pressure_control_parameters>} eco <omega_max>
 
-In both cases, :attr:`num_beads` is the number of beads in the ring polymer, which should be a positive even integer no larger than 128.
+In all forms, :attr:`num_beads` is the number of beads in the ring polymer, which should be a positive even integer no larger than 128.
 The first case is similar to the NVT ensemble with :attr:`nvt_lan` as the Langevin thermostat is used for both the internal and the centroid modes [Ceriotti2010]_. 
 The second case is similar to the NPT ensemble with :attr:`npt_ber`, where a Berendsen barostat is added compared to the first case.
 Note that :attr:`pimd` (that is, not :attr:`rpmd` or :attr:`trpmd` described below) must be the first run that requires to set :attr:`num_beads` and one cannot change :attr:`num_beads` from run to run.
@@ -29,6 +29,7 @@ Appending ``eco <omega_max>`` selects the economised path-integral internal-mode
 Here :attr:`omega_max` is the highest physical vibrational wavenumber to be reproduced, in units of cm\ :sup:`-1`.
 The dimensionless fitting range is recalculated from the instantaneous target temperature as :math:`x_{\max}=hc\omega_{\max}/(k_{\rm B}T)`, so Eco frequencies also follow a temperature ramp from :attr:`T_1` to :attr:`T_2`.
 If the ``eco`` option is omitted, GPUMD uses the original Trotter internal-mode frequencies.
+The Eco option is available for :attr:`pimd` only; :attr:`rpmd` and :attr:`trpmd` use the original Trotter frequencies.
 
 :attr:`rpmd`
 ^^^^^^^^^^^^
@@ -37,7 +38,6 @@ If the first parameter is :attr:`rpmd`, it means that the current run will use r
 It can be used as follows::
 
     ensemble rpmd <num_beads> 
-    ensemble rpmd <num_beads> eco <omega_max>
 
 This can be understood as the NVE version of :term:`PIMD`, where no thermostat is applied.
 
@@ -48,7 +48,5 @@ If the first parameter is :attr:`trpmd`, it means that the current run will use 
 It can be used as follows::
 
     ensemble trpmd <num_beads> 
-    ensemble trpmd <num_beads> eco <omega_max>
 
 This is similar to :term:`RPMD`, but the Langevin thermosat is applied to the internal modes.
-For both :attr:`rpmd` and :attr:`trpmd`, the optional Eco parameters should be the same as in the preceding :attr:`pimd` run.

--- a/src/integrate/eco_pimd.cu
+++ b/src/integrate/eco_pimd.cu
@@ -1,0 +1,373 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*----------------------------------------------------------------------------80
+The Eco-PIMD frequencies minimise Eq. (17) of
+
+Z. Zeng and D. E. Manolopoulos, "Economised path integrals",
+arXiv:2607.06414 (2026).
+
+The shifted Newton step and line search follow the reference Fortran program
+supplied with that paper. The symmetric Hessian is diagonalised with GPUMD's
+existing cuSOLVER/hipSOLVER wrapper rather than LAPACK DSYEV. A small-x series
+avoids cancellation in the objective kernel, and a relative convergence test
+stops iterations in the flat valley of an already-converged fit.
+------------------------------------------------------------------------------*/
+
+#include "eco_pimd.cuh"
+#include <cstddef>
+#include "utilities/cusolver_wrapper.cuh"
+#include "utilities/error.cuh"
+#include <algorithm>
+#include <cmath>
+#include <utility>
+#include <vector>
+
+namespace
+{
+struct Objective
+{
+  double value = 0.0;
+  std::vector<double> gradient;
+  std::vector<double> hessian;
+};
+
+int matrix_index(const int row, const int column, const int size)
+{
+  return row + column * size;
+}
+
+Objective evaluate_objective(
+  const std::vector<double>& target,
+  const std::vector<double>& grid,
+  const std::vector<double>& weights,
+  const std::vector<double>& frequencies)
+{
+  const int number_of_grid_points = static_cast<int>(grid.size());
+  const int number_of_modes = static_cast<int>(frequencies.size());
+
+  Objective objective;
+  objective.gradient.assign(number_of_modes, 0.0);
+  objective.hessian.assign(number_of_modes * number_of_modes, 0.0);
+
+  std::vector<double> first_derivatives(number_of_modes, 0.0);
+  std::vector<double> second_derivatives(number_of_modes, 0.0);
+
+  for (int j = 0; j < number_of_grid_points; ++j) {
+    const double x_squared = grid[j] * grid[j];
+    double residual = -1.0;
+
+    for (int k = 0; k < number_of_modes; ++k) {
+      const double denominator_inverse =
+        1.0 / (frequencies[k] * frequencies[k] + x_squared);
+      const double contribution = target[j] * weights[k] * denominator_inverse;
+      residual += contribution;
+      first_derivatives[k] =
+        -2.0 * denominator_inverse * contribution * frequencies[k];
+      second_derivatives[k] = 2.0 * denominator_inverse * denominator_inverse * contribution *
+                              (3.0 * frequencies[k] * frequencies[k] - x_squared);
+    }
+
+    objective.value += 0.5 * residual * residual;
+
+    for (int k = 0; k < number_of_modes; ++k) {
+      objective.gradient[k] += residual * first_derivatives[k];
+      for (int i = 0; i <= k; ++i) {
+        objective.hessian[matrix_index(i, k, number_of_modes)] +=
+          first_derivatives[i] * first_derivatives[k];
+      }
+      objective.hessian[matrix_index(k, k, number_of_modes)] +=
+        residual * second_derivatives[k];
+    }
+  }
+
+  const double normalization = 1.0 / static_cast<double>(number_of_grid_points);
+  objective.value *= normalization;
+  for (int k = 0; k < number_of_modes; ++k) {
+    objective.gradient[k] *= normalization;
+    for (int i = 0; i <= k; ++i) {
+      const int upper_index = matrix_index(i, k, number_of_modes);
+      objective.hessian[upper_index] *= normalization;
+      objective.hessian[matrix_index(k, i, number_of_modes)] =
+        objective.hessian[upper_index];
+    }
+  }
+
+  return objective;
+}
+
+void validate_eigendecomposition(
+  const std::vector<double>& hessian,
+  const std::vector<double>& eigenvalues,
+  const std::vector<double>& eigenvectors)
+{
+  const int size = static_cast<int>(eigenvalues.size());
+  double hessian_norm_squared = 0.0;
+  double residual_norm_squared = 0.0;
+  double orthogonality_error_squared = 0.0;
+
+  for (int i = 0; i < size; ++i) {
+    if (!std::isfinite(eigenvalues[i])) {
+      PRINT_INPUT_ERROR("Non-finite eigenvalue in the Eco-PIMD Newton step.");
+    }
+    if (i > 0 && eigenvalues[i] < eigenvalues[i - 1]) {
+      PRINT_INPUT_ERROR("Unordered eigenvalues in the Eco-PIMD Newton step.");
+    }
+
+    for (int j = 0; j < size; ++j) {
+      const double hessian_element = hessian[matrix_index(i, j, size)];
+      const double eigenvector_element = eigenvectors[matrix_index(i, j, size)];
+      if (!std::isfinite(eigenvector_element)) {
+        PRINT_INPUT_ERROR("Non-finite eigenvector in the Eco-PIMD Newton step.");
+      }
+      hessian_norm_squared += hessian_element * hessian_element;
+
+      double hessian_times_vector = 0.0;
+      for (int k = 0; k < size; ++k) {
+        hessian_times_vector +=
+          hessian[matrix_index(i, k, size)] * eigenvectors[matrix_index(k, j, size)];
+      }
+      const double residual =
+        hessian_times_vector - eigenvalues[j] * eigenvector_element;
+      residual_norm_squared += residual * residual;
+    }
+  }
+
+  for (int i = 0; i < size; ++i) {
+    for (int j = 0; j < size; ++j) {
+      double overlap = 0.0;
+      for (int k = 0; k < size; ++k) {
+        overlap += eigenvectors[matrix_index(k, i, size)] *
+                   eigenvectors[matrix_index(k, j, size)];
+      }
+      if (i == j) {
+        overlap -= 1.0;
+      }
+      orthogonality_error_squared += overlap * overlap;
+    }
+  }
+
+  const double residual_error =
+    std::sqrt(residual_norm_squared) / std::max(1.0, std::sqrt(hessian_norm_squared));
+  const double orthogonality_error =
+    std::sqrt(orthogonality_error_squared) / std::max(1, size);
+  if (residual_error > 1.0e-8 || orthogonality_error > 1.0e-8) {
+    PRINT_INPUT_ERROR("Inaccurate eigendecomposition in the Eco-PIMD Newton step.");
+  }
+}
+
+std::vector<double> find_newton_direction(const Objective& objective)
+{
+  const int number_of_modes = static_cast<int>(objective.gradient.size());
+  std::vector<double> eigenvalues(number_of_modes, 0.0);
+  std::vector<double> eigenvectors(number_of_modes * number_of_modes, 0.0);
+  std::vector<double> hessian_for_solver = objective.hessian;
+
+  eigenvectors_symmetric_Jacobi(
+    number_of_modes,
+    hessian_for_solver.data(),
+    eigenvalues.data(),
+    eigenvectors.data());
+  validate_eigendecomposition(objective.hessian, eigenvalues, eigenvectors);
+
+  std::vector<double> gradient_in_eigenbasis(number_of_modes, 0.0);
+  for (int column = 0; column < number_of_modes; ++column) {
+    for (int row = 0; row < number_of_modes; ++row) {
+      gradient_in_eigenbasis[column] +=
+        eigenvectors[matrix_index(row, column, number_of_modes)] * objective.gradient[row];
+    }
+  }
+
+  const double shift =
+    std::max(1.0e-16 * eigenvalues.back(), -2.0 * eigenvalues.front());
+  for (int k = 0; k < number_of_modes; ++k) {
+    const double shifted_eigenvalue = eigenvalues[k] + shift;
+    if (!(shifted_eigenvalue > 0.0) || !std::isfinite(shifted_eigenvalue)) {
+      PRINT_INPUT_ERROR("Invalid shifted Hessian eigenvalue in the Eco-PIMD Newton step.");
+    }
+    gradient_in_eigenbasis[k] /= -shifted_eigenvalue;
+  }
+
+  std::vector<double> direction(number_of_modes, 0.0);
+  for (int row = 0; row < number_of_modes; ++row) {
+    for (int column = 0; column < number_of_modes; ++column) {
+      direction[row] += eigenvectors[matrix_index(row, column, number_of_modes)] *
+                        gradient_in_eigenbasis[column];
+    }
+  }
+  return direction;
+}
+
+bool take_newton_step(
+  const std::vector<double>& target,
+  const std::vector<double>& grid,
+  const std::vector<double>& weights,
+  std::vector<double>& frequencies,
+  Objective& objective)
+{
+  const int number_of_modes = static_cast<int>(frequencies.size());
+  const std::vector<double> direction = find_newton_direction(objective);
+
+  double directional_derivative = 0.0;
+  double gradient_norm_squared = 0.0;
+  double direction_norm_squared = 0.0;
+  for (int k = 0; k < number_of_modes; ++k) {
+    directional_derivative += objective.gradient[k] * direction[k];
+    gradient_norm_squared += objective.gradient[k] * objective.gradient[k];
+    direction_norm_squared += direction[k] * direction[k];
+  }
+  const double descent_tolerance =
+    1.0e-12 * std::sqrt(gradient_norm_squared * direction_norm_squared);
+  if (directional_derivative > descent_tolerance) {
+    PRINT_INPUT_ERROR("Eco-PIMD Newton direction is not a descent direction.");
+  }
+
+  double step_size = 2.0;
+  for (int iteration = 0; iteration < 60; ++iteration) {
+    step_size *= 0.5;
+    std::vector<double> trial_frequencies(number_of_modes, 0.0);
+    for (int k = 0; k < number_of_modes; ++k) {
+      trial_frequencies[k] = frequencies[k] + step_size * direction[k];
+    }
+
+    if (!(trial_frequencies.front() > 0.0) ||
+        !std::is_sorted(trial_frequencies.begin(), trial_frequencies.end())) {
+      continue;
+    }
+
+    Objective trial_objective =
+      evaluate_objective(target, grid, weights, trial_frequencies);
+    if (trial_objective.value <= objective.value) {
+      frequencies.swap(trial_frequencies);
+      objective = std::move(trial_objective);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void validate_initial_frequencies(
+  const std::vector<double>& frequencies, const int number_of_modes)
+{
+  if (static_cast<int>(frequencies.size()) != number_of_modes) {
+    PRINT_INPUT_ERROR("Incorrect number of initial frequencies for Eco-PIMD.");
+  }
+  if (!(frequencies.front() > 0.0) ||
+      !std::is_sorted(frequencies.begin(), frequencies.end())) {
+    PRINT_INPUT_ERROR("Eco-PIMD initial frequencies must be positive and ordered.");
+  }
+  for (const double frequency : frequencies) {
+    if (!std::isfinite(frequency)) {
+      PRINT_INPUT_ERROR("Eco-PIMD initial frequencies must be finite.");
+    }
+  }
+}
+} // namespace
+
+Eco_PIMD_Result find_eco_pimd_frequencies(
+  const int number_of_beads,
+  const double x_max,
+  const std::vector<double>& initial_frequencies)
+{
+  if (number_of_beads < 2) {
+    PRINT_INPUT_ERROR("Eco-PIMD requires at least two beads.");
+  }
+  if (!(x_max > 0.0) || !std::isfinite(x_max)) {
+    PRINT_INPUT_ERROR("Eco-PIMD requires a positive finite x_max.");
+  }
+
+  const int number_of_modes = number_of_beads / 2;
+  const int number_of_grid_points =
+    std::max(100, static_cast<int>(std::floor(10.0 * x_max + 0.5)));
+  const double grid_spacing = x_max / static_cast<double>(number_of_grid_points);
+  const double pi = std::acos(-1.0);
+
+  std::vector<double> grid(number_of_grid_points, 0.0);
+  std::vector<double> target(number_of_grid_points, 0.0);
+  for (int j = 0; j < number_of_grid_points; ++j) {
+    grid[j] = (static_cast<double>(j) + 0.5) * grid_spacing;
+    const double half_x = 0.5 * grid[j];
+    if (half_x < 0.25) {
+      const double half_x_squared = half_x * half_x;
+      target[j] = 4.0 /
+                  (1.0 / 3.0 - half_x_squared / 45.0 +
+                   2.0 * half_x_squared * half_x_squared / 945.0 -
+                   half_x_squared * half_x_squared * half_x_squared / 4725.0);
+    } else {
+      target[j] = grid[j] * grid[j] / (half_x / std::tanh(half_x) - 1.0);
+    }
+  }
+
+  std::vector<double> weights(number_of_modes, 2.0);
+  if (2 * number_of_modes == number_of_beads) {
+    weights.back() = 1.0;
+  }
+
+  Eco_PIMD_Result result;
+  std::vector<double> frequencies(number_of_modes, 0.0);
+
+  for (int k = 0; k < number_of_modes; ++k) {
+    frequencies[k] = 2.0 * static_cast<double>(number_of_beads) *
+                     std::sin(static_cast<double>(k + 1) * pi / number_of_beads);
+  }
+  Objective trotter_objective = evaluate_objective(target, grid, weights, frequencies);
+  result.rmse_trotter = std::sqrt(2.0 * trotter_objective.value);
+
+  for (int k = 0; k < number_of_modes; ++k) {
+    frequencies[k] = 2.0 * static_cast<double>(k + 1) * pi;
+  }
+  Objective matsubara_objective = evaluate_objective(target, grid, weights, frequencies);
+  result.rmse_matsubara = std::sqrt(2.0 * matsubara_objective.value);
+
+  if (!initial_frequencies.empty()) {
+    frequencies = initial_frequencies;
+    validate_initial_frequencies(frequencies, number_of_modes);
+  }
+  Objective objective = evaluate_objective(target, grid, weights, frequencies);
+
+  bool converged = false;
+  for (int iteration = 1; iteration <= 500; ++iteration) {
+    const double previous_value = objective.value;
+    if (!take_newton_step(target, grid, weights, frequencies, objective)) {
+      break;
+    }
+    result.number_of_iterations = iteration;
+    if (previous_value - objective.value <= 1.0e-12 * previous_value) {
+      converged = true;
+      break;
+    }
+  }
+
+  double maximum_gradient = 0.0;
+  for (const double gradient : objective.gradient) {
+    maximum_gradient = std::max(maximum_gradient, std::fabs(gradient));
+  }
+  if (!converged && objective.value > 1.0e-8 && maximum_gradient > 1.0e-6) {
+    PRINT_INPUT_ERROR("Eco-PIMD frequency optimisation did not converge.");
+  }
+
+  result.rmse_eco = std::sqrt(2.0 * objective.value);
+  result.independent_frequencies = frequencies;
+  result.mode_factors.assign(number_of_beads, 0.0);
+  for (int k = 1; k <= number_of_modes; ++k) {
+    result.mode_factors[k] = frequencies[k - 1] / static_cast<double>(number_of_beads);
+  }
+  for (int k = 1; k <= (number_of_beads - 1) / 2; ++k) {
+    result.mode_factors[number_of_beads - k] = result.mode_factors[k];
+  }
+
+  return result;
+}

--- a/src/integrate/eco_pimd.cuh
+++ b/src/integrate/eco_pimd.cuh
@@ -1,0 +1,38 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include <vector>
+
+struct Eco_PIMD_Result
+{
+  // omega_k / omega_P for k = 0, ..., P - 1.
+  std::vector<double> mode_factors;
+
+  // Independent dimensionless frequencies y_k = beta * hbar * omega_k.
+  // Keeping these allows a temperature-dependent calculation to use the
+  // previous solution as the next Newton starting point.
+  std::vector<double> independent_frequencies;
+
+  double rmse_trotter = 0.0;
+  double rmse_matsubara = 0.0;
+  double rmse_eco = 0.0;
+  int number_of_iterations = 0;
+};
+
+Eco_PIMD_Result find_eco_pimd_frequencies(
+  int number_of_beads,
+  double x_max,
+  const std::vector<double>& initial_frequencies = std::vector<double>());

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -898,7 +898,6 @@ void Ensemble_PIMD::compute2(
   GPU_Vector<double>& thermo)
 {
   omega_n = number_of_beads * K_B * temperature / HBAR;
-  update_eco_modes();
 
   gpu_nve_2<<<(number_of_atoms - 1) / 64 + 1, 64>>>(
     number_of_atoms,

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -23,13 +23,18 @@ References for implementation:
     Roman Korol et al., J. Chem Phys. 151, 124103 (2019).
 ------------------------------------------------------------------------------*/
 
+#include "eco_pimd.cuh"
 #include "ensemble_pimd.cuh"
 #include "langevin_utilities.cuh"
 #include "utilities/common.cuh"
 #include "utilities/gpu_macro.cuh"
+#include <algorithm>
 #include <chrono>
+#include <cmath>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <utility>
 
 void Ensemble_PIMD::initialize_rng()
 {
@@ -41,13 +46,20 @@ void Ensemble_PIMD::initialize_rng()
 };
 
 Ensemble_PIMD::Ensemble_PIMD(
-  int number_of_atoms_input, int number_of_beads_input, bool thermostat_internal_input, Atom& atom)
+  int number_of_atoms_input,
+  int number_of_beads_input,
+  bool thermostat_internal_input,
+  Atom& atom,
+  bool use_eco_pimd_input,
+  double eco_omega_max_cm1_input)
 {
   number_of_atoms = number_of_atoms_input;
   number_of_beads = number_of_beads_input;
   num_target_pressure_components = 0;
   thermostat_internal = thermostat_internal_input;
   thermostat_centroid = false;
+  use_eco_pimd = use_eco_pimd_input;
+  eco_omega_max_cm1 = eco_omega_max_cm1_input;
   initialize(atom);
 }
 
@@ -55,7 +67,9 @@ Ensemble_PIMD::Ensemble_PIMD(
   int number_of_atoms_input,
   int number_of_beads_input,
   double temperature_coupling_input,
-  Atom& atom)
+  Atom& atom,
+  bool use_eco_pimd_input,
+  double eco_omega_max_cm1_input)
 {
   number_of_atoms = number_of_atoms_input;
   number_of_beads = number_of_beads_input;
@@ -63,6 +77,8 @@ Ensemble_PIMD::Ensemble_PIMD(
   temperature_coupling = temperature_coupling_input;
   thermostat_internal = true;
   thermostat_centroid = true;
+  use_eco_pimd = use_eco_pimd_input;
+  eco_omega_max_cm1 = eco_omega_max_cm1_input;
   initialize(atom);
 }
 
@@ -73,11 +89,15 @@ Ensemble_PIMD::Ensemble_PIMD(
   int num_target_pressure_components_input,
   double target_pressure_input[6],
   double pressure_coupling_input[6],
-  Atom& atom)
+  Atom& atom,
+  bool use_eco_pimd_input,
+  double eco_omega_max_cm1_input)
 {
   number_of_atoms = number_of_atoms_input;
   number_of_beads = number_of_beads_input;
   temperature_coupling = temperature_coupling_input;
+  use_eco_pimd = use_eco_pimd_input;
+  eco_omega_max_cm1 = eco_omega_max_cm1_input;
   num_target_pressure_components = num_target_pressure_components_input;
   for (int i = 0; i < 6; i++) {
     target_pressure[i] = target_pressure_input[i];
@@ -171,10 +191,52 @@ void Ensemble_PIMD::initialize(Atom& atom)
   }
   transformation_matrix.copy_from_host(transformation_matrix_cpu.data());
 
+  if (use_eco_pimd) {
+    eco_mode_factors.resize(number_of_beads);
+  }
+
   curand_states.resize(number_of_atoms);
   int grid_size = (number_of_atoms - 1) / 128 + 1;
   initialize_curand_states<<<grid_size, 128>>>(curand_states.data(), number_of_atoms, rand());
   GPU_CHECK_KERNEL
+}
+
+void Ensemble_PIMD::update_eco_modes()
+{
+  if (!use_eco_pimd) {
+    return;
+  }
+  if (!(temperature > 0.0) || !std::isfinite(temperature)) {
+    PRINT_INPUT_ERROR("Eco-PIMD requires a positive finite temperature.");
+  }
+
+  const double temperature_tolerance =
+    1.0e-12 * std::max(1.0, std::fabs(temperature));
+  if (std::fabs(temperature - eco_last_temperature) <= temperature_tolerance) {
+    return;
+  }
+
+  // h*c/k_B in K cm; omega_max is supplied as a wavenumber in cm^-1.
+  const double cm_to_kelvin = 1.4387768775039338;
+  const double x_max = cm_to_kelvin * eco_omega_max_cm1 / temperature;
+  Eco_PIMD_Result result =
+    find_eco_pimd_frequencies(number_of_beads, x_max, eco_independent_frequencies);
+
+  eco_mode_factors.copy_from_host(result.mode_factors.data());
+  eco_independent_frequencies = std::move(result.independent_frequencies);
+  eco_last_temperature = temperature;
+
+  if (!eco_frequencies_reported) {
+    printf(
+      "    Eco-PIMD frequencies: T=%g K, x_max=%g, RMSE(Trotter)=%g, "
+      "RMSE(Eco)=%g, Newton iterations=%d.\n",
+      temperature,
+      x_max,
+      result.rmse_trotter,
+      result.rmse_eco,
+      result.number_of_iterations);
+    eco_frequencies_reported = true;
+  }
 }
 
 Ensemble_PIMD::~Ensemble_PIMD(void)
@@ -186,6 +248,8 @@ static __global__ void gpu_nve_1(
   const int number_of_atoms,
   const int number_of_beads,
   const double omega_n,
+  const bool use_eco_pimd,
+  const double* eco_mode_factors,
   const double time_step,
   const double* transformation_matrix,
   const double* g_mass,
@@ -227,7 +291,8 @@ static __global__ void gpu_nve_1(
     }
 
     for (int k = 1; k < number_of_beads; ++k) {
-      double omega_k = 2.0 * omega_n * sin(k * PI / number_of_beads);
+      double omega_k = use_eco_pimd ? omega_n * eco_mode_factors[k]
+                                     : 2.0 * omega_n * sin(k * PI / number_of_beads);
       // The exact solution is actaully not very stable:
       // double cos_factor = cos(omega_k * time_step);
       // double sin_factor = sin(omega_k * time_step);
@@ -293,6 +358,8 @@ static __global__ void gpu_langevin(
   const double temperature,
   const double temperature_coupling,
   const double omega_n,
+  const bool use_eco_pimd,
+  const double* eco_mode_factors,
   const double time_step,
   const double* transformation_matrix,
   const double* g_mass,
@@ -321,8 +388,14 @@ static __global__ void gpu_langevin(
       if (k == 0 && !thermostat_centroid) {
         continue;
       }
-      double c1 = (k == 0) ? exp(-0.5 / temperature_coupling)
-                           : exp(-time_step * omega_n * sin(k * PI / number_of_beads));
+      double c1;
+      if (k == 0) {
+        c1 = exp(-0.5 / temperature_coupling);
+      } else if (use_eco_pimd) {
+        c1 = exp(-0.5 * time_step * omega_n * eco_mode_factors[k]);
+      } else {
+        c1 = exp(-time_step * omega_n * sin(k * PI / number_of_beads));
+      }
       double c2 = sqrt((1 - c1 * c1) * K_B * temperature * number_of_beads / g_mass[n]);
       for (int d = 0; d < 3; ++d) {
         int index_kd = k * 3 + d;
@@ -775,6 +848,8 @@ void Ensemble_PIMD::langevin(const double time_step, Atom& atom)
       temperature,
       temperature_coupling,
       omega_n,
+      use_eco_pimd,
+      use_eco_pimd ? eco_mode_factors.data() : nullptr,
       time_step,
       transformation_matrix.data(),
       atom.mass.data(),
@@ -799,6 +874,7 @@ void Ensemble_PIMD::compute1(
   GPU_Vector<double>& thermo)
 {
   omega_n = number_of_beads * K_B * temperature / HBAR;
+  update_eco_modes();
 
   langevin(time_step, atom);
 
@@ -810,6 +886,8 @@ void Ensemble_PIMD::compute1(
     number_of_atoms,
     number_of_beads,
     omega_n,
+    use_eco_pimd,
+    use_eco_pimd ? eco_mode_factors.data() : nullptr,
     time_step,
     transformation_matrix.data(),
     atom.mass.data(),
@@ -827,6 +905,7 @@ void Ensemble_PIMD::compute2(
   GPU_Vector<double>& thermo)
 {
   omega_n = number_of_beads * K_B * temperature / HBAR;
+  update_eco_modes();
 
   gpu_nve_2<<<(number_of_atoms - 1) / 64 + 1, 64>>>(
     number_of_atoms,

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -46,20 +46,13 @@ void Ensemble_PIMD::initialize_rng()
 };
 
 Ensemble_PIMD::Ensemble_PIMD(
-  int number_of_atoms_input,
-  int number_of_beads_input,
-  bool thermostat_internal_input,
-  Atom& atom,
-  bool use_eco_pimd_input,
-  double eco_omega_max_cm1_input)
+  int number_of_atoms_input, int number_of_beads_input, bool thermostat_internal_input, Atom& atom)
 {
   number_of_atoms = number_of_atoms_input;
   number_of_beads = number_of_beads_input;
   num_target_pressure_components = 0;
   thermostat_internal = thermostat_internal_input;
   thermostat_centroid = false;
-  use_eco_pimd = use_eco_pimd_input;
-  eco_omega_max_cm1 = eco_omega_max_cm1_input;
   initialize(atom);
 }
 

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -28,10 +28,20 @@ class Ensemble_PIMD : public Ensemble
 {
 public:
   Ensemble_PIMD(
-    int number_of_atoms_input, int number_of_beads_input, bool thermostat_internal, Atom& atom);
+    int number_of_atoms_input,
+    int number_of_beads_input,
+    bool thermostat_internal,
+    Atom& atom,
+    bool use_eco_pimd_input,
+    double eco_omega_max_cm1_input);
 
   Ensemble_PIMD(
-    int number_of_atoms_input, int number_of_beads_input, double temperature_coupling, Atom& atom);
+    int number_of_atoms_input,
+    int number_of_beads_input,
+    double temperature_coupling,
+    Atom& atom,
+    bool use_eco_pimd_input,
+    double eco_omega_max_cm1_input);
 
   Ensemble_PIMD(
     int number_of_atoms_input,
@@ -40,7 +50,9 @@ public:
     int num_target_pressure_components,
     double target_pressure[6],
     double pressure_coupling[6],
-    Atom& atom);
+    Atom& atom,
+    bool use_eco_pimd_input,
+    double eco_omega_max_cm1_input);
 
   virtual ~Ensemble_PIMD(void);
 
@@ -64,6 +76,10 @@ protected:
   bool thermostat_internal = false;
   bool thermostat_centroid = false;
   double omega_n;
+  bool use_eco_pimd = false;
+  bool eco_frequencies_reported = false;
+  double eco_omega_max_cm1 = 0.0;
+  double eco_last_temperature = -1.0;
   GPU_Vector<gpurandState> curand_states;
   GPU_Vector<double*> position_beads;
   GPU_Vector<double*> velocity_beads;
@@ -71,11 +87,14 @@ protected:
   GPU_Vector<double*> force_beads;
   GPU_Vector<double*> virial_beads;
   GPU_Vector<double> transformation_matrix;
+  GPU_Vector<double> eco_mode_factors;
   GPU_Vector<double> kinetic_energy_virial_part;
+  std::vector<double> eco_independent_frequencies;
 
   GPU_Vector<double> sum_1024; // for intermidiate summation
 
   void initialize(Atom& atom);
+  void update_eco_modes();
   void langevin(const double time_step, Atom& atom);
   std::mt19937 rng;
   void initialize_rng();

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -28,12 +28,7 @@ class Ensemble_PIMD : public Ensemble
 {
 public:
   Ensemble_PIMD(
-    int number_of_atoms_input,
-    int number_of_beads_input,
-    bool thermostat_internal,
-    Atom& atom,
-    bool use_eco_pimd_input,
-    double eco_omega_max_cm1_input);
+    int number_of_atoms_input, int number_of_beads_input, bool thermostat_internal, Atom& atom);
 
   Ensemble_PIMD(
     int number_of_atoms_input,

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -244,15 +244,32 @@ void Integrate::initialize(
       break;
     }
     case 31: // RPMD
-      ensemble.reset(new Ensemble_PIMD(number_of_atoms, number_of_beads, false, atom));
+      ensemble.reset(new Ensemble_PIMD(
+        number_of_atoms,
+        number_of_beads,
+        false,
+        atom,
+        use_eco_pimd,
+        eco_omega_max_cm1));
       break;
     case 32: // TRPMD
-      ensemble.reset(new Ensemble_PIMD(number_of_atoms, number_of_beads, true, atom));
+      ensemble.reset(new Ensemble_PIMD(
+        number_of_atoms,
+        number_of_beads,
+        true,
+        atom,
+        use_eco_pimd,
+        eco_omega_max_cm1));
       break;
     case 33: // PIMD
       if (num_target_pressure_components == 0) {
-        ensemble.reset(
-          new Ensemble_PIMD(number_of_atoms, number_of_beads, temperature_coupling, atom));
+        ensemble.reset(new Ensemble_PIMD(
+          number_of_atoms,
+          number_of_beads,
+          temperature_coupling,
+          atom,
+          use_eco_pimd,
+          eco_omega_max_cm1));
       } else {
         ensemble.reset(new Ensemble_PIMD(
           number_of_atoms,
@@ -261,7 +278,9 @@ void Integrate::initialize(
           num_target_pressure_components,
           target_pressure,
           pressure_coupling,
-          atom));
+          atom,
+          use_eco_pimd,
+          eco_omega_max_cm1));
       }
       break;
     default:
@@ -414,6 +433,9 @@ void Integrate::parse_ensemble(
 {
   qtb_f_max = 200.0;
   qtb_n_f = 100;
+  use_eco_pimd = false;
+  eco_omega_max_cm1 = 0.0;
+  int pimd_num_param = num_param;
 
   // 1. Determine the integration method
   if (strcmp(param[1], "nve") == 0) {
@@ -519,19 +541,10 @@ void Integrate::parse_ensemble(
     // The rest of the parsing happens in the dedicated section below
   } else if (strcmp(param[1], "rpmd") == 0) {
     type = 31;
-    if (num_param != 3) {
-      PRINT_INPUT_ERROR("ensemble rpmd should have 1 parameter.");
-    }
   } else if (strcmp(param[1], "trpmd") == 0) {
     type = 32;
-    if (num_param != 3) {
-      PRINT_INPUT_ERROR("ensemble trpmd should have 1 parameter.");
-    }
   } else if (strcmp(param[1], "pimd") == 0) {
     type = 33;
-    if (num_param != 6 && num_param != 9 && num_param != 13 && num_param != 19) {
-      PRINT_INPUT_ERROR("ensemble pimd should have 4 or 7 or 11 or 17 parameters.");
-    }
   } else if (strcmp(param[1], "msst") == 0) {
     type = -1;
     ensemble.reset(new Ensemble_MSST(param, num_param));
@@ -935,6 +948,43 @@ void Integrate::parse_ensemble(
   // 5. PIMD related
   if (type >= 31 && type <= 40) {
 
+    // Optional Eco frequencies are selected by appending
+    // "eco omega_max_cm1" to an existing PIMD, RPMD, or TRPMD command.
+    if (type == 31 || type == 32) {
+      if (num_param == 5) {
+        if (strcmp(param[3], "eco") != 0) {
+          PRINT_INPUT_ERROR("The optional RPMD/TRPMD frequency scheme should be eco.");
+        }
+        use_eco_pimd = true;
+        pimd_num_param = 3;
+        if (!is_valid_real(param[4], &eco_omega_max_cm1)) {
+          PRINT_INPUT_ERROR("Eco-PIMD omega_max should be a number in cm^-1.");
+        }
+      } else if (num_param != 3) {
+        PRINT_INPUT_ERROR(
+          "ensemble rpmd/trpmd should have 1 parameter, optionally followed by "
+          "eco omega_max_cm1.");
+      }
+    } else {
+      if (num_param >= 8 && strcmp(param[num_param - 2], "eco") == 0) {
+        use_eco_pimd = true;
+        pimd_num_param = num_param - 2;
+        if (!is_valid_real(param[num_param - 1], &eco_omega_max_cm1)) {
+          PRINT_INPUT_ERROR("Eco-PIMD omega_max should be a number in cm^-1.");
+        }
+      }
+      if (
+        pimd_num_param != 6 && pimd_num_param != 9 && pimd_num_param != 13 &&
+        pimd_num_param != 19) {
+        PRINT_INPUT_ERROR(
+          "ensemble pimd should have 4, 7, 11, or 17 parameters, optionally followed by "
+          "eco omega_max_cm1.");
+      }
+    }
+    if (use_eco_pimd && eco_omega_max_cm1 <= 0.0) {
+      PRINT_INPUT_ERROR("Eco-PIMD omega_max should > 0.");
+    }
+
     // number of beads for RPMD, TRPMD, or PIMD
     if (!is_valid_int(param[2], &number_of_beads)) {
       PRINT_INPUT_ERROR("number of beads should be an integer.");
@@ -979,8 +1029,8 @@ void Integrate::parse_ensemble(
       num_target_pressure_components = 0;
 
       // pressures:
-      if (num_param >= 9) {
-        if (num_param == 13) {
+      if (pimd_num_param >= 9) {
+        if (pimd_num_param == 13) {
           for (int i = 0; i < 3; i++) {
             if (!is_valid_real(param[6 + i], &target_pressure[i])) {
               PRINT_INPUT_ERROR("Pressure should be a number.");
@@ -1000,7 +1050,7 @@ void Integrate::parse_ensemble(
             box.cpu_h[6] != 0 || box.cpu_h[7] != 0) {
             PRINT_INPUT_ERROR("Cannot use triclinic box with only 3 target pressure components.");
           }
-        } else if (num_param == 9) { // isotropic
+        } else if (pimd_num_param == 9) { // isotropic
           if (!is_valid_real(param[6], &target_pressure[0])) {
             PRINT_INPUT_ERROR("Pressure should be a number.");
           }
@@ -1310,7 +1360,7 @@ void Integrate::parse_ensemble(
       printf("    number of beads is %d.\n", number_of_beads);
       break;
     case 33:
-      if (num_param >= 9) {
+      if (pimd_num_param >= 9) {
         printf("Use NPT-PIMD for this run.\n");
       } else {
         printf("Use NVT-PIMD for this run.\n");
@@ -1319,7 +1369,7 @@ void Integrate::parse_ensemble(
       printf("    initial temperature is %g K.\n", temperature1);
       printf("    final temperature is %g K.\n", temperature2);
       printf("    tau_T is %g time_step.\n", temperature_coupling);
-      if (num_param >= 9) {
+      if (pimd_num_param >= 9) {
         if (num_target_pressure_components == 1) {
           printf("    isotropic pressure is %g GPa.\n", target_pressure[0]);
           printf("    bulk modulus is %g GPa.\n", elastic_modulus[0]);
@@ -1356,6 +1406,11 @@ void Integrate::parse_ensemble(
     default:
       PRINT_INPUT_ERROR("Invalid ensemble type.");
       break;
+  }
+
+  if (type >= 31 && type <= 33 && use_eco_pimd) {
+    printf("    use Eco-PIMD internal-mode frequencies.\n");
+    printf("    Eco-PIMD omega_max is %g cm^-1.\n", eco_omega_max_cm1);
   }
 }
 

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -244,22 +244,10 @@ void Integrate::initialize(
       break;
     }
     case 31: // RPMD
-      ensemble.reset(new Ensemble_PIMD(
-        number_of_atoms,
-        number_of_beads,
-        false,
-        atom,
-        use_eco_pimd,
-        eco_omega_max_cm1));
+      ensemble.reset(new Ensemble_PIMD(number_of_atoms, number_of_beads, false, atom));
       break;
     case 32: // TRPMD
-      ensemble.reset(new Ensemble_PIMD(
-        number_of_atoms,
-        number_of_beads,
-        true,
-        atom,
-        use_eco_pimd,
-        eco_omega_max_cm1));
+      ensemble.reset(new Ensemble_PIMD(number_of_atoms, number_of_beads, true, atom));
       break;
     case 33: // PIMD
       if (num_target_pressure_components == 0) {
@@ -541,8 +529,14 @@ void Integrate::parse_ensemble(
     // The rest of the parsing happens in the dedicated section below
   } else if (strcmp(param[1], "rpmd") == 0) {
     type = 31;
+    if (num_param != 3) {
+      PRINT_INPUT_ERROR("ensemble rpmd should have 1 parameter.");
+    }
   } else if (strcmp(param[1], "trpmd") == 0) {
     type = 32;
+    if (num_param != 3) {
+      PRINT_INPUT_ERROR("ensemble trpmd should have 1 parameter.");
+    }
   } else if (strcmp(param[1], "pimd") == 0) {
     type = 33;
   } else if (strcmp(param[1], "msst") == 0) {
@@ -949,23 +943,8 @@ void Integrate::parse_ensemble(
   if (type >= 31 && type <= 40) {
 
     // Optional Eco frequencies are selected by appending
-    // "eco omega_max_cm1" to an existing PIMD, RPMD, or TRPMD command.
-    if (type == 31 || type == 32) {
-      if (num_param == 5) {
-        if (strcmp(param[3], "eco") != 0) {
-          PRINT_INPUT_ERROR("The optional RPMD/TRPMD frequency scheme should be eco.");
-        }
-        use_eco_pimd = true;
-        pimd_num_param = 3;
-        if (!is_valid_real(param[4], &eco_omega_max_cm1)) {
-          PRINT_INPUT_ERROR("Eco-PIMD omega_max should be a number in cm^-1.");
-        }
-      } else if (num_param != 3) {
-        PRINT_INPUT_ERROR(
-          "ensemble rpmd/trpmd should have 1 parameter, optionally followed by "
-          "eco omega_max_cm1.");
-      }
-    } else {
+    // "eco omega_max_cm1" to an existing PIMD command.
+    if (type == 33) {
       if (num_param >= 8 && strcmp(param[num_param - 2], "eco") == 0) {
         use_eco_pimd = true;
         pimd_num_param = num_param - 2;
@@ -980,9 +959,9 @@ void Integrate::parse_ensemble(
           "ensemble pimd should have 4, 7, 11, or 17 parameters, optionally followed by "
           "eco omega_max_cm1.");
       }
-    }
-    if (use_eco_pimd && eco_omega_max_cm1 <= 0.0) {
-      PRINT_INPUT_ERROR("Eco-PIMD omega_max should > 0.");
+      if (use_eco_pimd && eco_omega_max_cm1 <= 0.0) {
+        PRINT_INPUT_ERROR("Eco-PIMD omega_max should > 0.");
+      }
     }
 
     // number of beads for RPMD, TRPMD, or PIMD
@@ -1408,7 +1387,7 @@ void Integrate::parse_ensemble(
       break;
   }
 
-  if (type >= 31 && type <= 33 && use_eco_pimd) {
+  if (type == 33 && use_eco_pimd) {
     printf("    use Eco-PIMD internal-mode frequencies.\n");
     printf("    Eco-PIMD omega_max is %g cm^-1.\n", eco_omega_max_cm1);
   }

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -103,6 +103,8 @@ public:
 
   // PIMD
   int number_of_beads;
+  bool use_eco_pimd = false;
+  double eco_omega_max_cm1 = 0.0;
 
   // TTM parameters
   TTM_Parameters ttm_parameters;

--- a/tests_pytest/test_eco_pimd.py
+++ b/tests_pytest/test_eco_pimd.py
@@ -1,0 +1,46 @@
+"""Focused integration test for Eco-PIMD input and frequency optimisation."""
+
+import re
+import shutil
+import subprocess
+
+import numpy as np
+import pytest
+
+from conftest import MODELS_DIR, STRUCTURES_DIR
+
+pytestmark = pytest.mark.fast
+
+
+def test_eco_pimd_frequency_fit(tmp_path, gpumd_command):
+    shutil.copy(STRUCTURES_DIR / 'C-nat16-rattled.xyz', tmp_path / 'model.xyz')
+    shutil.copy(MODELS_DIR / 'nep_C.txt', tmp_path / 'nep.txt')
+    (tmp_path / 'run.in').write_text(
+        '\n'.join([
+            'potential nep.txt',
+            'velocity 300 seed 42',
+            'time_step 0.5',
+            'ensemble pimd 8 300 300 100 eco 3500',
+            'dump_thermo 1',
+            'run 1',
+            '',
+        ])
+    )
+
+    completed = subprocess.run(
+        [gpumd_command],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    match = re.search(
+        r'RMSE\(Trotter\)=([0-9.eE+-]+), RMSE\(Eco\)=([0-9.eE+-]+)',
+        completed.stdout,
+    )
+    assert match is not None
+    rmse_trotter, rmse_eco = map(float, match.groups())
+    assert np.isfinite(rmse_trotter)
+    assert np.isfinite(rmse_eco)
+    assert rmse_eco < rmse_trotter
+    assert np.all(np.isfinite(np.loadtxt(tmp_path / 'thermo.out')))

--- a/tests_pytest/test_eco_pimd.py
+++ b/tests_pytest/test_eco_pimd.py
@@ -44,3 +44,30 @@ def test_eco_pimd_frequency_fit(tmp_path, gpumd_command):
     assert np.isfinite(rmse_eco)
     assert rmse_eco < rmse_trotter
     assert np.all(np.isfinite(np.loadtxt(tmp_path / 'thermo.out')))
+
+
+@pytest.mark.parametrize('ensemble', ['rpmd', 'trpmd'])
+def test_eco_suffix_is_rejected_for_dynamics(tmp_path, gpumd_command, ensemble):
+    shutil.copy(STRUCTURES_DIR / 'C-nat16-rattled.xyz', tmp_path / 'model.xyz')
+    shutil.copy(MODELS_DIR / 'nep_C.txt', tmp_path / 'nep.txt')
+    (tmp_path / 'run.in').write_text(
+        '\n'.join([
+            'potential nep.txt',
+            'velocity 300 seed 42',
+            'time_step 0.5',
+            f'ensemble {ensemble} 8 eco 3500',
+            'run 1',
+            '',
+        ])
+    )
+
+    completed = subprocess.run(
+        [gpumd_command],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output = completed.stdout + completed.stderr
+    assert completed.returncode != 0
+    assert f'ensemble {ensemble} should have 1 parameter.' in output


### PR DESCRIPTION
**Summary** 
This pull request adds economised path-integral (Eco-PIMD) to GPUMD, following Zezhu Zeng and David E. Manolopoulos, [Economised path integrals](https://arxiv.org/abs/2607.06414).

**Modification** 

1. Added an isolated Eco frequency optimiser in eco_pimd.cu and eco_pimd.cuh.

2. Used GPUMD’s existing cuSOLVER/hipSOLVER symmetric Jacobi eigensolver, with explicit residual and orthogonality checks.

3. Added the optional suffix eco <omega_max_cm1> for PIMD only. RPMD and TRPMD retain their original Trotter behaviour.

4. Reoptimised the Eco frequencies when the target temperature changes, using the previous solution as a warm start.

5. Preserved the original Trotter expressions and behaviour when the eco option is omitted.

6. Added input documentation, the paper reference, and a focused integration test.

**Validation** 

Right now, just reproduced the RMSE curves in Fig. 1 of the Eco-PIMD paper at (x_{\max}=50) for all even bead counts from (P=2) to (P=100). 