### PR TITLE
fix unwrapped position calculations

### DIFF
--- a/src/force/force.cu
+++ b/src/force/force.cu
@@ -421,7 +421,8 @@ void Force::set_hnemdec_parameters(
   hnemd_fe_[2] = hnemd_fe_z;
 }
 
-static __global__ void gpu_apply_pbc(int N, Box box, double* g_x, double* g_y, double* g_z)
+static __global__ void gpu_apply_pbc(
+  int N, Box box, double* g_x, double* g_y, double* g_z, int* g_position_image)
 {
   int n = blockIdx.x * blockDim.x + threadIdx.x;
   if (n < N) {
@@ -434,22 +435,34 @@ static __global__ void gpu_apply_pbc(int N, Box box, double* g_x, double* g_y, d
     if (box.pbc_x == 1) {
       if (sx < 0.0) {
         sx += 1.0;
+        if (g_position_image != nullptr)
+          g_position_image[n]--;
       } else if (sx > 1.0) {
         sx -= 1.0;
+        if (g_position_image != nullptr)
+          g_position_image[n]++;
       }
     }
     if (box.pbc_y == 1) {
       if (sy < 0.0) {
         sy += 1.0;
+        if (g_position_image != nullptr)
+          g_position_image[n + N]--;
       } else if (sy > 1.0) {
         sy -= 1.0;
+        if (g_position_image != nullptr)
+          g_position_image[n + N]++;
       }
     }
     if (box.pbc_z == 1) {
       if (sz < 0.0) {
         sz += 1.0;
+        if (g_position_image != nullptr)
+          g_position_image[n + N * 2]--;
       } else if (sz > 1.0) {
         sz -= 1.0;
+        if (g_position_image != nullptr)
+          g_position_image[n + N * 2]++;
       }
     }
     g_x[n] = box.cpu_h[0] * sx + box.cpu_h[1] * sy + box.cpu_h[2] * sz;
@@ -499,7 +512,8 @@ void Force::compute(
       box,
       position_per_atom.data(),
       position_per_atom.data() + number_of_atoms,
-      position_per_atom.data() + number_of_atoms * 2);
+      position_per_atom.data() + number_of_atoms * 2,
+      nullptr);
   }
 
   initialize_properties<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
@@ -777,7 +791,8 @@ void Force::compute(
   GPU_Vector<double>& force_per_atom,
   GPU_Vector<double>& virial_per_atom,
   GPU_Vector<double>& velocity_per_atom,
-  GPU_Vector<double>& mass_per_atom)
+  GPU_Vector<double>& mass_per_atom,
+  int* position_image)
 {
   box.set_is_orthogonal();
 
@@ -788,7 +803,8 @@ void Force::compute(
       box,
       position_per_atom.data(),
       position_per_atom.data() + number_of_atoms,
-      position_per_atom.data() + number_of_atoms * 2);
+      position_per_atom.data() + number_of_atoms * 2,
+      position_image);
   }
 
   initialize_properties<<<(number_of_atoms - 1) / 128 + 1, 128>>>(

--- a/src/force/force.cuh
+++ b/src/force/force.cuh
@@ -49,7 +49,8 @@ public:
     GPU_Vector<double>& force_per_atom,
     GPU_Vector<double>& virial_per_atom,
     GPU_Vector<double>& velocity_per_atom,
-    GPU_Vector<double>& mass_per_atom);
+    GPU_Vector<double>& mass_per_atom,
+    int* position_image = nullptr);
 
   void finalize();
 

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -292,43 +292,6 @@ void Integrate::finalize()
   deform_z = 0;
 }
 
