### PR TITLE
dynamic langevin

### DIFF
--- a/src/integrate/ensemble_lan.cu
+++ b/src/integrate/ensemble_lan.cu
@@ -84,6 +84,41 @@ Ensemble_LAN::Ensemble_LAN(
   energy_transferred[1] = 0.0;
 }
 
+Ensemble_LAN::Ensemble_LAN(
+  int t,
+  int mg,
+  double* mv,
+  int N,
+  double* source_region_input,
+  double* sink_region_input,
+  double T,
+  double Tc,
+  double dT)
+{
+  type = t;
+  move_group = mg;
+  move_velocity[0] = mv[0];
+  move_velocity[1] = mv[1];
+  move_velocity[2] = mv[2];
+  temperature = T;
+  temperature_coupling = Tc;
+  delta_temperature = dT;
+  use_region = true;
+  for (int i = 0; i < 6; ++i) {
+    source_region[i] = source_region_input[i];
+    sink_region[i] = sink_region_input[i];
+  }
+  c1 = exp(-0.5 / temperature_coupling);
+  c2_source = sqrt((1 - c1 * c1) * K_B * (T + dT));
+  c2_sink = sqrt((1 - c1 * c1) * K_B * (T - dT));
+  curand_states.resize(N);
+  int grid_size = (N - 1) / 128 + 1;
+  initialize_curand_states<<<grid_size, 128>>>(curand_states.data(), N, rand());
+  GPU_CHECK_KERNEL
+  energy_transferred[0] = 0.0;
+  energy_transferred[1] = 0.0;
+}
+
 Ensemble_LAN::~Ensemble_LAN(void)
 {
   // nothing
@@ -194,6 +229,103 @@ void Ensemble_LAN::integrate_heat_lan_half(
   energy_transferred[1] -= ek2[sink] * 0.5;
 }
 
+void Ensemble_LAN::integrate_heat_lan_region_half(
+  const Box& box,
+  const GPU_Vector<double>& position_per_atom,
+  const GPU_Vector<double>& mass,
+  GPU_Vector<double>& velocity_per_atom)
+{
+  const int number_of_atoms = mass.size();
+  double ek2[2];
+  GPU_Vector<double> ke(2);
+
+  find_ke_region<<<2, 512>>>(
+    number_of_atoms,
+    box,
+    source_region[0],
+    source_region[1],
+    source_region[2],
+    source_region[3],
+    source_region[4],
+    source_region[5],
+    sink_region[0],
+    sink_region[1],
+    sink_region[2],
+    sink_region[3],
+    sink_region[4],
+    sink_region[5],
+    position_per_atom.data(),
+    position_per_atom.data() + number_of_atoms,
+    position_per_atom.data() + 2 * number_of_atoms,
+    mass.data(),
+    velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms,
+    velocity_per_atom.data() + 2 * number_of_atoms,
+    ke.data());
+  GPU_CHECK_KERNEL
+
+  ke.copy_to_host(ek2);
+  energy_transferred[0] += ek2[0] * 0.5;
+  energy_transferred[1] += ek2[1] * 0.5;
+
+  gpu_langevin_region<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
+    curand_states.data(),
+    number_of_atoms,
+    box,
+    source_region[0],
+    source_region[1],
+    source_region[2],
+    source_region[3],
+    source_region[4],
+    source_region[5],
+    sink_region[0],
+    sink_region[1],
+    sink_region[2],
+    sink_region[3],
+    sink_region[4],
+    sink_region[5],
+    c1,
+    c2_source,
+    c2_sink,
+    position_per_atom.data(),
+    position_per_atom.data() + number_of_atoms,
+    position_per_atom.data() + 2 * number_of_atoms,
+    mass.data(),
+    velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms,
+    velocity_per_atom.data() + 2 * number_of_atoms);
+  GPU_CHECK_KERNEL
+
+  find_ke_region<<<2, 512>>>(
+    number_of_atoms,
+    box,
+    source_region[0],
+    source_region[1],
+    source_region[2],
+    source_region[3],
+    source_region[4],
+    source_region[5],
+    sink_region[0],
+    sink_region[1],
+    sink_region[2],
+    sink_region[3],
+    sink_region[4],
+    sink_region[5],
+    position_per_atom.data(),
+    position_per_atom.data() + number_of_atoms,
+    position_per_atom.data() + 2 * number_of_atoms,
+    mass.data(),
+    velocity_per_atom.data(),
+    velocity_per_atom.data() + number_of_atoms,
+    velocity_per_atom.data() + 2 * number_of_atoms,
+    ke.data());
+  GPU_CHECK_KERNEL
+
+  ke.copy_to_host(ek2);
+  energy_transferred[0] -= ek2[0] * 0.5;
+  energy_transferred[1] -= ek2[1] * 0.5;
+}
+
 void Ensemble_LAN::compute1(
   const double time_step,
   const std::vector<Group>& group,
@@ -213,7 +345,12 @@ void Ensemble_LAN::compute1(
       atom.position_per_atom,
       atom.velocity_per_atom);
   } else {
-    integrate_heat_lan_half(group, atom.mass, atom.velocity_per_atom);
+    if (use_region) {
+      integrate_heat_lan_region_half(
+        box, atom.position_per_atom, atom.mass, atom.velocity_per_atom);
+    } else {
+      integrate_heat_lan_half(group, atom.mass, atom.velocity_per_atom);
+    }
 
     velocity_verlet(
       true,
@@ -264,6 +401,11 @@ void Ensemble_LAN::compute2(
       atom.position_per_atom,
       atom.velocity_per_atom);
 
-    integrate_heat_lan_half(group, atom.mass, atom.velocity_per_atom);
+    if (use_region) {
+      integrate_heat_lan_region_half(
+        box, atom.position_per_atom, atom.mass, atom.velocity_per_atom);
+    } else {
+      integrate_heat_lan_half(group, atom.mass, atom.velocity_per_atom);
+    }
   }
 }

