### PR TITLE
perf(dp): run compact canonical graphs on device

### DIFF
--- a/src/force/dp.cu
+++ b/src/force/dp.cu
@@ -27,6 +27,7 @@ The class dealing with the Deep Potential(DP).
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
 #include <cmath>
+#include <cstdint>
 #include <sstream>
 #include <cstring>
 
@@ -598,6 +599,113 @@ static __global__ void dp_fill_edges(
   }
 }
 
+// Build the compact canonical graph ABI used by compressed DPA4C artifacts.
+// The neighbor list is already destination-major (one contiguous row per
+// center), so its exclusive offsets are the destination CSR.  This kernel
+// writes the uint32 source row, float32 bond vectors, and per-source counts.
+static __global__ void dp_fill_canonical_edges(
+  const int N,
+  const int* __restrict__ NN,
+  const int* __restrict__ NL,
+  const int* __restrict__ edge_offset,
+  const double* __restrict__ x,
+  const double* __restrict__ y,
+  const double* __restrict__ z,
+  const Box box,
+  int* source,
+  float* edge_vec,
+  int* source_count)
+{
+  const int n1 = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n1 < N) {
+    const int count = NN[n1];
+    const int base = edge_offset[n1];
+    const double x1 = x[n1];
+    const double y1 = y[n1];
+    const double z1 = z[n1];
+    for (int c = 0; c < count; ++c) {
+      const int n2 = NL[static_cast<size_t>(c) * N + n1];
+      double x12 = x[n2] - x1;
+      double y12 = y[n2] - y1;
+      double z12 = z[n2] - z1;
+      apply_mic(box, x12, y12, z12);
+      const int edge = base + c;
+      source[edge] = n2;
+      edge_vec[edge * 3] = static_cast<float>(x12);
+      edge_vec[edge * 3 + 1] = static_cast<float>(y12);
+      edge_vec[edge * 3 + 2] = static_cast<float>(z12);
+      atomicAdd(source_count + n2, 1);
+    }
+  }
+}
+
+static __global__ void dp_prepare_canonical_nodes(
+  const int N,
+  const int nedge,
+  const int* __restrict__ type,
+  const int* __restrict__ destination_offset,
+  std::int64_t* model_type,
+  std::int64_t* destination_row_ptr)
+{
+  const int n1 = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n1 < N) {
+    model_type[n1] = static_cast<std::int64_t>(type[n1]);
+    destination_row_ptr[n1] =
+      static_cast<std::int64_t>(destination_offset[n1]);
+  }
+  if (n1 == N - 1) {
+    destination_row_ptr[N] = static_cast<std::int64_t>(nedge);
+  }
+}
+
+static __global__ void dp_prepare_canonical_source_rows(
+  const int N,
+  const int nedge,
+  const int* __restrict__ source_offset,
+  std::int64_t* source_row_ptr,
+  int* source_cursor)
+{
+  const int n1 = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n1 < N) {
+    const int offset = source_offset[n1];
+    source_row_ptr[n1] = static_cast<std::int64_t>(offset);
+    source_cursor[n1] = offset;
+  }
+  if (n1 == N - 1) {
+    source_row_ptr[N] = static_cast<std::int64_t>(nedge);
+  }
+}
+
+static __global__ void dp_build_canonical_source_order(
+  const int nedge,
+  const int* __restrict__ source,
+  int* source_cursor,
+  int* source_order)
+{
+  const int edge = blockIdx.x * blockDim.x + threadIdx.x;
+  if (edge < nedge) {
+    const int position = atomicAdd(source_cursor + source[edge], 1);
+    source_order[position] = edge;
+  }
+}
+
+static __global__ void dp_fill_canonical_guards(
+  const int edge_begin,
+  const int edge_storage,
+  int* source,
+  float* edge_vec,
+  int* source_order)
+{
+  const int edge = edge_begin + blockIdx.x * blockDim.x + threadIdx.x;
+  if (edge < edge_storage) {
+    source[edge] = 0;
+    edge_vec[edge * 3] = 0.0f;
+    edge_vec[edge * 3 + 1] = 0.0f;
+    edge_vec[edge * 3 + 2] = 0.0f;
+    source_order[edge] = edge;
+  }
+}
+
 // Scatter the device model outputs into GPUMD's per-atom arrays.  Force and
 // virial are converted from the model's row-major layout to GPUMD's
 // structure-of-arrays layout, applying the unit-conversion factors.  The
