### PR TITLE
Apply PIMD Berendsen barostat scaling only to centroids

### DIFF
--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -769,10 +769,11 @@ static __global__ void gpu_pressure_orthogonal(
     double scale_factor[3] = {scale_factor_x, scale_factor_y, scale_factor_z};
     for (int d = 0; d < 3; ++d) {
       const int index = i + d * number_of_particles;
-      g_average_position[index] *= scale_factor[d];
+      const double displacement = (scale_factor[d] - 1.0) * g_average_position[index];
       for (int k = 0; k < number_of_beads; ++k) {
-        g_beads_position[k][index] *= scale_factor[d];
+        g_beads_position[k][index] += displacement;
       }
+      g_average_position[index] *= scale_factor[d];
     }
   }
 }
@@ -788,10 +789,11 @@ static __global__ void gpu_pressure_isotropic(
   if (i < number_of_particles) {
     for (int d = 0; d < 3; ++d) {
       const int index = i + d * number_of_particles;
-      g_average_position[index] *= scale_factor;
+      const double displacement = (scale_factor - 1.0) * g_average_position[index];
       for (int k = 0; k < number_of_beads; ++k) {
-        g_beads_position[k][index] *= scale_factor;
+        g_beads_position[k][index] += displacement;
       }
+      g_average_position[index] *= scale_factor;
     }
   }
 }
@@ -813,20 +815,23 @@ static __global__ void gpu_pressure_triclinic(
 {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < number_of_particles) {
-    double x_old = g_average_position[i];
-    double y_old = g_average_position[i + number_of_particles];
-    double z_old = g_average_position[i + number_of_particles * 2];
-    g_average_position[i] = mu0 * x_old + mu1 * y_old + mu2 * z_old;
-    g_average_position[i + number_of_particles] = mu3 * x_old + mu4 * y_old + mu5 * z_old;
-    g_average_position[i + number_of_particles * 2] = mu6 * x_old + mu7 * y_old + mu8 * z_old;
+    const double x_old = g_average_position[i];
+    const double y_old = g_average_position[i + number_of_particles];
+    const double z_old = g_average_position[i + number_of_particles * 2];
+    const double x_new = mu0 * x_old + mu1 * y_old + mu2 * z_old;
+    const double y_new = mu3 * x_old + mu4 * y_old + mu5 * z_old;
+    const double z_new = mu6 * x_old + mu7 * y_old + mu8 * z_old;
+    const double displacement_x = x_new - x_old;
+    const double displacement_y = y_new - y_old;
+    const double displacement_z = z_new - z_old;
     for (int k = 0; k < number_of_beads; ++k) {
-      double x_old = g_beads_position[k][i];
-      double y_old = g_beads_position[k][i + number_of_particles];
-      double z_old = g_beads_position[k][i + number_of_particles * 2];
-      g_beads_position[k][i] = mu0 * x_old + mu1 * y_old + mu2 * z_old;
-      g_beads_position[k][i + number_of_particles] = mu3 * x_old + mu4 * y_old + mu5 * z_old;
-      g_beads_position[k][i + number_of_particles * 2] = mu6 * x_old + mu7 * y_old + mu8 * z_old;
+      g_beads_position[k][i] += displacement_x;
+      g_beads_position[k][i + number_of_particles] += displacement_y;
+      g_beads_position[k][i + number_of_particles * 2] += displacement_z;
     }
+    g_average_position[i] = x_new;
+    g_average_position[i + number_of_particles] = y_new;
+    g_average_position[i + number_of_particles * 2] = z_new;
   }
 }
 


### PR DESCRIPTION
#  **Summary** (Briefly summarize the purpose of this pull request)

The barostat scaling should be applied only to the centroid coordinates, consistent with the NPT-PIMD formulation of Ceriotti et al. （https://doi.org/10.1016/j.cpc.2013.10.027, based on the constant-pressure path-integral framework of Martyna et al. （https://doi.org/10.1063/1.478193）

Tests show that the old and new implementations produce essentially identical macroscopic results for the Berendsen barostat, even though they treat the internal ring-polymer modes differently. 


# **Modification** (Describe the main changes made in this pull request)

- Apply isotropic, orthogonal, and triclinic barostat transformations to
  the ring-polymer centroids.
- Translate all beads of each atom by the same centroid displacement,
  preserving the internal bead-to-centroid coordinates.
- Leave the pressure estimator, PBC handling, and input syntax unchanged.

#  **Licensing** (Please read and confirm before submitting this pull request)

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.

# **Validation** (Describe how this pull request was tested)

- With `-DDEBUG`, the old and new executables give identical NVT bead coordinates for both cubic and triclinic cells.
- One-step isotropic, orthogonal, and triclinic NPT tests preserve the internal bead-to-centroid coordinates within 7.5e-9 A.
- An 8000-atom Si system with 8 beads was run for 10 ps. The pressure converged to 0 GPa, and the old and new implementations produced essentially identical mean pressure and volume.

# **Others**
