### PR TITLE
Write the dump_netcdf mass every frame

### DIFF
--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -76,15 +76,17 @@ Currently, the following optional arguments are accepted:
        - eV
      * - :attr:`mass`
        - ``mass``
-       - ``(atom)``
+       - ``(frame, atom)``
        - amu
      * - :attr:`group_labels`
        - ``group_labels``
        - ``(atom, grouping_method)``
        - --
 
-  The mass and the group labels cannot change during a run and are therefore written once,
-  without a frame dimension.
+  The group labels are fixed by the :ref:`simulation model file <model_xyz>` and are therefore
+  written once, without a frame dimension.
+  The mass is written every frame, because a :term:`MC` trial performed with the
+  :ref:`mc keyword <kw_mc>` changes the species of a site and with it the mass.
   The ``group_labels`` variable holds one label per grouping method, giving the group each atom
   belongs to.
   The rank-2 tensors are stored row-major, so ``virial[frame, atom, i, j]`` is the *ij*
@@ -142,6 +144,9 @@ Requirements and specifications
   and is refused for any other model.
 * :attr:`group_labels` requires at least one grouping method to be defined in
   :ref:`model.xyz <model_xyz>`.
+* The ``type`` and ``mass`` variables both carry a frame dimension, so the species and the mass
+  of an atom always refer to the same frame. A trajectory sampled alongside :term:`MC` trials is
+  therefore self-consistent.
 
 Examples
 --------

--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -87,6 +87,10 @@ Currently, the following optional arguments are accepted:
   written once, without a frame dimension.
   The mass is written every frame, because a :term:`MC` trial performed with the
   :ref:`mc keyword <kw_mc>` changes the species of a site and with it the mass.
+  Note that this also means that a lot of data is duplicated.
+  Since the mass can usually be attributed based on the atom type,
+  in most cases it is recommended *not* to write the mass but to rather assign it
+  after the fact based on the atom type in order to save storage space.
   The ``group_labels`` variable holds one label per grouping method, giving the group each atom
   belongs to.
   The rank-2 tensors are stored row-major, so ``virial[frame, atom, i, j]`` is the *ij*

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -492,7 +492,7 @@ void DUMP_NETCDF::preprocess(
     validate_file_definition();
     NC_CHECK(nc_inq_dimlen(ncid, frame_dim, &lenp));
   } else {
-    create_file(group, atom);
+    create_file(group);
   }
 }
 
@@ -523,7 +523,7 @@ void DUMP_NETCDF::define_per_frame_variable(
   }
 }
 
