### PR TITLE
Plumed fix

### DIFF
--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -241,6 +241,11 @@ void Run::perform_a_run()
       atom.mass);
   }
 
+  // PLUMED bias force/virial must be present before the first integration
+  // half-step. This hook is a no-op for all non-PLUMED properties and for
+  // PLUMED analysis runs with interval > 1.
+  measure.process_dynamics(0, box, atom);
+
   double initial_time_step = time_step;
 
   const auto time_begin = std::chrono::high_resolution_clock::now();
@@ -287,6 +292,11 @@ void Run::perform_a_run()
     add_spring.compute(step, group, atom);
     add_random_force.compute(step, atom);
     add_efield.compute(step, group, atom, force);
+
+    // Apply PLUMED bias after evaluating the physical force and before the
+    // second integration half-step, so both force and virial enter the MD
+    // dynamics at the correct time.
+    measure.process_dynamics(step + 1, box, atom);
 
     integrate.compute2(time_step, double(step) / number_of_steps, group, box, atom, thermo, force);
 

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -241,9 +241,6 @@ void Run::perform_a_run()
       atom.mass);
   }
 
-  // PLUMED bias force/virial must be present before the first integration
-  // half-step. This hook is a no-op for all non-PLUMED properties and for
-  // PLUMED analysis runs with interval > 1.
   measure.process_dynamics(0, box, atom);
 
   double initial_time_step = time_step;
@@ -293,9 +290,6 @@ void Run::perform_a_run()
     add_random_force.compute(step, atom);
     add_efield.compute(step, group, atom, force);
 
-    // Apply PLUMED bias after evaluating the physical force and before the
-    // second integration half-step, so both force and virial enter the MD
-    // dynamics at the correct time.
     measure.process_dynamics(step + 1, box, atom);
 
     integrate.compute2(time_step, double(step) / number_of_steps, group, box, atom, thermo, force);

--- a/src/makefile
+++ b/src/makefile
@@ -26,10 +26,10 @@ WARN_FLAGS += -Wformat -Wformat-security -Wformat-overflow -Wformat-truncation
 ifdef OS # For Windows with the cl.exe compiler
 CFLAGS = -O3 $(CUDA_ARCH)
 else # For linux
-CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)" -DDEBUG	-DUSE_PLUMED
+CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)"
 endif
-INC = -I$(HOME)/app/plumed-2.9.4-install/include -I./
-LDFLAGS = -L$(HOME)/app/plumed-2.9.4-install/lib -lplumed -lplumedKernel
+INC = -I./
+LDFLAGS =
 LIBS = -lcublas -lcusolver -lcufft
 
 

--- a/src/makefile
+++ b/src/makefile
@@ -26,7 +26,7 @@ WARN_FLAGS += -Wformat -Wformat-security -Wformat-overflow -Wformat-truncation
 ifdef OS # For Windows with the cl.exe compiler
 CFLAGS = -O3 $(CUDA_ARCH)
 else # For linux
-CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)"
+CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)" -DDEBUG	
 endif
 INC = -I./
 LDFLAGS = 

--- a/src/makefile
+++ b/src/makefile
@@ -29,7 +29,7 @@ else # For linux
 CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)"
 endif
 INC = -I./
-LDFLAGS =
+LDFLAGS = 
 LIBS = -lcublas -lcusolver -lcufft
 
 

--- a/src/makefile
+++ b/src/makefile
@@ -26,10 +26,10 @@ WARN_FLAGS += -Wformat -Wformat-security -Wformat-overflow -Wformat-truncation
 ifdef OS # For Windows with the cl.exe compiler
 CFLAGS = -O3 $(CUDA_ARCH)
 else # For linux
-CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)" -DDEBUG	
+CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)" -DDEBUG	-DUSE_PLUMED
 endif
-INC = -I./
-LDFLAGS = 
+INC = -I$(HOME)/app/plumed-2.9.4-install/include -I./
+LDFLAGS = -L$(HOME)/app/plumed-2.9.4-install/lib -lplumed -lplumedKernel
 LIBS = -lcublas -lcusolver -lcufft
 
 

--- a/src/measure/measure.cu
+++ b/src/measure/measure.cu
@@ -118,3 +118,13 @@ void Measure::process(
       force);
   }
 }
