### PR TITLE
Fix RNG state advancement in NPT-SCR barostat

### DIFF
--- a/src/integrate/ensemble_npt_scr.cu
+++ b/src/integrate/ensemble_npt_scr.cu
@@ -74,7 +74,7 @@ Ensemble_NPT_SCR::~Ensemble_NPT_SCR(void)
 }
 
 static void cpu_pressure_orthogonal(
-  std::mt19937 rng,
+  std::mt19937& rng,
   int deform_x,
   int deform_y,
   int deform_z,
@@ -135,7 +135,7 @@ static void cpu_pressure_orthogonal(
 }
 
 static void cpu_pressure_isotropic(
-  std::mt19937 rng,
+  std::mt19937& rng,
   Box& box,
   double target_temperature,
   double* target_pressure,
@@ -160,7 +160,7 @@ static void cpu_pressure_isotropic(
 }
 
 static void cpu_pressure_triclinic(
-  std::mt19937 rng,
+  std::mt19937& rng,
   Box& box,
   double target_temperature,
   double* p0,


### PR DESCRIPTION
**Summary** (Briefly summarize the purpose of this pull request)

Pass the persistent random-number generator by reference to the
isotropic, orthogonal, and triclinic NPT-SCR pressure-control routines.
Previously, each routine advanced only a copy of the generator, causing
the persistent RNG state not to advance correctly.

**Modification** (Describe the main changes made in this pull request)

**Licensing** (Please read and confirm before submitting this pull request)

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.

**Validation** (Describe how this pull request was tested)

**Others**