--- a/src/integrate/ensemble_lan.cuh
+++ b/src/integrate/ensemble_lan.cuh
@@ -28,6 +28,7 @@ public:
   Ensemble_LAN();
   Ensemble_LAN(int, int, double, double);
   Ensemble_LAN(int, int, double*, int, int, int, int, int, int, double, double, double);
+  Ensemble_LAN(int, int, double*, int, double*, double*, double, double, double);
   virtual ~Ensemble_LAN(void);
 
   virtual void compute1(
@@ -46,6 +47,9 @@ public:
 
 protected:
   int N_source, N_sink, offset_source, offset_sink;
+  bool use_region = false;
+  double source_region[6];
+  double sink_region[6];
   double c1, c2, c2_source, c2_sink;
   GPU_Vector<gpurandState> curand_states;
   GPU_Vector<gpurandState> curand_states_source;
@@ -56,6 +60,12 @@ protected:
 
   void integrate_heat_lan_half(
     const std::vector<Group>& group,
+    const GPU_Vector<double>& mass,
+    GPU_Vector<double>& velocity_per_atom);
+
+  void integrate_heat_lan_region_half(
+    const Box& box,
+    const GPU_Vector<double>& position_per_atom,
     const GPU_Vector<double>& mass,
     GPU_Vector<double>& velocity_per_atom);
 };

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -180,19 +180,32 @@ void Integrate::initialize(
         time_step));
       break;
     case 22: // heat-Langevin