-static __global__ void gpu_copy_position(
-  const int number_of_particles,
-  const double* g_xi,
-  const double* g_yi,
-  const double* g_zi,
-  double* g_xo,
-  double* g_yo,
-  double* g_zo)
-{
-  const int i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i < number_of_particles) {
-    g_xo[i] = g_xi[i];
-    g_yo[i] = g_yi[i];
-    g_zo[i] = g_zi[i];
-  }
-}
-
-static __global__ void gpu_update_unwrapped_position(
-  const int number_of_particles,
-  const double* g_xnew,
-  const double* g_ynew,
-  const double* g_znew,
-  const double* g_xold,
-  const double* g_yold,
-  const double* g_zold,
-  double* g_xo,
-  double* g_yo,
-  double* g_zo)
-{
-  const int i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i < number_of_particles) {
-    g_xo[i] += g_xnew[i] - g_xold[i];
-    g_yo[i] += g_ynew[i] - g_yold[i];
-    g_zo[i] += g_znew[i] - g_zold[i];
-  }
-}
-
 void Integrate::compute1(
   const double time_step,
   const double step_over_number_of_steps,
@@ -344,34 +307,7 @@ void Integrate::compute1(
       temperature1 + (temperature2 - temperature1) * step_over_number_of_steps;
   }
 
-  if (atom.unwrapped_position.size() > 0) {
-    gpu_copy_position<<<(atom.number_of_atoms - 1) / 128 + 1, 128>>>(
-      atom.number_of_atoms,
-      atom.position_per_atom.data(),
-      atom.position_per_atom.data() + atom.number_of_atoms,
-      atom.position_per_atom.data() + atom.number_of_atoms * 2,
-      atom.position_temp.data(),
-      atom.position_temp.data() + atom.number_of_atoms,
-      atom.position_temp.data() + atom.number_of_atoms * 2);
-    GPU_CHECK_KERNEL
-  }
-
   ensemble->compute1(time_step, group, box, atom, thermo);
-
-  if (atom.unwrapped_position.size() > 0) {
-    gpu_update_unwrapped_position<<<(atom.number_of_atoms - 1) / 128 + 1, 128>>>(
-      atom.number_of_atoms,
-      atom.position_per_atom.data(),
-      atom.position_per_atom.data() + atom.number_of_atoms,
-      atom.position_per_atom.data() + atom.number_of_atoms * 2,
-      atom.position_temp.data(),
-      atom.position_temp.data() + atom.number_of_atoms,
-      atom.position_temp.data() + atom.number_of_atoms * 2,
-      atom.unwrapped_position.data(),
-      atom.unwrapped_position.data() + atom.number_of_atoms,
-      atom.unwrapped_position.data() + atom.number_of_atoms * 2);
-    GPU_CHECK_KERNEL
-  }
 }
 
 void Integrate::compute2(

--- a/src/main_gpumd/add_spring.cu
+++ b/src/main_gpumd/add_spring.cu
@@ -527,13 +527,7 @@ void Add_Spring::load_restart(const int call_id, const int previous_call_id)
 void Add_Spring::parse(const char** param, int num_param, const std::vector<Group>& groups, Atom& atom)
 {
   printf("Add spring [%d call(s)].\n", num_calls_);
-  if (atom.unwrapped_position.size() < atom.position_per_atom.size()) {
-    atom.unwrapped_position.resize(atom.position_per_atom.size());
-    atom.unwrapped_position.copy_from_device(atom.position_per_atom.data());
-  }
-  if (atom.position_temp.size() < atom.position_per_atom.size()) {
-    atom.position_temp.resize(atom.position_per_atom.size());
-  }
+  atom.enable_unwrapped_position();
 
   if (num_calls_ >= MAX_SPRING_CALLS) {
     std::string error_msg = "add_spring cannot be used more than " + std::to_string(MAX_SPRING_CALLS) + " times.\n";

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -238,9 +238,11 @@ void Run::perform_a_run()
       atom.force_per_atom,
       atom.virial_per_atom,
       atom.velocity_per_atom,
-      atom.mass);
+      atom.mass,
+      atom.position_image.size() > 0 ? atom.position_image.data() : nullptr);
   }
 
+  atom.update_unwrapped_position(box);
   measure.process_dynamics(0, box, atom);
 
   double initial_time_step = time_step;
@@ -281,9 +283,11 @@ void Run::perform_a_run()
         atom.force_per_atom,
         atom.virial_per_atom,
         atom.velocity_per_atom,
-        atom.mass);
+        atom.mass,
+        atom.position_image.size() > 0 ? atom.position_image.data() : nullptr);
     }
 
+    atom.update_unwrapped_position(box);
     electron_stop.compute(time_step, atom);
     add_force.compute(step, group, atom);
     add_spring.compute(step, group, atom);
@@ -293,6 +297,7 @@ void Run::perform_a_run()
     measure.process_dynamics(step + 1, box, atom);
 
     integrate.compute2(time_step, double(step) / number_of_steps, group, box, atom, thermo, force);
+    atom.update_unwrapped_position(box);
 
     mc.compute(step, number_of_steps, atom, box, group);
 

