### PR TITLE
pimd_scr

### DIFF
--- a/doc/gpumd/input_parameters/ensemble_pimd.rst
+++ b/doc/gpumd/input_parameters/ensemble_pimd.rst
@@ -23,13 +23,26 @@ It can be used in the following ways::
 In all forms, :attr:`num_beads` is the number of beads in the ring polymer, which should be a positive even integer no larger than 128.
 The first case is similar to the NVT ensemble with :attr:`nvt_lan` as the Langevin thermostat is used for both the internal and the centroid modes [Ceriotti2010]_. 
 The second case is similar to the NPT ensemble with :attr:`npt_ber`, where a Berendsen barostat is added compared to the first case.
-Note that :attr:`pimd` (that is, not :attr:`rpmd` or :attr:`trpmd` described below) must be the first run that requires to set :attr:`num_beads` and one cannot change :attr:`num_beads` from run to run.
+Note that :attr:`pimd` or :attr:`pimd_scr` (that is, not :attr:`rpmd` or :attr:`trpmd` described below) must be the first run that requires to set :attr:`num_beads` and one cannot change :attr:`num_beads` from run to run.
 
 Appending ``eco <omega_max>`` selects the economised path-integral internal-mode frequencies [Zeng2026]_.
 Here :attr:`omega_max` is the highest physical vibrational wavenumber to be reproduced, in units of cm\ :sup:`-1`.
 The dimensionless fitting range is recalculated from the instantaneous target temperature as :math:`x_{\max}=hc\omega_{\max}/(k_{\rm B}T)`, so Eco frequencies also follow a temperature ramp from :attr:`T_1` to :attr:`T_2`.
 If the ``eco`` option is omitted, GPUMD uses the original Trotter internal-mode frequencies.