@@ -684,37 +792,104 @@ void DP::compute_gpu_edges(
     thrust::device, dp_NN_local.data(), dp_NN_local.data() + N, 0,
     thrust::plus<int>());
 
-  // Transpose positions from GPUMD SoA (x1..xN, y1..yN, z1..zN) to the
-  // row-major (x1, y1, z1, ...) layout the model consumes.
-  dp_position_gpu_trans.resize(N * 3);
-  dp_position_transpose<<<grid_size, BLOCK_SIZE_FORCE>>>(
-    position_per_atom.data(), dp_position_gpu_trans.data(), N);
-  GPU_CHECK_KERNEL
-
-  if (nedge > 0) {
-    if (dp_edge_index.size() < (size_t)(2 * nedge)) {
-      dp_edge_index.resize(2 * nedge);
-    }
-    if (dp_edge_vec.size() < (size_t)(3 * nedge)) {
-      dp_edge_vec.resize(3 * nedge);
-    }
-    dp_fill_edges<<<grid_size, BLOCK_SIZE_FORCE>>>(
-      N, N, dp_NN_local.data(), dp_NL_local.data(), dp_edge_offset.data(),
-      position_per_atom.data(), position_per_atom.data() + N,
-      position_per_atom.data() + N * 2, box, nedge, dp_edge_index.data(),
-      dp_edge_vec.data());
-    GPU_CHECK_KERNEL
-  }
-
   dp_atom_energy_gpu.resize(N);
   dp_force_rowmajor.resize(N * 3);
   dp_atom_virial_gpu.resize(N * 9);
 