-      ensemble.reset(new Ensemble_LAN(
-        type,
-        move_group,
-        move_velocity,
-        source,
-        sink,
-        group[0].cpu_size[source],
-        group[0].cpu_size[sink],
-        group[0].cpu_size_sum[source],
-        group[0].cpu_size_sum[sink],
-        temperature,
-        temperature_coupling,
-        delta_temperature));
+      if (use_heat_lan_region) {
+        ensemble.reset(new Ensemble_LAN(
+          type,
+          move_group,
+          move_velocity,
+          number_of_atoms,
+          heat_source_region,
+          heat_sink_region,
+          temperature,
+          temperature_coupling,
+          delta_temperature));
+      } else {
+        ensemble.reset(new Ensemble_LAN(
+          type,
+          move_group,
+          move_velocity,
+          source,
+          sink,
+          group[0].cpu_size[source],
+          group[0].cpu_size[sink],
+          group[0].cpu_size_sum[source],
+          group[0].cpu_size_sum[sink],
+          temperature,
+          temperature_coupling,
+          delta_temperature));
+      }
       break;
     case 23: // heat-BDP
       ensemble.reset(
@@ -359,6 +372,7 @@ void Integrate::parse_ensemble(
   qtb_n_f = 100;
   use_eco_pimd = false;
   eco_omega_max_cm1 = 0.0;
+  use_heat_lan_region = false;
   int pimd_num_param = num_param;
 
   // 1. Determine the integration method
@@ -429,9 +443,10 @@ void Integrate::parse_ensemble(
     }
   } else if (strcmp(param[1], "heat_lan") == 0) {
     type = 22;
-    if (num_param != 7) {
-      PRINT_INPUT_ERROR("ensemble heat_lan should have 5 parameters.");
+    if (num_param != 7 && num_param != 17) {
+      PRINT_INPUT_ERROR("ensemble heat_lan should have 5 or 15 parameters.");
     }
+    use_heat_lan_region = num_param == 17;
   } else if (strcmp(param[1], "heat_bdp") == 0) {
     type = 23;
     if (num_param != 7) {
@@ -683,30 +698,67 @@ void Integrate::parse_ensemble(
       PRINT_INPUT_ERROR("|Temperature difference| is too large.");
     }
 
-    // group labels of heat source and sink
-    if (!is_valid_int(param[5], &source)) {
-      PRINT_INPUT_ERROR("Group ID for heat source should be an integer.");
-    }
-    if (!is_valid_int(param[6], &sink)) {
-      PRINT_INPUT_ERROR("Group ID for heat sink should be an integer.");
-    }
-    if (group.size() < 1) {
-      PRINT_INPUT_ERROR("Cannot heat/cold without grouping method.");
-    }
-    if (source == sink) {
-      PRINT_INPUT_ERROR("Source and sink cannot be the same group.");
-    }
-    if (source < 0) {
-      PRINT_INPUT_ERROR("Group ID for heat source should >= 0.");
-    }
-    if (source >= group[0].number) {
-      PRINT_INPUT_ERROR("Group ID for heat source should < #groups.");
-    }
-    if (sink < 0) {
-      PRINT_INPUT_ERROR("Group ID for heat sink should >= 0.");
-    }
-    if (sink >= group[0].number) {
-      PRINT_INPUT_ERROR("Group ID for heat sink should < #groups.");
+    if (type == 22 && use_heat_lan_region) {
+      for (int i = 0; i < 6; ++i) {
+        if (!is_valid_real(param[5 + i], &heat_source_region[i])) {
+          PRINT_INPUT_ERROR("Heat source region bounds should be numbers.");
+        }
+        if (!is_valid_real(param[11 + i], &heat_sink_region[i])) {
+          PRINT_INPUT_ERROR("Heat sink region bounds should be numbers.");
+        }
+      }
+      for (int d = 0; d < 3; ++d) {
+        int i = 2 * d;
+        if (!(heat_source_region[i] >= 0.0 && heat_source_region[i] <= 1.0 &&
+              heat_source_region[i + 1] >= 0.0 && heat_source_region[i + 1] <= 1.0)) {
+          PRINT_INPUT_ERROR("Heat source region bounds should be in [0, 1].");
+        }
+        if (!(heat_sink_region[i] >= 0.0 && heat_sink_region[i] <= 1.0 &&
+              heat_sink_region[i + 1] >= 0.0 && heat_sink_region[i + 1] <= 1.0)) {
+          PRINT_INPUT_ERROR("Heat sink region bounds should be in [0, 1].");
+        }
+        if (heat_source_region[i] >= heat_source_region[i + 1]) {
+          PRINT_INPUT_ERROR("Heat source region minimum should be smaller than maximum.");
+        }
+        if (heat_sink_region[i] >= heat_sink_region[i + 1]) {
+          PRINT_INPUT_ERROR("Heat sink region minimum should be smaller than maximum.");
+        }
+      }
+      if (
+        heat_source_region[0] < heat_sink_region[1] &&
+        heat_sink_region[0] < heat_source_region[1] &&
+        heat_source_region[2] < heat_sink_region[3] &&
+        heat_sink_region[2] < heat_source_region[3] &&
+        heat_source_region[4] < heat_sink_region[5] &&
+        heat_sink_region[4] < heat_source_region[5]) {
+        PRINT_INPUT_ERROR("Heat source and sink regions cannot overlap.");
+      }
+    } else {
+      // group labels of heat source and sink
+      if (!is_valid_int(param[5], &source)) {
+        PRINT_INPUT_ERROR("Group ID for heat source should be an integer.");
+      }
+      if (!is_valid_int(param[6], &sink)) {
+        PRINT_INPUT_ERROR("Group ID for heat sink should be an integer.");
+      }
+      if (group.size() < 1) {
+        PRINT_INPUT_ERROR("Cannot heat/cold without grouping method.");
+      }
+      if (source == sink) {
+        PRINT_INPUT_ERROR("Source and sink cannot be the same group.");
+      }
+      if (source < 0) {
+        PRINT_INPUT_ERROR("Group ID for heat source should >= 0.");
+      }
+      if (source >= group[0].number) {
+        PRINT_INPUT_ERROR("Group ID for heat source should < #groups.");
+      }
+      if (sink < 0) {
+        PRINT_INPUT_ERROR("Group ID for heat sink should >= 0.");
+      }
+      if (sink >= group[0].number) {
+        PRINT_INPUT_ERROR("Group ID for heat sink should < #groups.");
+      }
     }
   }
 
@@ -1210,8 +1262,27 @@ void Integrate::parse_ensemble(
       printf("    delta_T is %g K.\n", delta_temperature);
       printf("    T_hot is %g K.\n", temperature + delta_temperature);
       printf("    T_cold is %g K.\n", temperature - delta_temperature);
-      printf("    heat source is group %d in grouping method 0.\n", source);
-      printf("    heat sink is group %d in grouping method 0.\n", sink);
+      if (use_heat_lan_region) {
+        printf(
+          "    heat source fractional region is [%g, %g) [%g, %g) [%g, %g).\n",
+          heat_source_region[0],
+          heat_source_region[1],
+          heat_source_region[2],
+          heat_source_region[3],
+          heat_source_region[4],
+          heat_source_region[5]);
+        printf(
+          "    heat sink fractional region is [%g, %g) [%g, %g) [%g, %g).\n",
+          heat_sink_region[0],
+          heat_sink_region[1],
+          heat_sink_region[2],
+          heat_sink_region[3],
+          heat_sink_region[4],
+          heat_sink_region[5]);
+      } else {
+        printf("    heat source is group %d in grouping method 0.\n", source);
+        printf("    heat sink is group %d in grouping method 0.\n", sink);
+      }
       break;
     case 23:
       printf("Integrate with heating and cooling for this run.\n");

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -83,6 +83,9 @@ public:
   double temperature1; // target initial temperature for a run
   double temperature2; // target final temperature for a run
   double delta_temperature;
+  bool use_heat_lan_region = false;
+  double heat_source_region[6];
+  double heat_sink_region[6];
   double target_pressure[6];
   int num_target_pressure_components;
   double temperature_coupling;

--- a/src/integrate/langevin_utilities.cuh
+++ b/src/integrate/langevin_utilities.cuh
@@ -18,6 +18,7 @@ Some CUDA kernels for Langevin thermostats.
 ------------------------------------------------------------------------------*/
 
 #pragma once
+#include "model/box.cuh"
 #include "utilities/gpu_macro.cuh"
 
 #define CURAND_NORMAL(a) gpurand_normal_double(a)
@@ -148,6 +149,125 @@ static __global__ void gpu_langevin(
   }
 }
 
+static __device__ void get_fractional_position(
+  const Box& box,
+  const double x,
+  const double y,
+  const double z,
+  double& sa,
+  double& sb,
+  double& sc)
+{
+  sa = box.cpu_h[9] * x + box.cpu_h[10] * y + box.cpu_h[11] * z;
+  sb = box.cpu_h[12] * x + box.cpu_h[13] * y + box.cpu_h[14] * z;
+  sc = box.cpu_h[15] * x + box.cpu_h[16] * y + box.cpu_h[17] * z;
+
+  if (box.pbc_x == 1) {
+    if (sa < 0.0) {
+      sa += 1.0;
+    } else if (sa >= 1.0) {
+      sa -= 1.0;
+    }
+  }
+  if (box.pbc_y == 1) {
+    if (sb < 0.0) {
+      sb += 1.0;
+    } else if (sb >= 1.0) {
+      sb -= 1.0;
+    }
+  }
+  if (box.pbc_z == 1) {
+    if (sc < 0.0) {
+      sc += 1.0;
+    } else if (sc >= 1.0) {
+      sc -= 1.0;
+    }
+  }
+}
+
+static __device__ bool is_in_region(
+  const double sa,
+  const double sb,
+  const double sc,
+  const double amin,
+  const double amax,
+  const double bmin,
+  const double bmax,
+  const double cmin,
+  const double cmax)
+{
+  return sa >= amin && sa < amax && sb >= bmin && sb < bmax && sc >= cmin && sc < cmax;
+}
+
+// local Langevin thermostatting based on fractional-coordinate regions
+static __global__ void gpu_langevin_region(
+  gpurandState* g_state,
+  const int N,
+  const Box box,
+  const double source_amin,
+  const double source_amax,
+  const double source_bmin,
+  const double source_bmax,
+  const double source_cmin,
+  const double source_cmax,
+  const double sink_amin,
+  const double sink_amax,
+  const double sink_bmin,
+  const double sink_bmax,
+  const double sink_cmin,
+  const double sink_cmax,
+  const double c1,
+  const double c2_source,
+  const double c2_sink,
+  const double* g_x,
+  const double* g_y,
+  const double* g_z,
+  const double* g_mass,
+  double* g_vx,
+  double* g_vy,
+  double* g_vz)
+{
+  int n = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n < N) {
+    double sa, sb, sc;
+    get_fractional_position(box, g_x[n], g_y[n], g_z[n], sa, sb, sc);
+
+    double c2 = 0.0;
+    if (is_in_region(
+          sa,
+          sb,
+          sc,
+          source_amin,
+          source_amax,
+          source_bmin,
+          source_bmax,
+          source_cmin,
+          source_cmax)) {
+      c2 = c2_source;
+    } else if (is_in_region(
+                 sa,
+                 sb,
+                 sc,
+                 sink_amin,
+                 sink_amax,
+                 sink_bmin,
+                 sink_bmax,
+                 sink_cmin,
+                 sink_cmax)) {
+      c2 = c2_sink;
+    } else {
+      return;
+    }
+
+    gpurandState state = g_state[n];
+    double c2m = c2 * sqrt(1.0 / g_mass[n]);
+    g_vx[n] = c1 * g_vx[n] + c2m * CURAND_NORMAL(&state);
+    g_vy[n] = c1 * g_vy[n] + c2m * CURAND_NORMAL(&state);
+    g_vz[n] = c1 * g_vz[n] + c2m * CURAND_NORMAL(&state);
+    g_state[n] = state;
+  }
+}
+
 // group kinetic energy
 static __global__ void find_ke(
   const int* g_group_size,
@@ -191,3 +311,88 @@ static __global__ void find_ke(
     g_ke[bid] = s_ke[0];
   } // kinetic energy times 2
 }
+
+// kinetic energy in the source and sink regions
+static __global__ void find_ke_region(
+  const int N,
+  const Box box,
+  const double source_amin,
+  const double source_amax,
+  const double source_bmin,
+  const double source_bmax,
+  const double source_cmin,
+  const double source_cmax,
+  const double sink_amin,
+  const double sink_amax,
+  const double sink_bmin,
+  const double sink_bmax,
+  const double sink_cmin,
+  const double sink_cmax,
+  const double* g_x,
+  const double* g_y,
+  const double* g_z,
+  const double* g_mass,
+  const double* g_vx,
+  const double* g_vy,
+  const double* g_vz,
+  double* g_ke)
+{
+  //<<<2, 512>>>
+  int tid = threadIdx.x;
+  int bid = blockIdx.x;
+  int number_of_patches = (N - 1) / 512 + 1;
+  __shared__ double s_ke[512];
+  s_ke[tid] = 0.0;
+
+  for (int patch = 0; patch < number_of_patches; ++patch) {
+    int n = tid + patch * 512;
+    if (n < N) {
+      double sa, sb, sc;
+      get_fractional_position(box, g_x[n], g_y[n], g_z[n], sa, sb, sc);
+      bool in_region;
+      if (bid == 0) {
+        in_region = is_in_region(
+          sa,
+          sb,
+          sc,
+          source_amin,
+          source_amax,
+          source_bmin,
+          source_bmax,
+          source_cmin,
+          source_cmax);
+      } else {
+        in_region = is_in_region(
+          sa,
+          sb,
+          sc,
+          sink_amin,
+          sink_amax,
+          sink_bmin,
+          sink_bmax,
+          sink_cmin,
+          sink_cmax);
+      }
+      if (in_region) {
+        double mass = g_mass[n];
+        double vx = g_vx[n];
+        double vy = g_vy[n];
+        double vz = g_vz[n];
+        s_ke[tid] += (vx * vx + vy * vy + vz * vz) * mass;
+      }
+    }
+  }
+  __syncthreads();
+
+  for (int offset = blockDim.x >> 1; offset > 0; offset >>= 1) {
+    if (tid < offset) {
+      s_ke[tid] += s_ke[tid + offset];
+    }
+    __syncthreads();
+  }
+
+  if (tid == 0) {
+    g_ke[bid] = s_ke[0];
+  } // kinetic energy times 2
+}
+

--- a/src/integrate/langevin_utilities.cuh
+++ b/src/integrate/langevin_utilities.cuh
@@ -161,28 +161,6 @@ static __device__ void get_fractional_position(
   sa = box.cpu_h[9] * x + box.cpu_h[10] * y + box.cpu_h[11] * z;
   sb = box.cpu_h[12] * x + box.cpu_h[13] * y + box.cpu_h[14] * z;
   sc = box.cpu_h[15] * x + box.cpu_h[16] * y + box.cpu_h[17] * z;
-
-  if (box.pbc_x == 1) {
-    if (sa < 0.0) {
-      sa += 1.0;
-    } else if (sa >= 1.0) {
-      sa -= 1.0;
-    }
-  }
-  if (box.pbc_y == 1) {
-    if (sb < 0.0) {
-      sb += 1.0;
-    } else if (sb >= 1.0) {
-      sb -= 1.0;
-    }
-  }
-  if (box.pbc_z == 1) {
-    if (sc < 0.0) {
-      sc += 1.0;
-    } else if (sc >= 1.0) {
-      sc -= 1.0;
-    }
-  }
 }
 
 static __device__ bool is_in_region(


### PR DESCRIPTION
# **Summary** (Briefly summarize the purpose of this pull request)

Fix #1635 by adding dynamically selected spatial regions to `ensemble heat_lan`.

# **Modification** (Describe the main changes made in this pull request)

This PR extends `ensemble heat_lan` to support dynamically selected Langevin heat-source and heat-sink regions based on the current atomic positions.

The existing group-based syntax is kept unchanged. A new region-based form is added, where the source and sink are defined using fractional coordinates along the three simulation-cell vectors.

This allows atoms to enter or leave the thermostatted regions during the simulation, without introducing dynamic groups or changing the existing grouping infrastructure.

## New syntax

The original group-based syntax is unchanged:

```text
ensemble heat_lan T T_coup delta_T label_source label_sink
```

A new region-based syntax is added:

```
ensemble heat_lan T T_coup delta_T a_min_source a_max_source b_min_source b_max_source c_min_source c_max_source a_min_sink a_max_sink b_min_sink b_max_sink c_min_sink c_max_sink
```

The regions are defined in fractional coordinates with respect to the current simulation box.

For example,

```
ensemble heat_lan 3000 100 200 0.20 0.30 0 1 0 1 0.70 0.80 0 1 0 1
```

defines

source: 0.20 <= s_a < 0.30
sink: 0.70 <= s_a < 0.80

with no restriction along the b and c box directions.

# **Licensing** (Please read and confirm before submitting this pull request)

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.

# **Validation** (Describe how this pull request was tested)

## Regression tests

All tests in `run_tests_zheyong.sh` pass, including one using `heat_lan`.

## New test

```
potential   Si_2022_NEP4_3body.txt
velocity    3000 seed 12345

time_step   2

# Melt and equilibrate liquid Si at 3000 K and 0 GPa.
ensemble    npt_scr 3000 3000 100 0 50 1000
dump_thermo 100
dump_restart 20000
run         20000

# Test the dynamic-region Langevin heat source and sink.
# Fractional-coordinate regions along the box vectors:
# source: 0.20 <= s_a < 0.30, full b and c directions (3200 K)
# sink:   0.70 <= s_a < 0.80, full b and c directions (2800 K)
ensemble    heat_lan 3000 100 200 0.20 0.30 0 1 0 1 0.70 0.80 0 1 0 1
compute     0 10 100 temperature
dump_thermo 100
dump_xyz     1000 dump.xyz velocity
dump_restart 20000
run         20000
```

The trajectory gives an average source temperature of about 3200 K and an average sink temperature of about 2830 K, consistent with the target temperatures of 3200 K and 2800 K.

<img width="1200" height="800" alt="region_temperature_profile" src="https://github.com/user-attachments/assets/ee1ccd21-2804-42c0-8ebe-032aeb93f66e" />




**Others**