+
+void Measure::process_dynamics(
+  const int md_step,
+  Box& box,
+  Atom& atom)
+{
+  for (auto& prop : properties) {
+    prop->process_dynamics(md_step, box, atom);
+  }
+}

--- a/src/measure/measure.cuh
+++ b/src/measure/measure.cuh
@@ -59,5 +59,10 @@ public:
     Atom& atom,
     Force& force);
 
+  void process_dynamics(
+    const int md_step,
+    Box& box,
+    Atom& atom);
+
   std::vector<std::unique_ptr<Property>> properties;
 };

--- a/src/measure/plumed.cu
+++ b/src/measure/plumed.cu
@@ -32,47 +32,39 @@ Interface to the PLUMED plugin: https://www.plumed.org
 
 const double ENERGY_UNIT_CONVERSION = N_A * E_C / 1000; // from eV to kJ/mol
 
-static __global__ void gpu_sum(const int N, const double* g_data, double* g_data_sum)
-{
-  int number_of_rounds = (N - 1) / 1024 + 1;
-  __shared__ double s_data[1024];
-  s_data[threadIdx.x] = 0.0;
-  for (int round = 0; round < number_of_rounds; ++round) {
-    int n = threadIdx.x + round * 1024;
-    if (n < N) {
-      s_data[threadIdx.x] += g_data[n + blockIdx.x * N];
-    }
-  }
-  __syncthreads();
-  for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
-    if (threadIdx.x < offset) {
-      s_data[threadIdx.x] += s_data[threadIdx.x + offset];
-    }
-    __syncthreads();
-  }
-  if (threadIdx.x == 0) {
-    g_data_sum[blockIdx.x] = s_data[0];
-  }
-}
-
-static void __global__ gpu_scale_virial(
+static __global__ void gpu_add_plumed_virial(
   const int N,
-  const double* factors,
+  const double vxx,
+  const double vyy,
+  const double vzz,
+  const double vxy,
+  const double vxz,
+  const double vyz,
+  const double vyx,
+  const double vzx,
+  const double vzy,
   double* g_sxx,
   double* g_syy,
   double* g_szz,
   double* g_sxy,
   double* g_sxz,
-  double* g_syz)
+  double* g_syz,
+  double* g_syx,
+  double* g_szx,
+  double* g_szy)
 {
   const int i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < N) {
-    g_sxx[i] *= factors[0];
-    g_syy[i] *= factors[4];
-    g_szz[i] *= factors[8];
-    g_sxy[i] *= factors[1];
-    g_sxz[i] *= factors[2];
-    g_syz[i] *= factors[5];
+    const double inv_N = 1.0 / N;
+    g_sxx[i] += vxx * inv_N;
+    g_syy[i] += vyy * inv_N;
+    g_szz[i] += vzz * inv_N;
+    g_sxy[i] += vxy * inv_N;
+    g_sxz[i] += vxz * inv_N;
+    g_syz[i] += vyz * inv_N;
+    g_syx[i] += vyx * inv_N;
+    g_szx[i] += vzx * inv_N;
+    g_szy[i] += vzy * inv_N;
   }
 }
 
@@ -86,11 +78,8 @@ void PLUMED::preprocess(
   Force& force)
 {
   n_atom = atom.number_of_atoms;
-  gpu_v_vector.resize(6);
-  gpu_v_factor.resize(9);
   cpu_b_vector = std::vector<double>(9);
   cpu_v_vector = std::vector<double>(9);
-  cpu_v_factor = std::vector<double>(9);
   cpu_m_vector = std::vector<double>(3 * n_atom);
   cpu_f_vector = std::vector<double>(3 * n_atom);
   cpu_q_vector = std::vector<double>(3 * n_atom);
@@ -164,6 +153,84 @@ void PLUMED::init(const double ts, const double T)
   plumed_cmd(plumed_main, "init", NULL);
 }
 