-  // Run the exported model entirely on the device.
-  deep_pot.compute_edges_gpu(
-    dp_atom_energy_gpu.data(), dp_force_rowmajor.data(),
-    dp_atom_virial_gpu.data(), dp_position_gpu_trans.data(), type.data(),
-    dp_edge_index.data(), dp_edge_vec.data(), N, nedge);
+  if (deep_pot.uses_canonical_graph_inference()) {
+    // Reuse existing DP scratch buffers for the additional canonical ABI
+    // arrays. Their element widths match the required int64/uint32 storage,
+    // so no class-layout or neighbor implementation change is needed.
+    const int edge_storage = nedge < 2 ? 2 : nedge;
+    if (dp_edge_index.size() < static_cast<size_t>(2 * edge_storage)) {
+      dp_edge_index.resize(2 * edge_storage);
+    }
+    if (dp_edge_vec.size() < static_cast<size_t>(3 * edge_storage)) {
+      dp_edge_vec.resize(3 * edge_storage);
+    }
+    dp_position_gpu_trans.resize(N);  // int64 model type
+    dp_position_gpu.resize(N + 1);    // int64 destination row pointer
+    if (e_f_v_gpu.size() < static_cast<size_t>(N + 1)) {
+      e_f_v_gpu.resize(N + 1);        // int64 source row pointer
+    }
+    ghost_count.resize(N);            // uint32 source counts
+    ghost_sum.resize(N);              // uint32 source cursors
+
+    auto* model_type =
+      reinterpret_cast<std::int64_t*>(dp_position_gpu_trans.data());
+    auto* destination_row_ptr =
+      reinterpret_cast<std::int64_t*>(dp_position_gpu.data());
+    auto* source_row_ptr = reinterpret_cast<std::int64_t*>(e_f_v_gpu.data());
+    int* source = dp_edge_index.data();
+    int* source_order = dp_edge_index.data() + edge_storage;
+    float* edge_vec = reinterpret_cast<float*>(dp_edge_vec.data());
+
+    dp_prepare_canonical_nodes<<<grid_size, BLOCK_SIZE_FORCE>>>(
+      N, nedge, type.data(), dp_edge_offset.data(), model_type,
+      destination_row_ptr);
+    GPU_CHECK_KERNEL
+    CHECK(gpuMemset(ghost_count.data(), 0, sizeof(int) * N));
+    if (nedge > 0) {
+      dp_fill_canonical_edges<<<grid_size, BLOCK_SIZE_FORCE>>>(
+        N, dp_NN_local.data(), dp_NL_local.data(), dp_edge_offset.data(),
+        position_per_atom.data(), position_per_atom.data() + N,
+        position_per_atom.data() + N * 2, box, source, edge_vec,
+        ghost_count.data());
+      GPU_CHECK_KERNEL
+    }
+    thrust::exclusive_scan(
+      thrust::device, ghost_count.data(), ghost_count.data() + N,
+      dp_edge_offset.data());
+    dp_prepare_canonical_source_rows<<<grid_size, BLOCK_SIZE_FORCE>>>(
+      N, nedge, dp_edge_offset.data(), source_row_ptr, ghost_sum.data());
+    GPU_CHECK_KERNEL
+    if (nedge > 0) {
+      const int edge_grid = (nedge - 1) / BLOCK_SIZE_FORCE + 1;
+      dp_build_canonical_source_order<<<edge_grid, BLOCK_SIZE_FORCE>>>(
+        nedge, source, ghost_sum.data(), source_order);
+      GPU_CHECK_KERNEL
+    }
+    if (edge_storage > nedge) {
+      const int guard_grid =
+        (edge_storage - nedge - 1) / BLOCK_SIZE_FORCE + 1;
+      dp_fill_canonical_guards<<<guard_grid, BLOCK_SIZE_FORCE>>>(
+        nedge, edge_storage, source, edge_vec, source_order);
+      GPU_CHECK_KERNEL
+    }
+
+    deep_pot.compute_canonical_graph_gpu(
+      dp_atom_energy_gpu.data(), dp_force_rowmajor.data(),
+      dp_atom_virial_gpu.data(), model_type,
+      reinterpret_cast<std::uint32_t*>(source), edge_vec,
+      destination_row_ptr, source_row_ptr,
+      reinterpret_cast<std::uint32_t*>(source_order), N, N,
+      static_cast<std::int64_t>(edge_storage));
+  } else {
+    // Transpose positions from GPUMD SoA (x1..xN, y1..yN, z1..zN) to the
+    // row-major (x1, y1, z1, ...) layout the edge model consumes.
+    dp_position_gpu_trans.resize(N * 3);
+    dp_position_transpose<<<grid_size, BLOCK_SIZE_FORCE>>>(
+      position_per_atom.data(), dp_position_gpu_trans.data(), N);
+    GPU_CHECK_KERNEL
+    if (nedge > 0) {
+      if (dp_edge_index.size() < static_cast<size_t>(2 * nedge)) {
+        dp_edge_index.resize(2 * nedge);
+      }
+      if (dp_edge_vec.size() < static_cast<size_t>(3 * nedge)) {
+        dp_edge_vec.resize(3 * nedge);
+      }
+      dp_fill_edges<<<grid_size, BLOCK_SIZE_FORCE>>>(
+        N, N, dp_NN_local.data(), dp_NL_local.data(), dp_edge_offset.data(),
+        position_per_atom.data(), position_per_atom.data() + N,
+        position_per_atom.data() + N * 2, box, nedge, dp_edge_index.data(),
+        dp_edge_vec.data());
+      GPU_CHECK_KERNEL
+    }
+    deep_pot.compute_edges_gpu(
+      dp_atom_energy_gpu.data(), dp_force_rowmajor.data(),
+      dp_atom_virial_gpu.data(), dp_position_gpu_trans.data(), type.data(),
+      dp_edge_index.data(), dp_edge_vec.data(), N, nedge);
+  }
 
   // Scatter the device outputs into GPUMD's per-atom arrays.
   dp_scatter_outputs<<<grid_size, BLOCK_SIZE_FORCE>>>(
@@ -760,8 +935,7 @@ void DP::compute(
     const bool mic_valid = (box.pbc_x == 0 || thickness_x > 2.0 * neighbor_rc) &&
                            (box.pbc_y == 0 || thickness_y > 2.0 * neighbor_rc) &&
                            (box.pbc_z == 0 || thickness_z > 2.0 * neighbor_rc);
-    if (mic_valid && deep_pot.supports_device_edge_inference() &&
-        !deep_pot.uses_canonical_graph_inference()) {
+    if (mic_valid && deep_pot.supports_device_edge_inference()) {
       compute_gpu_edges(
         box, type, position_per_atom, potential_per_atom, force_per_atom,
         virial_per_atom);


### PR DESCRIPTION
**Summary**

Follow up on #1679 by running compact canonical DeepMD artifacts, including compressed DPA4C, through their native device ABI instead of the standalone `DeepPot::compute` path. The change is confined to `src/force/dp.cu`; `neighbor.cu` and the class layout are unchanged.

**Implementation**

GPUMD's filtered neighbor list is already destination-major. The new branch builds the remaining compact canonical ABI arrays on the GPU: int64 model types, uint32 source indices, float32 edge vectors, destination CSR, source CSR, and the source-edge permutation. It then calls `DeepPot::compute_canonical_graph_gpu`. Existing edge/vector and ordinary graph artifacts continue to call `compute_edges_gpu`, while small cells that require explicit periodic images keep the existing standalone route. Existing DP scratch buffers are reused so this remains a one-file change.

**Why this is a GPUMD fix**

The same compressed artifact succeeds through the DeepMD Python API and LAMMPS Kokkos. GPUMD 5.7 originally sent it to `compute_edges_gpu`, which DeepMD correctly rejected with `compute_edges_gpu cannot serve a compact canonical artifact; use compute_canonical_graph_gpu.` PR #1679 fixed that crash by routing the artifact through standalone compute. This follow-up connects the intended canonical GPU entry point and removes the large performance penalty of that correctness fallback.

**Validation**

Clean build from commit `e7e9c74f2ec8ec63eae93479f10898ae8c2b2020`, based on upstream master `f8cc14ac8d483a2920f469eb5f85f8cfb7ed47cf`, on an NVIDIA A800-SXM4-80GB with DeePMD-kit 3.2.0. Volc build/canary task: `t-20260826013920-fq99f`. Binary SHA-256: `c74d29d0277923422c0775f9cc0350a79e534c1e56418cfa4c4aa7662dc79eeb`. Both GitHub Actions build jobs pass.

The compressed artifact was generated by graph freeze followed by `dp --pt-expt compress`; embedded `lower_input_kind=dpa4c_canonical`, SHA-256 `f297b94d1cb508560103dac81e10ec9043992741502739ef5db868695528ac35`. On the identical 1,536-atom triclinic water structure, GPUMD versus DeepMD Python gave:

- DPA4: |dE| 3.08e-5 eV, max |dF| 3.30e-5 eV/A, max |dV| 3.86e-4 eV.
- DPA4C graph: |dE| 3.74e-5 eV, max |dF| 1.84e-5 eV/A, max |dV| 3.63e-4 eV.
- DPA4C compressed: |dE| 3.63e-5 eV, max |dF| 1.38e-5 eV/A, max |dV| 1.28e-4 eV.

The completed fixed regression matrix covers DPA4, DPA4C graph and compressed DPA4C. All 120 EFV cases pass (20 structures x 3 models x T1/T3); GPUMD-versus-API RMSE ranges are 7.97e-6--5.90e-5 eV for total energy, 1.73e-6--2.47e-6 eV/A for force components and 4.70e-5--7.52e-5 eV for virial components. NVE has 1,000 finite production samples per engine/model after 1 ps NVT + 10 ps NVE; the maximum absolute endpoint total-energy drift is 2.44e-4 eV/atom. RDF has 500 bins for every engine/model/pair after 10 ps NVT and uses identical all-atom normalization without fixed initial molecule exclusions.

Three-repeat 9,826-atom throughput medians (atom-step/s) are:

- DPA4: GPUMD T1 0.0631M, GPUMD T3 0.0877M, LAMMPS T1 0.0626M.
- DPA4C graph: GPUMD T1 1.593M, GPUMD T3 1.575M, LAMMPS T1 1.358M.
- DPA4C compressed: GPUMD T1 9.059M, GPUMD T3 8.530M, LAMMPS T1 4.893M.

For compressed DPA4C, the merged standalone route measured about 0.154M atom-step/s in the same A800 environment. The native canonical device route is therefore about 59x faster than that route and 1.85x the LAMMPS T1 throughput at 9,826 atoms. The machine audit passed all artifact, provenance, count, finiteness and figure checks. Final task IDs include EFV `t-20260826014556-qpqfn` through `t-20260826014621-kt9b9`, efficiency `t-20260826014602-b76zn`, `t-20260826014612-fmv8w`, `t-20260826014625-qtlgr`, and final GPUMD MD refresh `t-20260826014628-mm5fl` through `t-20260826025126-29dhd`.

**Licensing**

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. No external source code with incompatible licensing has been copied into this pull request.