-void DUMP_NETCDF::create_file(const std::vector<Group>& groups, const Atom& atom)
+void DUMP_NETCDF::create_file(const std::vector<Group>& groups)
 {
   const int creation_mode = compression_level_ >= 0 ? NC_NETCDF4 : NC_64BIT_OFFSET;
   const int create_status = nc_create(filename_.c_str(), creation_mode, &ncid);
@@ -586,9 +586,10 @@ void DUMP_NETCDF::create_file(const std::vector<Group>& groups, const Atom& atom
   NC_CHECK(nc_put_att_text(ncid, cell_lengths_var, UNITS_STR, 8, "angstrom"));
   NC_CHECK(nc_put_att_text(ncid, cell_angles_var, UNITS_STR, 6, "degree"));
 
-  // Per-atom data variables. The type is written per frame, as it always has been; the
-  // quantities that cannot change during a run are defined further down without a frame
-  // dimension, so that they are stored once rather than repeated every frame.
+  // Per-atom data variables. The type and the mass are written per frame, because a Monte
+  // Carlo trial changes the species of a site and with it both of them. The group labels are
+  // fixed by the simulation model file and are defined further down without a frame dimension,
+  // so that they are stored once rather than repeated every frame.
   dimids[0] = frame_dim;
   dimids[1] = atom_dim;
   NC_CHECK(nc_def_var(ncid, TYPE_STR, NC_INT, 2, dimids, &type_var));
@@ -625,15 +626,12 @@ void DUMP_NETCDF::create_file(const std::vector<Group>& groups, const Atom& atom
   if (quantities_.has_virial_) {
     define_per_frame_variable(VIRIAL_STR, 4, 9, "eV", virial_var);
   }
-
-  // Quantities that are constant over the run. They are written once and left uncompressed,
-  // being one copy rather than one per frame.
-  const nc_type per_atom_type = precision_ == 1 ? NC_FLOAT : NC_DOUBLE;
   if (quantities_.has_mass_) {
-    dimids[0] = atom_dim;
-    NC_CHECK(nc_def_var(ncid, MASS_STR, per_atom_type, 1, dimids, &mass_var));
-    NC_CHECK(nc_put_att_text(ncid, mass_var, UNITS_STR, 3, "amu"));
+    define_per_frame_variable(MASS_STR, 2, 1, "amu", mass_var);
   }
+
+  // The group labels are constant over the run. They are written once and left uncompressed,
+  // being one copy rather than one per frame.
   if (quantities_.has_group_) {
     dimids[0] = atom_dim;
     dimids[1] = grouping_method_dim;
@@ -658,17 +656,7 @@ void DUMP_NETCDF::create_file(const std::vector<Group>& groups, const Atom& atom
   countp[1] = 5;
   NC_CHECK(nc_put_vara_text(ncid, cell_angular_var, startp, countp, "gamma"));
 
-  // The constant quantities, written once now rather than once per frame
-  if (quantities_.has_mass_) {
-    for (int n = 0; n < number_of_atoms_to_dump_; ++n) {
-      host_double_[n] = atom.cpu_mass[dump_indices_[n]];
-    }
-    pack_scalar_by_precision(
-      precision_, number_of_atoms_to_dump_, host_double_, pack_float_, pack_double_);
-    const size_t mass_start[1] = {0};
-    const size_t mass_count[1] = {size_t(number_of_atoms_to_dump_)};
-    put_packed(mass_var, mass_start, mass_count);
-  }
+  // The group labels, written once now rather than once per frame
   if (quantities_.has_group_) {
     cpu_group_labels_.resize(size_t(number_of_atoms_to_dump_) * number_of_grouping_methods_);
     for (int n = 0; n < number_of_atoms_to_dump_; ++n) {
@@ -826,6 +814,16 @@ void DUMP_NETCDF::validate_file_definition()
   }
   if (quantities_.has_virial_) {
     NC_CHECK(nc_inq_varid(ncid, VIRIAL_STR, &virial_var));
+  }
+  // The mass carries a frame dimension, so a file that stores it per atom alone has no room
+  // for the frames this run writes.
+  if (quantities_.has_mass_) {
+    NC_CHECK(nc_inq_varid(ncid, MASS_STR, &mass_var));
+    int number_of_mass_dimensions = 0;
+    NC_CHECK(nc_inq_varndims(ncid, mass_var, &number_of_mass_dimensions));
+    if (number_of_mass_dimensions != 2) {
+      append_mismatch("mass layout");
+    }
   }
 }
 
@@ -1018,6 +1016,11 @@ void DUMP_NETCDF::write(const double global_time, const Box& box, Atom& atom, Fo
       pack_float_,
       pack_double_);
     put_packed(virial_var, tensor_start, tensor_count);
+  }
+  if (quantities_.has_mass_) {
+    stage(atom.mass, 1, gather_double_, host_double_);
+    pack_scalar_by_precision(precision_, number_to_dump, host_double_, pack_float_, pack_double_);
+    put_packed(mass_var, atom_start, atom_count);
   }
 
   ++lenp;

--- a/src/measure/dump_netcdf.cuh
+++ b/src/measure/dump_netcdf.cuh
@@ -136,7 +136,7 @@ private:
 
   size_t lenp; // frame number
 
-  void create_file(const std::vector<Group>& groups, const Atom& atom);
+  void create_file(const std::vector<Group>& groups);
   void define_per_frame_variable(
     const char* name, const int rank, const int values_per_atom, const char* units, int& var);
   void load_file_definition();

--- a/tests_pytest/test_io_dump_commands.py
+++ b/tests_pytest/test_io_dump_commands.py
@@ -18,7 +18,7 @@ from ase.cell import Cell
 from ase.io import read
 from calorine.gpumd import read_xyz
 
-from conftest import MODELS_DIR
+from conftest import MODELS_DIR, make_bulk_perovskite
 from io_helpers import BASE_N_STEPS, CommandIOCase, run_and_check, run_command_io_case
 from test_parsing import read_thermo_out
 
@@ -686,6 +686,58 @@ def test_dump_netcdf_appending_to_a_file_without_recorded_quantities_is_rejected
     assert 'different number of atoms' in output, output
 
 
+def _rewrite_with_a_per_atom_mass(netcdf4, path):
+    """Copies a trajectory into a file whose mass variable is indexed by atom alone. NetCDF
+    cannot change the shape of a variable in place, so the whole file is rebuilt, keeping the
+    first frame of the mass. This is the one layout dump_netcdf cannot write itself, and so the
+    only way to present it with a file it has to refuse."""
+    scratch = path.with_suffix('.rewritten.nc')
+    with netcdf4.Dataset(path) as source, \
+            netcdf4.Dataset(scratch, 'w', format='NETCDF3_64BIT_OFFSET') as target:
+        target.setncatts({name: source.getncattr(name) for name in source.ncattrs()})
+        for name, dimension in source.dimensions.items():
+            target.createDimension(name, None if dimension.isunlimited() else len(dimension))
+        for name, variable in source.variables.items():
+            per_atom_mass = name == 'mass'
+            created = target.createVariable(
+                name, variable.dtype, ('atom',) if per_atom_mass else variable.dimensions)
+            created.setncatts({a: variable.getncattr(a) for a in variable.ncattrs()})
+            created[:] = variable[0] if per_atom_mass else variable[:]
+    scratch.replace(path)
+
+
+@pytest.mark.filterwarnings('ignore:.*already contains files from an earlier calculation')
+def test_dump_netcdf_appending_to_a_file_with_a_per_atom_mass_is_rejected(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """The mass carries a frame dimension, so a file that stores one mass per atom has no room
+    for the frames a run writes. Every other check passes on such a file -- the atom count, the
+    precision, the group and the recorded quantities all match -- so without an explicit check
+    the run would fail inside netcdf-c, naming neither the file nor the remedy."""
+    netcdf4 = pytest.importorskip('netCDF4')
+    output_path = tmp_path / 'per_atom_mass.nc'
+    case = CommandIOCase(
+        name='dump_netcdf_per_atom_mass',
+        run_in_lines=[('dump_netcdf', [1, 'per_atom_mass.nc', 'mass'])],
+        expected_output_files=['per_atom_mass.nc'])
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+    with netcdf4.Dataset(output_path) as dataset:
+        assert dataset.variables['mass'].dimensions == ('frame', 'atom')
+
+    _rewrite_with_a_per_atom_mass(netcdf4, output_path)
+    with netcdf4.Dataset(output_path) as dataset:
+        assert dataset.variables['mass'].dimensions == ('atom',)
+
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    output = result.stdout + result.stderr
+    _skip_without_netcdf(output)
+    assert result.returncode != 0, 'a file storing one mass per atom should be refused'
+    assert 'per_atom_mass.nc' in output, output
+    assert 'different mass layout' in output, output
+
+
 def test_dump_netcdf_without_velocity(
         tmp_path, structure, model_path, model_type, gpumd_command):
     netcdf4 = pytest.importorskip('netCDF4')
@@ -734,6 +786,37 @@ def test_dump_netcdf_group_double_deflate(
         assert velocities.filters()['zlib']
         assert dataset.getncattr('gpumd_grouping_method') == 0
         assert dataset.getncattr('gpumd_group_id') == 1
+
+
+def test_dump_netcdf_group_mass_is_the_mass_of_the_selected_atoms(
+        tmp_path, structure, model_path, model_type, gpumd_command):
+    """With a group selected the mass is gathered on the device, like every other per-frame
+    quantity, rather than picked out on the host. The values therefore have to be the masses of
+    exactly the atoms of that group, in the order the group lists them, which is what comparing
+    against a whole-system dump of the same run pins down."""
+    netcdf4 = pytest.importorskip('netCDF4')
+    half = len(structure) // 2
+    case = CommandIOCase(
+        name='dump_netcdf_group_mass',
+        run_in_lines=[
+            ('dump_netcdf', [1, 'group_mass.nc', 'group', 0, 1, 'mass', 'precision', 'double']),
+            ('dump_netcdf', [1, 'all_mass.nc', 'mass', 'precision', 'double']),
+        ],
+        expected_output_files=['group_mass.nc', 'all_mass.nc'],
+        n_groups=2,
+    )
+    result = run_command_io_case(
+        tmp_path, structure, model_path, model_type, gpumd_command, case)
+    _check_netcdf_result(result)
+
+    with netcdf4.Dataset(tmp_path / 'group_mass.nc') as dataset:
+        assert dataset.variables['mass'].dimensions == ('frame', 'atom')
+        group_mass = np.array(dataset.variables['mass'][:])
+    with netcdf4.Dataset(tmp_path / 'all_mass.nc') as dataset:
+        whole_mass = np.array(dataset.variables['mass'][:])
+
+    assert group_mass.shape == (BASE_N_STEPS, len(structure) - half)
+    np.testing.assert_array_equal(group_mass, whole_mass[:, half:])
 
 
 def test_dump_netcdf_multiple_groups_in_one_run(
@@ -919,15 +1002,15 @@ NETCDF_QUANTITY_LAYOUT = {
     'potential': ('potential_energy', ('frame', 'atom'), 'eV'),
     'charge': ('charge', ('frame', 'atom'), 'e'),
     'virial': ('virial', ('frame', 'atom', 'spatial', 'spatial'), 'eV'),
-    'mass': ('mass', ('atom',), 'amu'),
+    'mass': ('mass', ('frame', 'atom'), 'amu'),
     'group_labels': ('group_labels', ('atom', 'grouping_method'), None),
 }
 
 
 def test_dump_netcdf_quantity_layout(tmp_path, structure, model_path, model_type, gpumd_command):
     """Each quantity has to land in the variable, with the dimensions and units, that the
-    documentation promises, since that layout is the whole interface to the file. The mass and
-    the group labels are constant over a run and carry no frame dimension."""
+    documentation promises, since that layout is the whole interface to the file. The group
+    labels are fixed by model.xyz and carry no frame dimension."""
     netcdf4 = pytest.importorskip('netCDF4')
     quantities = list(NETCDF_QUANTITY_LAYOUT)
     case = CommandIOCase(
@@ -961,6 +1044,56 @@ def test_dump_netcdf_quantity_layout(tmp_path, structure, model_path, model_type
 
     with netcdf4.Dataset(tmp_path / 'reversed.nc') as dataset:
         assert dataset.getncattr('gpumd_quantities') == recorded
+
+
+def test_dump_netcdf_mass_follows_the_species_of_a_site(tmp_path, gpumd_command):
+    """A Monte Carlo trial changes the species of a site, and with it the mass, so the mass has
+    to be recorded per frame next to the type. Pinned to BaTiO3 with a plain NEP model rather
+    than swept over the structure/model matrix, since the mc keyword needs more than one species
+    and accepts only NEP models. The cell is repeated because mc refuses a box shorter than twice
+    the radial cutoff of the model, and the MC temperature is far above anything physical on
+    purpose, so that every trial is accepted and the masses are certain to move within the few
+    steps this suite runs."""
+    netcdf4 = pytest.importorskip('netCDF4')
+    structure = make_bulk_perovskite().repeat((2, 2, 2))
+    case = CommandIOCase(
+        name='dump_netcdf_mc_mass',
+        run_in_lines=[
+            ('mc', ['canonical', 1, 20, 10000000, 10000000]),
+            ('dump_netcdf', [1, 'mc.nc', 'mass', 'precision', 'double']),
+        ],
+        expected_output_files=['mc.nc'])
+    result = run_command_io_case(
+        tmp_path, structure, MODELS_DIR / 'nep_BaTiO3.txt', 'nep', gpumd_command, case)
+    _check_netcdf_result(result)
+
+    with netcdf4.Dataset(tmp_path / 'mc.nc') as dataset:
+        assert dataset.variables['mass'].dimensions == ('frame', 'atom')
+        mass = np.array(dataset.variables['mass'][:])
+        types = np.array(dataset.variables['type'][:])
+    assert mass.shape == (BASE_N_STEPS, len(structure))
+
+    assert not np.array_equal(types[0], types[-1]), (
+        'no trial was accepted, so this case would pass whatever the mass variable held')
+    assert not np.array_equal(mass[0], mass[-1]), (
+        'the types moved while the masses did not, so the mass is not written per frame')
+
+    # Every site of a given type carries the mass of that type in every frame, which is what
+    # makes a frame self-consistent. The map is read off the first frame, where the types and
+    # the masses both come straight from model.xyz.
+    mass_of_type = {int(t): mass[0][types[0] == t][0] for t in np.unique(types[0])}
+    for frame in range(mass.shape[0]):
+        expected = np.array([mass_of_type[int(t)] for t in types[frame]])
+        np.testing.assert_array_equal(
+            mass[frame], expected,
+            err_msg=f'frame {frame}: the mass and the type of a site disagree')
+
+    # A canonical trial permutes the species, so the composition, and with it the multiset of
+    # masses, is the same in every frame.
+    for frame in range(mass.shape[0]):
+        np.testing.assert_array_equal(
+            np.sort(mass[frame]), np.sort(mass[0]),
+            err_msg=f'frame {frame}: the canonical ensemble did not conserve the composition')
 
 
 def test_dump_netcdf_writes_only_the_requested_quantities(


### PR DESCRIPTION
## Summary

`dump_netcdf` defined the `mass` variable over the `atom` dimension alone and wrote it once, when the file was created.
A Monte Carlo trial changes the species of a site and with it the mass, so from the first accepted trial the mass in the file no longer matched the `type` variable, which already carries a frame dimension.
Any analysis that takes the mass from the trajectory file, for instance a kinetic energy or a mass-weighted velocity autocorrelation, was wrong for runs that use the `mc` keyword.

`mass` now carries a frame dimension and is written every frame, staged from the device array `atom.mass` through the same path as the other per-atom quantities, so a group selection gathers only the atoms it writes and the variable picks up chunking and deflate when compression is requested.
`dump_xyz` already behaves this way.

## Breaking changes

The `mass` variable is `(frame, atom)` instead of `(atom)`, so a reader that indexes it by atom alone needs to select a frame.

Appending to a trajectory whose `mass` has no frame dimension is refused with a message naming the file, rather than failing inside netcdf-c.
Such a file needs to be renamed or removed to start a new trajectory.

## Testing

Three tests were added to `tests_pytest/test_io_dump_commands.py`:

* the mass follows the species of a site across `mc canonical` trials, with the mass and the type of every site agreeing in every frame and the canonical composition conserved;
* with a group selected, the masses in the file are exactly those of the atoms of that group, checked against a whole-system dump of the same run;
* appending to a file whose `mass` is indexed by atom alone is refused.

The `mass` entry of the existing quantity-layout table was updated to `(frame, atom)`.

`tests_pytest` passes in full on my workstation (RTX 3080Ti) with a NetCDF-enabled build: 452 passed and 145 skipped in `test_io_dump_commands.py`, and 294 passed and 78 skipped across the rest of the fast suite.
`dump_netcdf.cu` compiles without warnings under the project warning flags.