+void PLUMED::calculate(int plumed_step, Box& box, Atom& atom)
+{
+  atom.force_per_atom.copy_to_host(cpu_f_vector.data());
+  atom.position_per_atom.copy_to_host(cpu_q_vector.data());
+
+  cpu_b_vector[0] = box.cpu_h[0];
+  cpu_b_vector[1] = box.cpu_h[3];
+  cpu_b_vector[2] = box.cpu_h[6];
+  cpu_b_vector[3] = box.cpu_h[1];
+  cpu_b_vector[4] = box.cpu_h[4];
+  cpu_b_vector[5] = box.cpu_h[7];
+  cpu_b_vector[6] = box.cpu_h[2];
+  cpu_b_vector[7] = box.cpu_h[5];
+  cpu_b_vector[8] = box.cpu_h[8];
+
+  fill(cpu_v_vector.begin(), cpu_v_vector.end(), 0.0);
+  stop_flag = 0;
+
+  plumed_cmd(plumed_main, "setStep", &plumed_step);
+  plumed_cmd(plumed_main, "setMasses", cpu_m_vector.data());
+  plumed_cmd(plumed_main, "setBox", cpu_b_vector.data());
+  plumed_cmd(plumed_main, "setVirial", cpu_v_vector.data());
+  plumed_cmd(plumed_main, "setForcesX", &(cpu_f_vector.data()[0 * n_atom]));
+  plumed_cmd(plumed_main, "setForcesY", &(cpu_f_vector.data()[1 * n_atom]));
+  plumed_cmd(plumed_main, "setForcesZ", &(cpu_f_vector.data()[2 * n_atom]));
+  plumed_cmd(plumed_main, "setPositionsX", &(cpu_q_vector.data()[0 * n_atom]));
+  plumed_cmd(plumed_main, "setPositionsY", &(cpu_q_vector.data()[1 * n_atom]));
+  plumed_cmd(plumed_main, "setPositionsZ", &(cpu_q_vector.data()[2 * n_atom]));
+  plumed_cmd(plumed_main, "setStopFlag", &stop_flag);
+  plumed_cmd(plumed_main, "prepareCalc", NULL);
+  plumed_cmd(plumed_main, "performCalc", NULL);
+  plumed_cmd(plumed_main, "getBias", &bias_energy);
+
+  atom.force_per_atom.copy_from_host(cpu_f_vector.data());
+
+  // PLUMED and GPUMD use opposite virial sign conventions. Distribute the
+  // global PLUMED bias virial uniformly over atoms so that the total virial
+  // seen by the GPUMD pressure/barostat is correct without dividing by the
+  // pre-existing physical virial.
+  gpu_add_plumed_virial<<<(n_atom - 1) / 128 + 1, 128>>>(
+    n_atom,
+    -cpu_v_vector[0],
+    -cpu_v_vector[4],
+    -cpu_v_vector[8],
+    -cpu_v_vector[1],
+    -cpu_v_vector[2],
+    -cpu_v_vector[5],
+    -cpu_v_vector[3],
+    -cpu_v_vector[6],
+    -cpu_v_vector[7],
+    atom.virial_per_atom.data() + n_atom * 0,
+    atom.virial_per_atom.data() + n_atom * 1,
+    atom.virial_per_atom.data() + n_atom * 2,
+    atom.virial_per_atom.data() + n_atom * 3,
+    atom.virial_per_atom.data() + n_atom * 4,
+    atom.virial_per_atom.data() + n_atom * 5,
+    atom.virial_per_atom.data() + n_atom * 6,
+    atom.virial_per_atom.data() + n_atom * 7,
+    atom.virial_per_atom.data() + n_atom * 8);
+  GPU_CHECK_KERNEL
+}
+
+void PLUMED::process_dynamics(
+  const int md_step,
+  Box& box,
+  Atom& atom)
+{
+  // Biased PLUMED simulations require interval = 1. In this case PLUMED must
+  // modify force/virial before the second integration half-step. The initial
+  // md_step = 0 call supplies the bias force for the first half-step.
+  if (interval != 1) {
+    return;
+  }
+  dynamics_mode = true;
+  step = md_step;
+  calculate(step, box, atom);
+}
+
 void PLUMED::process(
   const int number_of_steps,
   int step_input,
@@ -178,68 +245,16 @@ void PLUMED::process(
   Atom& atom,
   Force& force)
 {
-  if (step_input % interval != 0) {
+  // interval = 1 is handled in process_dynamics() so the PLUMED bias enters
+  // the velocity-Verlet integration at the correct point.
+  if (dynamics_mode || step_input % interval != 0) {
     return;
   }
 
-  std::vector<double> tmp(6);
+  // Keep the historical invocation schedule when the dynamics hook is not used
+  // (for example in other executables) and for analysis-only interval > 1.
   step += interval;
-
-  atom.force_per_atom.copy_to_host(cpu_f_vector.data());
-  atom.position_per_atom.copy_to_host(cpu_q_vector.data());
-
-  cpu_b_vector[0] = box.cpu_h[0];
-  cpu_b_vector[1] = box.cpu_h[3];
-  cpu_b_vector[2] = box.cpu_h[6];
-  cpu_b_vector[3] = box.cpu_h[1];
-  cpu_b_vector[4] = box.cpu_h[4];
-  cpu_b_vector[5] = box.cpu_h[7];
-  cpu_b_vector[6] = box.cpu_h[2];
-  cpu_b_vector[7] = box.cpu_h[5];
-  cpu_b_vector[8] = box.cpu_h[8];
-
-  gpu_sum<<<6, 1024>>>(n_atom, atom.virial_per_atom.data(), gpu_v_vector.data());
-  GPU_CHECK_KERNEL
-  gpu_v_vector.copy_to_host(tmp.data());
-  fill(cpu_v_vector.begin(), cpu_v_vector.end(), 0.0);
-
-  plumed_cmd(plumed_main, "setStep", &step);
-  plumed_cmd(plumed_main, "setMasses", cpu_m_vector.data());
-  plumed_cmd(plumed_main, "setBox", cpu_b_vector.data());
-  plumed_cmd(plumed_main, "setVirial", cpu_v_vector.data());
-  plumed_cmd(plumed_main, "setForcesX", &(cpu_f_vector.data()[0 * n_atom]));
-  plumed_cmd(plumed_main, "setForcesY", &(cpu_f_vector.data()[1 * n_atom]));
-  plumed_cmd(plumed_main, "setForcesZ", &(cpu_f_vector.data()[2 * n_atom]));
-  plumed_cmd(plumed_main, "setPositionsX", &(cpu_q_vector.data()[0 * n_atom]));
-  plumed_cmd(plumed_main, "setPositionsY", &(cpu_q_vector.data()[1 * n_atom]));
-  plumed_cmd(plumed_main, "setPositionsZ", &(cpu_q_vector.data()[2 * n_atom]));
-  plumed_cmd(plumed_main, "prepareCalc", NULL);
-  plumed_cmd(plumed_main, "performCalc", NULL);
-  plumed_cmd(plumed_main, "getBias", &bias_energy);
-  plumed_cmd(plumed_main, "setStopFlag", &stop_flag);
-
-  atom.force_per_atom.copy_from_host(cpu_f_vector.data());
-
-  cpu_v_factor[0] = (tmp[0] - cpu_v_vector[0]) / tmp[0];
-  cpu_v_factor[1] = (tmp[3] - cpu_v_vector[1]) / tmp[3];
-  cpu_v_factor[2] = (tmp[4] - cpu_v_vector[2]) / tmp[4];
-  cpu_v_factor[3] = (tmp[3] - cpu_v_vector[3]) / tmp[3];
-  cpu_v_factor[4] = (tmp[1] - cpu_v_vector[4]) / tmp[1];
-  cpu_v_factor[5] = (tmp[5] - cpu_v_vector[5]) / tmp[5];
-  cpu_v_factor[6] = (tmp[4] - cpu_v_vector[6]) / tmp[4];
-  cpu_v_factor[7] = (tmp[5] - cpu_v_vector[7]) / tmp[5];
-  cpu_v_factor[8] = (tmp[2] - cpu_v_vector[8]) / tmp[2];
-  gpu_v_factor.copy_from_host(cpu_v_factor.data());
-  gpu_scale_virial<<<(n_atom - 1) / 128 + 1, 128>>>(
-    n_atom,
-    gpu_v_factor.data(),
-    atom.virial_per_atom.data() + n_atom * 0,
-    atom.virial_per_atom.data() + n_atom * 1,
-    atom.virial_per_atom.data() + n_atom * 2,
-    atom.virial_per_atom.data() + n_atom * 3,
-    atom.virial_per_atom.data() + n_atom * 4,
-    atom.virial_per_atom.data() + n_atom * 5);
-  GPU_CHECK_KERNEL
+  calculate(step, box, atom);
 }
 
 void PLUMED::postprocess(

--- a/src/measure/plumed.cuh
+++ b/src/measure/plumed.cuh
@@ -29,6 +29,7 @@ public:
   int step = 0;
   int interval = 1;
   int use_plumed = 0;
+  bool dynamics_mode = false;
 
   PLUMED(const char** param, int num_param);
   
@@ -58,6 +59,11 @@ public:
       Atom& atom,
       Force& force);
 
+  virtual void process_dynamics(
+    const int md_step,
+    Box& box,
+    Atom& atom);
+
   virtual void postprocess(
     Atom& atom,
     Box& box,
@@ -75,15 +81,14 @@ protected:
   double total_energy;
   char input_file[1024];
   char output_file[1024];
-  GPU_Vector<double> gpu_v_vector;  // Total Virial (GPU)
-  GPU_Vector<double> gpu_v_factor;  // Scaling factor of the virial (GPU)
   std::vector<double> cpu_m_vector; // Mass
   std::vector<double> cpu_b_vector; // Box
   std::vector<double> cpu_f_vector; // Forces
   std::vector<double> cpu_q_vector; // Positions
-  std::vector<double> cpu_v_vector; // Total Virial (CPU)
-  std::vector<double> cpu_v_factor; // Scaling factor of the virial (CPU)
+  std::vector<double> cpu_v_vector; // PLUMED virial (CPU)
   plumed plumed_main;
+
+  void calculate(int plumed_step, Box& box, Atom& atom);
 };
 
 #endif

--- a/src/measure/property.cuh
+++ b/src/measure/property.cuh
@@ -57,8 +57,6 @@ public:
       Atom& atom,
       Force& force) = 0;
 
-  // Optional hook for force modifiers that must be applied after the physical
-  // force is evaluated and before the second integration half-step.
   virtual void process_dynamics(
     const int md_step,
     Box& box,

--- a/src/measure/property.cuh
+++ b/src/measure/property.cuh
@@ -57,6 +57,15 @@ public:
       Atom& atom,
       Force& force) = 0;
 
+  // Optional hook for force modifiers that must be applied after the physical
+  // force is evaluated and before the second integration half-step.
+  virtual void process_dynamics(
+    const int md_step,
+    Box& box,
+    Atom& atom)
+  {
+  }
+
   virtual void postprocess(
     Atom& atom,
     Box& box,


### PR DESCRIPTION

# **Summary** (Briefly summarize the purpose of this pull request)

This PR corrects the integration of PLUMED bias forces and virials in GPUMD.

Fixes #619 

# **Modification** (Describe the main changes made in this pull request)

Problems fixed:

* the PLUMED bias force was not included in the current second velocity-Verlet half-step
* the PLUMED virial was added only after the NPT barostat had already used the virial
* only 6 of the 9 components of virial_per_atom were updated

# **Licensing** (Please read and confirm before submitting this pull request)

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.

# Validation

## NVE

[nve_plumed.zip](https://github.com/user-attachments/files/31338956/nve_plumed.zip)

A 250-atom PbTe system was simulated for 10 ps with a PLUMED harmonic distance restraint.

Because the PLUMED bias energy is not included in `thermo.out`, the conserved quantity should be

$$
E_{\mathrm{tot}} = KE + PE + E_{\mathrm{bias}}.
$$

Master does not conserve this and the fixed version does:

<img width="1440" height="900" alt="plumed_nve_energy_conservation" src="https://github.com/user-attachments/assets/05719ebd-debb-4b55-8618-d80d3bfbae24" />


## NPT 
[npt_plumed.zip](https://github.com/user-attachments/files/31338955/npt_plumed.zip)

A PLUMED volume restraint was chosen such that at the initial configuration

$$
\frac{\partial U_{\mathrm{bias}}}{\partial V}
=0.01\ {\rm eV/A^3}.
$$

The expected isotropic stress contribution is therefore

$$
0.01\times160.21766208
=1.6021766\ {\rm GPa}.
$$

The difference between the old and corrected implementations in the first NPT step is

sxx: 1.6021777 GPa
syy: 1.6021777 GPa
szz: 1.6021777 GPa

while the three shear components are unchanged.

This agrees with the analytical PLUMED virial contribution to approximately (10^{-6}) GPa and confirms that the corrected PLUMED virial is included before the NPT barostat.

<img width="1320" height="900" alt="plumed_npt_virial_validation" src="https://github.com/user-attachments/assets/68775cee-975e-464b-9091-007e48f1bc3f" />