--- a/src/measure/dump_netcdf.cu
+++ b/src/measure/dump_netcdf.cu
@@ -263,17 +263,8 @@ DUMP_NETCDF::DUMP_NETCDF(
 
   parse(param, num_param, groups);
 
-  // The integrator only maintains the unwrapped positions while this array is non-empty, so
-  // asking for them has to allocate it. Unlike dump_xyz this is done only when the quantity was
-  // requested, so that a run that does not ask for it does not pay for the unwrapping.
   if (quantities_.has_unwrapped_position_) {
-    if (atom.unwrapped_position.size() < atom.number_of_atoms * 3) {
-      atom.unwrapped_position.resize(atom.number_of_atoms * 3);
-      atom.unwrapped_position.copy_from_device(atom.position_per_atom.data());
-    }
-    if (atom.position_temp.size() < atom.number_of_atoms * 3) {
-      atom.position_temp.resize(atom.number_of_atoms * 3);
-    }
+    atom.enable_unwrapped_position();
   }
 
   property_name = "dump_netcdf";

--- a/src/measure/dump_xyz.cu
+++ b/src/measure/dump_xyz.cu
@@ -57,13 +57,7 @@ Dump_XYZ::Dump_XYZ(const char** param, int num_param, const std::vector<Group>& 
   is_nep_charge = check_is_nep_charge();
 
   parse(param, num_param, groups);
-  if (atom.unwrapped_position.size() < atom.number_of_atoms * 3) {
-    atom.unwrapped_position.resize(atom.number_of_atoms * 3);
-    atom.unwrapped_position.copy_from_device(atom.position_per_atom.data());
-  }
-  if (atom.position_temp.size() < atom.number_of_atoms * 3) {
-    atom.position_temp.resize(atom.number_of_atoms * 3);
-  }
+  atom.enable_unwrapped_position();
   property_name = "dump_xyz";
 }
 

--- a/src/measure/iron_conductivity.cu
+++ b/src/measure/iron_conductivity.cu
@@ -261,13 +261,7 @@ void IC::postprocess(
 IC::IC(const char** param, const int num_param, Atom& atom)
 {
   parse(param, num_param);
-  if (atom.unwrapped_position.size() < atom.number_of_atoms * 3) {
-    atom.unwrapped_position.resize(atom.number_of_atoms * 3);
-    atom.unwrapped_position.copy_from_device(atom.position_per_atom.data());
-  }
-  if (atom.position_temp.size() < atom.number_of_atoms * 3) {
-    atom.position_temp.resize(atom.number_of_atoms * 3);
-  }
+  atom.enable_unwrapped_position();
   property_name = "compute_ic";
 }
 

--- a/src/measure/msd.cu
+++ b/src/measure/msd.cu
@@ -468,13 +468,7 @@ void MSD::postprocess(
 MSD::MSD(const char** param, const int num_param, const std::vector<Group>& groups, Atom& atom)
 {
   parse(param, num_param, groups);
-  if (atom.unwrapped_position.size() < atom.number_of_atoms * 3) {
-    atom.unwrapped_position.resize(atom.number_of_atoms * 3);
-    atom.unwrapped_position.copy_from_device(atom.position_per_atom.data());
-  }
-  if (atom.position_temp.size() < atom.number_of_atoms * 3) {
-    atom.position_temp.resize(atom.number_of_atoms * 3);
-  }
+  atom.enable_unwrapped_position();
   property_name = "compute_msd";
 }
 

--- a/src/model/atom.cu
+++ b/src/model/atom.cu
@@ -18,6 +18,7 @@ The class defining the simulation box.
 ------------------------------------------------------------------------------*/
 
 #include "atom.cuh"
+#include "box.cuh"
 #include "utilities/error.cuh"
 #include "utilities/gpu_macro.cuh"
 #include <cmath>
@@ -31,4 +32,49 @@ int Atom::number_of_type(std::string& symbol)
       sum++;
   }
   return sum;
+}
+
+static __global__ void gpu_update_unwrapped_position(
+  const int number_of_atoms,
+  const Box box,
+  const double* position,
+  const int* image,
+  double* unwrapped_position)
+{
+  const int n = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n < number_of_atoms) {
+    const int ix = image[n];
+    const int iy = image[n + number_of_atoms];
+    const int iz = image[n + number_of_atoms * 2];
+    unwrapped_position[n] =
+      position[n] + box.cpu_h[0] * ix + box.cpu_h[1] * iy + box.cpu_h[2] * iz;
+    unwrapped_position[n + number_of_atoms] =
+      position[n + number_of_atoms] + box.cpu_h[3] * ix + box.cpu_h[4] * iy + box.cpu_h[5] * iz;
+    unwrapped_position[n + number_of_atoms * 2] =
+      position[n + number_of_atoms * 2] +
+      box.cpu_h[6] * ix + box.cpu_h[7] * iy + box.cpu_h[8] * iz;
+  }
+}
+
+void Atom::enable_unwrapped_position()
+{
+  if (unwrapped_position.size() < number_of_atoms * 3) {
+    unwrapped_position.resize(number_of_atoms * 3);
+    unwrapped_position.copy_from_device(position_per_atom.data());
+    position_image.resize(number_of_atoms * 3, 0);
+  }
+}
+
+void Atom::update_unwrapped_position(const Box& box)
+{
+  if (unwrapped_position.size() == 0)
+    return;
+
+  gpu_update_unwrapped_position<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
+    number_of_atoms,
+    box,
+    position_per_atom.data(),
+    position_image.data(),
+    unwrapped_position.data());
+  GPU_CHECK_KERNEL
 }