-The Eco option is available for :attr:`pimd` only; :attr:`rpmd` and :attr:`trpmd` use the original Trotter frequencies.
+The Eco option is available for :attr:`pimd` and :attr:`pimd_scr` only; :attr:`rpmd` and :attr:`trpmd` use the original Trotter frequencies.
+
+:attr:`pimd_scr`
+^^^^^^^^^^^^^^^^^
+If the first parameter is :attr:`pimd_scr`, it means that the current run will use path-integral molecular dynamics (:term:`PIMD`) with stochastic cell rescaling (:attr:`npt_scr`) for pressure control.
+
+It can be used in the following ways::
+
+    ensemble pimd_scr <num_beads> <T_1> <T_2> <T_coup> {<pressure_control_parameters>}
+    ensemble pimd_scr <num_beads> <T_1> <T_2> <T_coup> {<pressure_control_parameters>} eco <omega_max>
+
+The pressure-control parameters have the same meaning and support the same isotropic, orthogonal, and triclinic forms as in the pressure-controlled :attr:`pimd` case.
+The difference is that :attr:`pimd` uses the Berendsen barostat, whereas :attr:`pimd_scr` uses stochastic cell rescaling.
+The ``eco`` option has the same meaning as described above for :attr:`pimd`.
 
 :attr:`rpmd`
 ^^^^^^^^^^^^

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -653,7 +653,8 @@ gpu_find_thermo(const double volume, const double NkBT, const double* g_sum_1024
 }
 
 static void cpu_pressure_orthogonal(
-  std::mt19937 rng,
+  std::mt19937& rng,
+  bool use_scr_barostat,
   Box& box,
   double target_temperature,
   double* p0,
@@ -667,6 +668,11 @@ static void cpu_pressure_orthogonal(
   if (box.pbc_x == 1) {
     const double scale_factor_Berendsen = 1.0 - p_coupling[0] * (p0[0] - p[0]);
     scale_factor[0] = scale_factor_Berendsen;
+    if (use_scr_barostat) {
+      const double scale_factor_stochastic =
+        sqrt(2.0 * p_coupling[0] * K_B * target_temperature / box.get_volume()) * gasdev(rng);
+      scale_factor[0] += scale_factor_stochastic;
+    }
     box.cpu_h[0] *= scale_factor[0];
   } else {
     scale_factor[0] = 1.0;
@@ -675,6 +681,11 @@ static void cpu_pressure_orthogonal(
   if (box.pbc_y == 1) {
     const double scale_factor_Berendsen = 1.0 - p_coupling[1] * (p0[1] - p[1]);
     scale_factor[1] = scale_factor_Berendsen;
+    if (use_scr_barostat) {
+      const double scale_factor_stochastic =
+        sqrt(2.0 * p_coupling[1] * K_B * target_temperature / box.get_volume()) * gasdev(rng);
+      scale_factor[1] += scale_factor_stochastic;
+    }
     box.cpu_h[4] *= scale_factor[1];
   } else {
     scale_factor[1] = 1.0;
@@ -683,6 +694,11 @@ static void cpu_pressure_orthogonal(
   if (box.pbc_z == 1) {
     const double scale_factor_Berendsen = 1.0 - p_coupling[2] * (p0[2] - p[2]);
     scale_factor[2] = scale_factor_Berendsen;
+    if (use_scr_barostat) {
+      const double scale_factor_stochastic =
+        sqrt(2.0 * p_coupling[2] * K_B * target_temperature / box.get_volume()) * gasdev(rng);
+      scale_factor[2] += scale_factor_stochastic;
+    }
     box.cpu_h[8] *= scale_factor[2];
   } else {
     scale_factor[2] = 1.0;
@@ -719,7 +735,8 @@ static void cpu_pressure_isotropic(
 }
 
 static void cpu_pressure_triclinic(
-  std::mt19937 rng,
+  std::mt19937& rng,
+  bool use_scr_barostat,
   Box& box,
   double target_temperature,
   double* p0,
@@ -736,19 +753,19 @@ static void cpu_pressure_triclinic(
   mu[3] = mu[1] = -p_coupling[5] * (p0[5] - p[3]); // xy
   mu[6] = mu[2] = -p_coupling[4] * (p0[4] - p[4]); // xz
   mu[7] = mu[5] = -p_coupling[3] * (p0[3] - p[5]); // yz
-  /*
-  double p_coupling_3by3[3][3] = {
-    {p_coupling[0], p_coupling[3], p_coupling[4]},
-    {p_coupling[3], p_coupling[1], p_coupling[5]},
-    {p_coupling[4], p_coupling[5], p_coupling[2]}};
-  const double volume = box.get_volume();
-  for (int r = 0; r < 3; ++r) {
-    for (int c = 0; c < 3; ++c) {
-      mu[r * 3 + c] +=
-        sqrt(2.0 * p_coupling_3by3[r][c] * K_B * target_temperature / volume) * gasdev(rng);
+  if (use_scr_barostat) {
+    double p_coupling_3by3[3][3] = {
+      {p_coupling[0], p_coupling[5], p_coupling[4]},
+      {p_coupling[5], p_coupling[1], p_coupling[3]},
+      {p_coupling[4], p_coupling[3], p_coupling[2]}};
+    const double volume = box.get_volume();
+    for (int r = 0; r < 3; ++r) {
+      for (int c = 0; c < 3; ++c) {
+        mu[r * 3 + c] +=
+          sqrt(2.0 * p_coupling_3by3[r][c] * K_B * target_temperature / volume) * gasdev(rng);
+      }
     }
   }
-  */
   double h_old[9];
   for (int i = 0; i < 9; ++i) {
     h_old[i] = box.cpu_h[i];
@@ -987,7 +1004,14 @@ void Ensemble_PIMD::compute2(
   } else if (num_target_pressure_components == 3) {
     double scale_factor[3];
     cpu_pressure_orthogonal(
-      rng, box, temperature, target_pressure, pressure_coupling, thermo.data(), scale_factor);
+      rng,
+      use_scr_barostat,
+      box,
+      temperature,
+      target_pressure,
+      pressure_coupling,
+      thermo.data(),
+      scale_factor);
     gpu_pressure_orthogonal<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
       number_of_atoms,
       number_of_beads,
@@ -1000,7 +1024,14 @@ void Ensemble_PIMD::compute2(
   } else if (num_target_pressure_components == 6) {
     double mu[9];
     cpu_pressure_triclinic(
-      rng, box, temperature, target_pressure, pressure_coupling, thermo.data(), mu);
+      rng,
+      use_scr_barostat,
+      box,
+      temperature,
+      target_pressure,
+      pressure_coupling,
+      thermo.data(),
+      mu);
     gpu_pressure_triclinic<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
       number_of_atoms,
       number_of_beads,

--- a/src/integrate/ensemble_pimd.cu
+++ b/src/integrate/ensemble_pimd.cu
@@ -26,6 +26,7 @@ References for implementation:
 #include "eco_pimd.cuh"
 #include "ensemble_pimd.cuh"
 #include "langevin_utilities.cuh"
+#include "svr_utilities.cuh"
 #include "utilities/common.cuh"
 #include "utilities/gpu_macro.cuh"
 #include <algorithm>
@@ -84,13 +85,15 @@ Ensemble_PIMD::Ensemble_PIMD(
   double pressure_coupling_input[6],
   Atom& atom,
   bool use_eco_pimd_input,
-  double eco_omega_max_cm1_input)
+  double eco_omega_max_cm1_input,
+  bool use_scr_barostat_input)
 {
   number_of_atoms = number_of_atoms_input;
   number_of_beads = number_of_beads_input;
   temperature_coupling = temperature_coupling_input;
   use_eco_pimd = use_eco_pimd_input;
   eco_omega_max_cm1 = eco_omega_max_cm1_input;
+  use_scr_barostat = use_scr_barostat_input;
   num_target_pressure_components = num_target_pressure_components_input;
   for (int i = 0; i < 6; i++) {
     target_pressure[i] = target_pressure_input[i];
@@ -688,7 +691,8 @@ static void cpu_pressure_orthogonal(
 }
 
 static void cpu_pressure_isotropic(
-  std::mt19937 rng,
+  std::mt19937& rng,
+  bool use_scr_barostat,
   Box& box,
   double target_temperature,
   double* target_pressure,
@@ -702,6 +706,12 @@ static void cpu_pressure_isotropic(
   const double scale_factor_Berendsen =
     1.0 - p_coupling[0] * (target_pressure[0] - pressure_instant);
   scale_factor = scale_factor_Berendsen;
+  if (use_scr_barostat) {
+    const double scale_factor_stochastic =
+      sqrt(0.666666666666667 * p_coupling[0] * K_B * target_temperature / box.get_volume()) *
+      gasdev(rng);
+    scale_factor += scale_factor_stochastic;
+  }
   box.cpu_h[0] *= scale_factor;
   box.cpu_h[4] *= scale_factor;
   box.cpu_h[8] *= scale_factor;
@@ -960,7 +970,14 @@ void Ensemble_PIMD::compute2(
   if (num_target_pressure_components == 1) {
     double scale_factor;
     cpu_pressure_isotropic(
-      rng, box, temperature, target_pressure, pressure_coupling, thermo.data(), scale_factor);
+      rng,
+      use_scr_barostat,
+      box,
+      temperature,
+      target_pressure,
+      pressure_coupling,
+      thermo.data(),
+      scale_factor);
     gpu_pressure_isotropic<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
       number_of_atoms,
       number_of_beads,

--- a/src/integrate/ensemble_pimd.cuh
+++ b/src/integrate/ensemble_pimd.cuh
@@ -47,7 +47,8 @@ public:
     double pressure_coupling[6],
     Atom& atom,
     bool use_eco_pimd_input,
-    double eco_omega_max_cm1_input);
+    double eco_omega_max_cm1_input,
+    bool use_scr_barostat_input);
 
   virtual ~Ensemble_PIMD(void);
 
@@ -72,6 +73,7 @@ protected:
   bool thermostat_centroid = false;
   double omega_n;
   bool use_eco_pimd = false;
+  bool use_scr_barostat = false;
   bool eco_frequencies_reported = false;
   double eco_omega_max_cm1 = 0.0;
   double eco_last_temperature = -1.0;

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -281,7 +281,8 @@ void Integrate::initialize(
           pressure_coupling,
           atom,
           use_eco_pimd,
-          eco_omega_max_cm1));
+          eco_omega_max_cm1,
+          use_scr_barostat));
       }
       break;
     default:
@@ -371,6 +372,7 @@ void Integrate::parse_ensemble(
   qtb_f_max = 200.0;
   qtb_n_f = 100;
   use_eco_pimd = false;
+  use_scr_barostat = false;
   eco_omega_max_cm1 = 0.0;
   use_heat_lan_region = false;
   int pimd_num_param = num_param;
@@ -490,6 +492,9 @@ void Integrate::parse_ensemble(
     }
   } else if (strcmp(param[1], "pimd") == 0) {
     type = 33;
+  } else if (strcmp(param[1], "pimd_scr") == 0) {
+    type = 33;
+    use_scr_barostat = true;
   } else if (strcmp(param[1], "msst") == 0) {
     type = -1;
     ensemble.reset(new Ensemble_MSST(param, num_param));
@@ -933,22 +938,28 @@ void Integrate::parse_ensemble(
     // Optional Eco frequencies are selected by appending
     // "eco omega_max_cm1" to an existing PIMD command.
     if (type == 33) {
-      if (num_param >= 8 && strcmp(param[num_param - 2], "eco") == 0) {
-        use_eco_pimd = true;
-        pimd_num_param = num_param - 2;
-        if (!is_valid_real(param[num_param - 1], &eco_omega_max_cm1)) {
-          PRINT_INPUT_ERROR("Eco-PIMD omega_max should be a number in cm^-1.");
+      if (use_scr_barostat) {
+        if (pimd_num_param != 9) {
+          PRINT_INPUT_ERROR("ensemble pimd_scr should have 7 parameters.");
         }
-      }
-      if (
-        pimd_num_param != 6 && pimd_num_param != 9 && pimd_num_param != 13 &&
-        pimd_num_param != 19) {
-        PRINT_INPUT_ERROR(
-          "ensemble pimd should have 4, 7, 11, or 17 parameters, optionally followed by "
-          "eco omega_max_cm1.");
-      }
-      if (use_eco_pimd && eco_omega_max_cm1 <= 0.0) {
-        PRINT_INPUT_ERROR("Eco-PIMD omega_max should > 0.");
+      } else {
+        if (num_param >= 8 && strcmp(param[num_param - 2], "eco") == 0) {
+          use_eco_pimd = true;
+          pimd_num_param = num_param - 2;
+          if (!is_valid_real(param[num_param - 1], &eco_omega_max_cm1)) {
+            PRINT_INPUT_ERROR("Eco-PIMD omega_max should be a number in cm^-1.");
+          }
+        }
+        if (
+          pimd_num_param != 6 && pimd_num_param != 9 && pimd_num_param != 13 &&
+          pimd_num_param != 19) {
+          PRINT_INPUT_ERROR(
+            "ensemble pimd should have 4, 7, 11, or 17 parameters, optionally followed by "
+            "eco omega_max_cm1.");
+        }
+        if (use_eco_pimd && eco_omega_max_cm1 <= 0.0) {
+          PRINT_INPUT_ERROR("Eco-PIMD omega_max should > 0.");
+        }
       }
     }
 
@@ -1347,7 +1358,11 @@ void Integrate::parse_ensemble(
       break;
     case 33:
       if (pimd_num_param >= 9) {
-        printf("Use NPT-PIMD for this run.\n");
+        if (use_scr_barostat) {
+          printf("Use NPT-PIMD with stochastic cell rescaling for this run.\n");
+        } else {
+          printf("Use NPT-PIMD for this run.\n");
+        }
       } else {
         printf("Use NVT-PIMD for this run.\n");
       }

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -938,18 +938,20 @@ void Integrate::parse_ensemble(
     // Optional Eco frequencies are selected by appending
     // "eco omega_max_cm1" to an existing PIMD command.
     if (type == 33) {
+      if (num_param >= 8 && strcmp(param[num_param - 2], "eco") == 0) {
+        use_eco_pimd = true;
+        pimd_num_param = num_param - 2;
+        if (!is_valid_real(param[num_param - 1], &eco_omega_max_cm1)) {
+          PRINT_INPUT_ERROR("Eco-PIMD omega_max should be a number in cm^-1.");
+        }
+      }
       if (use_scr_barostat) {
         if (pimd_num_param != 9 && pimd_num_param != 13 && pimd_num_param != 19) {
-          PRINT_INPUT_ERROR("ensemble pimd_scr should have 7, 11, or 17 parameters.");
+          PRINT_INPUT_ERROR(
+            "ensemble pimd_scr should have 7, 11, or 17 parameters, optionally followed by "
+            "eco omega_max_cm1.");
         }
       } else {
-        if (num_param >= 8 && strcmp(param[num_param - 2], "eco") == 0) {
-          use_eco_pimd = true;
-          pimd_num_param = num_param - 2;
-          if (!is_valid_real(param[num_param - 1], &eco_omega_max_cm1)) {
-            PRINT_INPUT_ERROR("Eco-PIMD omega_max should be a number in cm^-1.");
-          }
-        }
         if (
           pimd_num_param != 6 && pimd_num_param != 9 && pimd_num_param != 13 &&
           pimd_num_param != 19) {
@@ -957,9 +959,9 @@ void Integrate::parse_ensemble(
             "ensemble pimd should have 4, 7, 11, or 17 parameters, optionally followed by "
             "eco omega_max_cm1.");
         }
-        if (use_eco_pimd && eco_omega_max_cm1 <= 0.0) {
-          PRINT_INPUT_ERROR("Eco-PIMD omega_max should > 0.");
-        }
+      }
+      if (use_eco_pimd && eco_omega_max_cm1 <= 0.0) {
+        PRINT_INPUT_ERROR("Eco-PIMD omega_max should > 0.");
       }
     }
 

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -939,8 +939,8 @@ void Integrate::parse_ensemble(
     // "eco omega_max_cm1" to an existing PIMD command.
     if (type == 33) {
       if (use_scr_barostat) {
-        if (pimd_num_param != 9) {
-          PRINT_INPUT_ERROR("ensemble pimd_scr should have 7 parameters.");
+        if (pimd_num_param != 9 && pimd_num_param != 13 && pimd_num_param != 19) {
+          PRINT_INPUT_ERROR("ensemble pimd_scr should have 7, 11, or 17 parameters.");
         }
       } else {
         if (num_param >= 8 && strcmp(param[num_param - 2], "eco") == 0) {

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -107,6 +107,7 @@ public:
   // PIMD
   int number_of_beads;
   bool use_eco_pimd = false;
+  bool use_scr_barostat = false;
   double eco_omega_max_cm1 = 0.0;
 
   // TTM parameters

--- a/src/integrate/svr_utilities.cuh
+++ b/src/integrate/svr_utilities.cuh
@@ -101,7 +101,7 @@ static double resamplekin_sumnoises(int nn, std::mt19937& rng)
   }
 }
 
-static double resamplekin(double kk, double sigma, int ndeg, double taut, std::mt19937& rng)
+static inline double resamplekin(double kk, double sigma, int ndeg, double taut, std::mt19937& rng)
 {
   /*
     kk:    present value of the kinetic energy of the atoms to be thermalized (in arbitrary units)


### PR DESCRIPTION
# **Summary** (Briefly summarize the purpose of this pull request)

Add NPT-SCR method to PIMD.

# **Modification** (Describe the main changes made in this pull request)

New usage:
```
ensemble pimd_scr ...
```
Similar to old one 
```
ensemble pimd ...
```
but using SCR barostat instead of Berendsen barostat.

# **Licensing** (Please read and confirm before submitting this pull request)

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.

# **Validation** (Describe how this pull request was tested)

```
potential   Si_2022_NEP4_3body.txt
velocity    300 seed 12345
time_step   2

dump_thermo 10
ensemble    pimd_scr 16 300 300 50 0 0 0 0 0 0 100 100 100 100 100 100 500
run         2000
```

<img width="1775" height="1137" alt="pimd_berendsen_vs_scr_4ps" src="https://github.com/user-attachments/assets/631576fa-a950-40c0-9012-e839a18ac921" />


# **Others**