--- a/src/model/atom.cuh
+++ b/src/model/atom.cuh
@@ -18,6 +18,8 @@
 #include <string>
 #include <vector>
 
+class Box;
+
 class Atom
 {
 public:
@@ -33,7 +35,7 @@ public:
   GPU_Vector<double> mass;               // per-atom mass (1 component)
   GPU_Vector<float> charge;              // per-atom charge (1 component)
   GPU_Vector<double> position_per_atom;  // per-atom position (3 components)
-  GPU_Vector<double> position_temp;      // used to calculated unwrapped_position
+  GPU_Vector<int> position_image;        // per-atom periodic image (3 components)
   GPU_Vector<double> unwrapped_position; // unwrapped per-atom position (3 components)
   GPU_Vector<double> velocity_per_atom;  // per-atom velocity (3 components)
   GPU_Vector<double> force_per_atom;     // per-atom force (3 components)
@@ -49,4 +51,6 @@ public:
   std::vector<GPU_Vector<double>> virial_beads;
 
   int number_of_type(std::string& symbol);
+  void enable_unwrapped_position();
+  void update_unwrapped_position(const Box& box);
 };


### PR DESCRIPTION
# **Summary** (Briefly summarize the purpose of this pull request)

Fix #1470 

# **Modification** (Describe the main changes made in this pull request)

This PR fixes incorrect unwrapped atomic positions in variable-cell simulations.

The previous implementation accumulated Cartesian displacements directly:

$$
\mathbf r_i^{u}(t+\Delta t)=\mathbf r_i^{u}(t)+\left[\mathbf r_i(t+\Delta t)-\mathbf r_i(t)\right].
$$

This is valid for a fixed cell, but becomes incorrect when the simulation cell changes because the Cartesian displacement also contains cell deformation.

The new implementation tracks integer periodic images and reconstructs the unwrapped position from the current cell:

$$
\mathbf r_i^{u}=\mathbf r_i+n_x\mathbf a+n_y\mathbf b+n_z\mathbf c.
$$

The image counters are updated where GPUMD applies periodic boundary conditions. The existing assumption that an atom cannot cross more than one box within one MD step is unchanged.

The old `position_temp` array is removed and replaced by integer image counters, reducing the bookkeeping memory from about `48N` bytes to `36N` bytes when unwrapped positions are used.


# **Licensing** (Please read and confirm before submitting this pull request)

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.

# **Validation** (Describe how this pull request was tested)

## Regression tests

All the tests in `run_tests_zheyong.sh` passed, which means that the changes do not affect the dynamics involving wrapped positions.

## A test with NPT

```shell
potential   Si_2022_NEP4_3body.txt
velocity    2800

time_step   2

ensemble    npt_scr 2800 2800 100 0 0 0 0 0 0 50 50 50 50 50 50 1000
dump_restart 1000
dump_thermo 10
run         1000

ensemble    npt_scr 2800 2800 100 0 0 0 0 0 0 50 50 50 50 50 50 1000
compute_msd 2 200
dump_xyz   1000 npt.xyz unwrapped_position precision double
dump_thermo 10
run         10000
```

The old and fixed versions produced exactly the same physical trajectory.

For every atom and saved frame, we checked

$$
\mathbf n =H^{-1}\left(\mathbf r_{\mathrm{unwrapped}}-\mathbf r_{\mathrm{wrapped}}\right).
$$

For a correct unwrapped position, all components of $\mathbf n$ must be integers.

The maximum residual from the nearest integer is shown in the figure below:

<img width="1540" height="990" alt="issue1470_triclinic_image_residual" src="https://github.com/user-attachments/assets/29011cdb-932f-4919-987d-6e55f3365d2c" />

Although the wrapped trajectories are identical, the old and fixed unwrapped positions differ by up to 1.93 Å in this test:

<img width="1540" height="990" alt="issue1470_triclinic_unwrapped_difference" src="https://github.com/user-attachments/assets/3d80393d-b834-43ea-89d3-3c8cd7b8e95d" />


The same error also propagates into `compute_msd`, but the effect seems to be quite small:

<img width="2624" height="1624" alt="issue1470_msd_sdc_diff_4panel" src="https://github.com/user-attachments/assets/a69d9bd1-6cfd-401b-a4ab-375bed87293b" />


**Others**
