### PR TITLE
Generalize deform and decouple it from NPT ensembles

### DIFF
--- a/doc/gpumd/input_parameters/deform.rst
+++ b/doc/gpumd/input_parameters/deform.rst
@@ -5,39 +5,53 @@
 :attr:`deform`
 ==============
 
-This keyword is used to deform the simulation box, which can be used to do tensile tests.
+This keyword is used to continuously deform the simulation box during a run.
+It can be used for tensile, compressive, and shear deformation.
 
 Syntax
 ------
 
-The :attr:`deform` keyword supports two forms.
+The :attr:`deform` keyword supports two legacy forms and one general form.
 
-**4-parameter form** ::
+**4-parameter legacy form** ::
 
   deform <A_per_step> <deform_x> <deform_y> <deform_z>
 
-Here, :attr:`A_per_step` specifies the speed of the increase of the box length, which is in units of Ångstrom/step.
-For example, suppose the box length (in a given direction) in the beginning of a run is 100 Ångstrom and this parameter is :math:`10^{-5}` Ångstrom/step, then a run with :math:`10^{6}` steps will change the box length by 10%.
+Here, :attr:`A_per_step` specifies the increment of the box length per simulation step, in units of Ångstrom/step.
+For example, suppose the box length in a given direction at the beginning of a run is 100 Ångstrom and this parameter is :math:`10^{-5}` Ångstrom/step. A run with :math:`10^{6}` steps will then change the box length by 10%.
 This gives a strain rate of :math:`10^{8}` s :math:`^{-1}` if the time step is 1 fs.
-The second parameter :attr:`deform_x` can be 0 or 1, where 0 means do not deform the :math:`x` direction and 1 means deform the :math:`x` direction.
-The last two parameters have similar meanings for the :math:`y` and :math:`z` directions.
+The parameters :attr:`deform_x`, :attr:`deform_y`, and :attr:`deform_z` can be 0 or 1, where 1 enables deformation in the corresponding direction and 0 disables it.
 
 In this form, the same deformation rate is applied to all directions that are flagged as deformed.
 
-**6-parameter form** ::
+**6-parameter legacy form** ::
 
   deform <A_per_step_x> <A_per_step_y> <A_per_step_z> <deform_x> <deform_y> <deform_z>
 
-Here, :attr:`A_per_step_x`, :attr:`A_per_step_y`, :attr:`A_per_step_z` specify the increment (or decrement) of the box length in the x, y, and z directions per simulation step, respectively. The unit is Ångstrom/step. For example, if the box length in the x-direction is initially 100 Å and :attr:`A_per_step_x` is set to :math:`10^{-5}` Å/step, then after :math:`10^{6}` steps, the box length will change by 10%. With a time step of 1 fs, this corresponds to a strain rate of :math:`10^{8}` s :math:`^{-1}`. Use :attr:`deform_x`, :attr:`deform_y`, :attr:`deform_z` to enable or disable deformation in each direction. A value of `1` enables deformation, while `0` disables it. For a direction where deformation is disabled, the box length remains constant throughout the simulation.
+Here, :attr:`A_per_step_x`, :attr:`A_per_step_y`, and :attr:`A_per_step_z` specify the increments of the box lengths in the x, y, and z directions per simulation step, respectively, in units of Ångstrom/step.
+The parameters :attr:`deform_x`, :attr:`deform_y`, and :attr:`deform_z` enable or disable deformation in each direction.
 
 This form allows independent deformation rates in the x, y, and z directions.
 
-Example
--------
+**General form** ::
 
-For uniaxial tensile test, one can first equilibrate the system and then deform the box.
+  deform <component_1> <A_per_step_1> [<component_2> <A_per_step_2> ...]
 
-**Using the 4-parameter form**::
+The available components are
+
+.. code-block:: text
+
+  xx yy zz xy xz yz
+
+Each rate specifies the increment of the corresponding GPUMD box-matrix component per simulation step, in units of Ångstrom/step. Positive and negative values can be used.
+The components :attr:`xy`, :attr:`xz`, and :attr:`yz` are geometric box/tilt components and are not symmetric Voigt shear-strain components.
+Each component can only be specified once in a :attr:`deform` command.
+
+Examples
+--------
+
+For a uniaxial tensile test, one can first equilibrate the system and then deform the box.
+For example, using the legacy syntax::
 
   # equilibration stage
   ensemble npt_scr 300 300 100 0 0 0 100 100 100 1000
@@ -48,25 +62,28 @@ For uniaxial tensile test, one can first equilibrate the system and then deform 
   deform 0.00001 1 0 0
   run 1000000
 
-**Using the 6-parameter form**::
+The equivalent general syntax is::
 
-  # equilibration stage
-  ensemble npt_scr 300 300 100 0 0 0 100 100 100 1000
+  deform xx 0.00001
+
+The general syntax can also be used for shear deformation. For example::
+
+  ensemble nvt_nhc 300 300 100
+  deform xy 0.00001
   run 1000000
 
-  # production stage
-  ensemble npt_scr 300 300 100 0 0 0 100 100 100 1000
-  deform 0.00001 0 0 1 0 0
-  run 1000000
+Multiple box components can be deformed simultaneously. For example::
 
-Both examples achieve the same deformation (x-direction stretched at 0.00001 Å/step).
+  deform xx 0.00001 yy -0.000005 xy 0.00002
 
-Caveats
--------
-* Currently, one must use the NPT ensemble when using this keyword.
-  That is, the code assumes that the pressure components in the directions which are not deformed will be controlled.
-  If one does not want to control the pressure (box) in a direction that is not deformed, 
-  one can set the elastic constant for that direction to be larger than 2000 GPa.
-* In the equilibration stage, it is also recommended to use the NPT ensemble to obtain the zero strain state before applying the deformation.
-* One must control the three pressure components independently when using this keyword.
-* The 6-parameter form is more flexible and is recommended for new input files.
+Compatibility and caveats
+-------------------------
+
+* :attr:`deform` can be used with NVE and the standard NVT ensembles.
+* With NPT-Berendsen or NPT-SCR, isotropic pressure control cannot be combined with :attr:`deform`.
+* With 3 target pressure components, only diagonal :attr:`xx`, :attr:`yy`, and :attr:`zz` deformation is allowed, and the box must be orthogonal.
+* With 6 target pressure components, the general form of :attr:`deform` can be used. Pressure control is disabled for the box components controlled by :attr:`deform`.
+* The legacy forms cannot be combined with 6-component NPT pressure control and only support orthogonal boxes.
+* :attr:`deform` is currently not supported with MTTK pressure-control ensembles or other special box-changing ensembles.
+* Every direction involved in a deformation component must be periodic. For example, :attr:`xx` requires periodicity in x, while :attr:`xy` requires periodicity in both x and y.
+* Automatic lattice reduction or box flipping is not performed for very large cumulative shear. The simulation box should therefore not be allowed to become excessively skewed.

--- a/src/integrate/ensemble.cuh
+++ b/src/integrate/ensemble.cuh
@@ -87,7 +87,6 @@ public:
   int deform_x = 0;
   int deform_y = 0;
   int deform_z = 0;
-  double deform_rate[3];
   
   double energy_transferred[2]; // energy transferred from system to heat baths
 

--- a/src/integrate/ensemble.cuh
+++ b/src/integrate/ensemble.cuh
@@ -90,7 +90,7 @@ public:
   int deform_xy = 0;
   int deform_xz = 0;
   int deform_yz = 0;
-  
+
   double energy_transferred[2]; // energy transferred from system to heat baths
 
   std::vector<double> energy_transferred_n; // energy transferred from system to multiple heat baths

--- a/src/integrate/ensemble.cuh
+++ b/src/integrate/ensemble.cuh
@@ -87,6 +87,9 @@ public:
   int deform_x = 0;
   int deform_y = 0;
   int deform_z = 0;
+  int deform_xy = 0;
+  int deform_xz = 0;
+  int deform_yz = 0;
   
   double energy_transferred[2]; // energy transferred from system to heat baths
 

--- a/src/integrate/ensemble_ber.cu
+++ b/src/integrate/ensemble_ber.cu
@@ -43,7 +43,10 @@ Ensemble_BER::Ensemble_BER(
   double pc[6],
   int dx,
   int dy,
-  int dz)
+  int dz,
+  int dxy,
+  int dxz,
+  int dyz)
 {
   type = t;
   temperature = T;
@@ -56,6 +59,9 @@ Ensemble_BER::Ensemble_BER(
   deform_x = dx;
   deform_y = dy;
   deform_z = dz;
+  deform_xy = dxy;
+  deform_xz = dxz;
+  deform_yz = dyz;
 }
 
 Ensemble_BER::~Ensemble_BER(void)
@@ -94,6 +100,7 @@ static void cpu_pressure_orthogonal(
   double p[3];
   CHECK(gpuMemcpy(p, thermo + 2, sizeof(double) * 3, gpuMemcpyDeviceToHost));
 
+  // Disable the barostat components controlled by deform.
   if (deform_x) {
     scale_factor[0] = 1.0;
   } else if (box.pbc_x == 1) {
@@ -136,8 +143,18 @@ static void cpu_pressure_isotropic(
   box.get_inverse();
 }
 
-static void
-cpu_pressure_triclinic(Box& box, double* p0, double* p_coupling, double* thermo, double* mu)
+static void cpu_pressure_triclinic(
+  int deform_x,
+  int deform_y,
+  int deform_z,
+  int deform_xy,
+  int deform_xz,
+  int deform_yz,
+  Box& box,
+  double* p0,
+  double* p_coupling,
+  double* thermo,
+  double* mu)
 {
   // p_coupling and p0 are in Voigt notation: xx, yy, zz, yz, xz, xy
   double p[6]; // but thermo is this order: xx, yy, zz, xy, xz, yz
@@ -148,6 +165,26 @@ cpu_pressure_triclinic(Box& box, double* p0, double* p_coupling, double* thermo,
   mu[3] = mu[1] = -p_coupling[5] * (p0[5] - p[3]); // xy
   mu[6] = mu[2] = -p_coupling[4] * (p0[4] - p[4]); // xz
   mu[7] = mu[5] = -p_coupling[3] * (p0[3] - p[5]); // yz
+
+  if (deform_x) {
+    mu[0] = 1.0;
+  }
+  if (deform_y) {
+    mu[4] = 1.0;
+  }
+  if (deform_z) {
+    mu[8] = 1.0;
+  }
+  if (deform_xy) {
+    mu[1] = mu[3] = 0.0;
+  }
+  if (deform_xz) {
+    mu[2] = mu[6] = 0.0;
+  }
+  if (deform_yz) {
+    mu[5] = mu[7] = 0.0;
+  }
+
   double h_old[9];
   for (int i = 0; i < 9; ++i) {
     h_old[i] = box.cpu_h[i];
@@ -253,7 +290,18 @@ void Ensemble_BER::compute2(
       GPU_CHECK_KERNEL
     } else {
       double mu[9];
-      cpu_pressure_triclinic(box, target_pressure, pressure_coupling, thermo.data(), mu);
+      cpu_pressure_triclinic(
+        deform_x,
+        deform_y,
+        deform_z,
+        deform_xy,
+        deform_xz,
+        deform_yz,
+        box,
+        target_pressure,
+        pressure_coupling,
+        thermo.data(),
+        mu);
       gpu_pressure_triclinic<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
         number_of_atoms,
         mu[0],

--- a/src/integrate/ensemble_ber.cu
+++ b/src/integrate/ensemble_ber.cu
@@ -43,8 +43,7 @@ Ensemble_BER::Ensemble_BER(
   double pc[6],
   int dx,
   int dy,
-  int dz,
-  double rate[3])
+  int dz)
 {
   type = t;
   temperature = T;
@@ -57,9 +56,6 @@ Ensemble_BER::Ensemble_BER(
   deform_x = dx;
   deform_y = dy;
   deform_z = dz;
-  deform_rate[0] = rate[0];
-  deform_rate[1] = rate[1];
-  deform_rate[2] = rate[2];
 }
 
 Ensemble_BER::~Ensemble_BER(void)
@@ -89,7 +85,6 @@ static void cpu_pressure_orthogonal(
   int deform_x,
   int deform_y,
   int deform_z,
-  double deform_rate[3],
   Box& box,
   double* p0,
   double* p_coupling,
@@ -100,9 +95,7 @@ static void cpu_pressure_orthogonal(
   CHECK(gpuMemcpy(p, thermo + 2, sizeof(double) * 3, gpuMemcpyDeviceToHost));
 
   if (deform_x) {
-    scale_factor[0] = box.cpu_h[0];
-    scale_factor[0] = (scale_factor[0] + deform_rate[0]) / scale_factor[0];
-    box.cpu_h[0] *= scale_factor[0];
+    scale_factor[0] = 1.0;
   } else if (box.pbc_x == 1) {
     scale_factor[0] = 1.0 - p_coupling[0] * (p0[0] - p[0]);
     box.cpu_h[0] *= scale_factor[0];
@@ -111,9 +104,7 @@ static void cpu_pressure_orthogonal(
   }
 
   if (deform_y) {
-    scale_factor[1] = box.cpu_h[4];
-    scale_factor[1] = (scale_factor[1] + deform_rate[1]) / scale_factor[1];
-    box.cpu_h[4] *= scale_factor[1];
+    scale_factor[1] = 1.0;
   } else if (box.pbc_y == 1) {
     scale_factor[1] = 1.0 - p_coupling[1] * (p0[1] - p[1]);
     box.cpu_h[4] *= scale_factor[1];
@@ -122,9 +113,7 @@ static void cpu_pressure_orthogonal(
   }
 
   if (deform_z) {
-    scale_factor[2] = box.cpu_h[8];
-    scale_factor[2] = (scale_factor[2] + deform_rate[2]) / scale_factor[2];
-    box.cpu_h[8] *= scale_factor[2];
+    scale_factor[2] = 1.0;
   } else if (box.pbc_z == 1) {
     scale_factor[2] = 1.0 - p_coupling[2] * (p0[2] - p[2]);
     box.cpu_h[8] *= scale_factor[2];
@@ -248,7 +237,6 @@ void Ensemble_BER::compute2(
         deform_x,
         deform_y,
         deform_z,
-        deform_rate,
         box,
         target_pressure,
         pressure_coupling,

--- a/src/integrate/ensemble_ber.cu
+++ b/src/integrate/ensemble_ber.cu
@@ -186,8 +186,10 @@ static void cpu_pressure_triclinic(
   }
 
   double h_old[9];
+  double h_old_inverse[9];
   for (int i = 0; i < 9; ++i) {
     h_old[i] = box.cpu_h[i];
+    h_old_inverse[i] = box.cpu_h[i + 9];
   }
   for (int r = 0; r < 3; ++r) {
     for (int c = 0; c < 3; ++c) {
@@ -198,6 +200,45 @@ static void cpu_pressure_triclinic(
       box.cpu_h[r * 3 + c] = tmp;
     }
   }
+
+  bool need_remap = false;
+  if (deform_x && box.cpu_h[0] != h_old[0]) {
+    box.cpu_h[0] = h_old[0];
+    need_remap = true;
+  }
+  if (deform_y && box.cpu_h[4] != h_old[4]) {
+    box.cpu_h[4] = h_old[4];
+    need_remap = true;
+  }
+  if (deform_z && box.cpu_h[8] != h_old[8]) {
+    box.cpu_h[8] = h_old[8];
+    need_remap = true;
+  }
+  if (deform_xy && box.cpu_h[1] != h_old[1]) {
+    box.cpu_h[1] = h_old[1];
+    need_remap = true;
+  }
+  if (deform_xz && box.cpu_h[2] != h_old[2]) {
+    box.cpu_h[2] = h_old[2];
+    need_remap = true;
+  }
+  if (deform_yz && box.cpu_h[5] != h_old[5]) {
+    box.cpu_h[5] = h_old[5];
+    need_remap = true;
+  }
+
+  if (need_remap) {
+    for (int r = 0; r < 3; ++r) {
+      for (int c = 0; c < 3; ++c) {
+        double tmp = 0.0;
+        for (int k = 0; k < 3; ++k) {
+          tmp += box.cpu_h[r * 3 + k] * h_old_inverse[k * 3 + c];
+        }
+        mu[r * 3 + c] = tmp;
+      }
+    }
+  }
+
   box.get_inverse();
 }
 

--- a/src/integrate/ensemble_ber.cu
+++ b/src/integrate/ensemble_ber.cu
@@ -201,6 +201,9 @@ static void cpu_pressure_triclinic(
     }
   }
 
+  // Other barostat components can also change a box component controlled
+  // by deform. Restore such components and recompute the actual affine
+  // transformation when needed.
   bool need_remap = false;
   if (deform_x && box.cpu_h[0] != h_old[0]) {
     box.cpu_h[0] = h_old[0];

--- a/src/integrate/ensemble_ber.cuh
+++ b/src/integrate/ensemble_ber.cuh
@@ -20,7 +20,7 @@ class Ensemble_BER : public Ensemble
 {
 public:
   Ensemble_BER(int, int, double*, double, double);
-  Ensemble_BER(int, double, double, double*, int, double*, int, int, int);
+  Ensemble_BER(int, double, double, double*, int, double*, int, int, int, int, int, int);
   virtual ~Ensemble_BER(void);
 
   virtual void compute1(

--- a/src/integrate/ensemble_ber.cuh
+++ b/src/integrate/ensemble_ber.cuh
@@ -20,7 +20,7 @@ class Ensemble_BER : public Ensemble
 {
 public:
   Ensemble_BER(int, int, double*, double, double);
-  Ensemble_BER(int, double, double, double*, int, double*, int, int, int, double*);
+  Ensemble_BER(int, double, double, double*, int, double*, int, int, int);
   virtual ~Ensemble_BER(void);
 
   virtual void compute1(

--- a/src/integrate/ensemble_npt_scr.cu
+++ b/src/integrate/ensemble_npt_scr.cu
@@ -46,7 +46,10 @@ Ensemble_NPT_SCR::Ensemble_NPT_SCR(
   double pressure_coupling_input[6],
   int deform_x_input,
   int deform_y_input,
-  int deform_z_input)
+  int deform_z_input,
+  int deform_xy_input,
+  int deform_xz_input,
+  int deform_yz_input)
 {
   type = type_input;
   temperature = temperature_input;
@@ -60,6 +63,9 @@ Ensemble_NPT_SCR::Ensemble_NPT_SCR(
   deform_x = deform_x_input;
   deform_y = deform_y_input;
   deform_z = deform_z_input;
+  deform_xy = deform_xy_input;
+  deform_xz = deform_xz_input;
+  deform_yz = deform_yz_input;
 
   initialize_rng();
 }
@@ -85,6 +91,7 @@ static void cpu_pressure_orthogonal(
   CHECK(gpuMemcpy(p, thermo + 2, sizeof(double) * 3, gpuMemcpyDeviceToHost));
   const double volume = box.get_volume();
 
+  // Disable the barostat components controlled by deform.
   if (deform_x) {
     scale_factor[0] = 1.0;
   } else if (box.pbc_x == 1) {
@@ -151,6 +158,12 @@ static void cpu_pressure_isotropic(
 
 static void cpu_pressure_triclinic(
   std::mt19937& rng,
+  int deform_x,
+  int deform_y,
+  int deform_z,
+  int deform_xy,
+  int deform_xz,
+  int deform_yz,
   Box& box,
   double target_temperature,
   double* p0,
@@ -183,6 +196,26 @@ static void cpu_pressure_triclinic(
   mu[6] += noise_xz;
   mu[1] += noise_xy;
   mu[3] += noise_xy;
+
+  if (deform_x) {
+    mu[0] = 1.0;
+  }
+  if (deform_y) {
+    mu[4] = 1.0;
+  }
+  if (deform_z) {
+    mu[8] = 1.0;
+  }
+  if (deform_xy) {
+    mu[1] = mu[3] = 0.0;
+  }
+  if (deform_xz) {
+    mu[2] = mu[6] = 0.0;
+  }
+  if (deform_yz) {
+    mu[5] = mu[7] = 0.0;
+  }
+
   double h_old[9];
   for (int i = 0; i < 9; ++i) {
     h_old[i] = box.cpu_h[i];
@@ -289,7 +322,19 @@ void Ensemble_NPT_SCR::compute2(
   } else {
     double mu[9];
     cpu_pressure_triclinic(
-      rng, box, temperature, target_pressure, pressure_coupling, thermo.data(), mu);
+      rng,
+      deform_x,
+      deform_y,
+      deform_z,
+      deform_xy,
+      deform_xz,
+      deform_yz,
+      box,
+      temperature,
+      target_pressure,
+      pressure_coupling,
+      thermo.data(),
+      mu);
     gpu_pressure_triclinic<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
       number_of_atoms,
       mu[0],

--- a/src/integrate/ensemble_npt_scr.cu
+++ b/src/integrate/ensemble_npt_scr.cu
@@ -232,6 +232,9 @@ static void cpu_pressure_triclinic(
     }
   }
 
+  // Other barostat components can also change a box component controlled
+  // by deform. Restore such components and recompute the actual affine
+  // transformation when needed.
   bool need_remap = false;
   if (deform_x && box.cpu_h[0] != h_old[0]) {
     box.cpu_h[0] = h_old[0];

--- a/src/integrate/ensemble_npt_scr.cu
+++ b/src/integrate/ensemble_npt_scr.cu
@@ -46,8 +46,7 @@ Ensemble_NPT_SCR::Ensemble_NPT_SCR(
   double pressure_coupling_input[6],
   int deform_x_input,
   int deform_y_input,
-  int deform_z_input,
-  double deform_rate_input[3])
+  int deform_z_input)
 {
   type = type_input;
   temperature = temperature_input;
@@ -61,9 +60,6 @@ Ensemble_NPT_SCR::Ensemble_NPT_SCR(
   deform_x = deform_x_input;
   deform_y = deform_y_input;
   deform_z = deform_z_input;
-  deform_rate[0] = deform_rate_input[0];
-  deform_rate[1] = deform_rate_input[1];
-  deform_rate[2] = deform_rate_input[2];
 
   initialize_rng();
 }
@@ -78,7 +74,6 @@ static void cpu_pressure_orthogonal(
   int deform_x,
   int deform_y,
   int deform_z,
-  double deform_rate[3],
   Box& box,
   double target_temperature,
   double* p0,
@@ -91,9 +86,7 @@ static void cpu_pressure_orthogonal(
   const double volume = box.get_volume();
 
   if (deform_x) {
-    scale_factor[0] = box.cpu_h[0];
-    scale_factor[0] = (scale_factor[0] + deform_rate[0]) / scale_factor[0];
-    box.cpu_h[0] *= scale_factor[0];
+    scale_factor[0] = 1.0;
   } else if (box.pbc_x == 1) {
     const double scale_factor_Berendsen = 1.0 - p_coupling[0] * (p0[0] - p[0]);
     const double scale_factor_stochastic =
@@ -105,9 +98,7 @@ static void cpu_pressure_orthogonal(
   }
 
   if (deform_y) {
-    scale_factor[1] = box.cpu_h[4];
-    scale_factor[1] = (scale_factor[1] + deform_rate[1]) / scale_factor[1];
-    box.cpu_h[4] *= scale_factor[1];
+    scale_factor[1] = 1.0;
   } else if (box.pbc_y == 1) {
     const double scale_factor_Berendsen = 1.0 - p_coupling[1] * (p0[1] - p[1]);
     const double scale_factor_stochastic =
@@ -119,9 +110,7 @@ static void cpu_pressure_orthogonal(
   }
 
   if (deform_z) {
-    scale_factor[2] = box.cpu_h[8];
-    scale_factor[2] = (scale_factor[2] + deform_rate[2]) / scale_factor[2];
-    box.cpu_h[8] *= scale_factor[2];
+    scale_factor[2] = 1.0;
   } else if (box.pbc_z == 1) {
     const double scale_factor_Berendsen = 1.0 - p_coupling[2] * (p0[2] - p[2]);
     const double scale_factor_stochastic =
@@ -282,7 +271,6 @@ void Ensemble_NPT_SCR::compute2(
       deform_x,
       deform_y,
       deform_z,
-      deform_rate,
       box,
       temperature,
       target_pressure,

--- a/src/integrate/ensemble_npt_scr.cu
+++ b/src/integrate/ensemble_npt_scr.cu
@@ -217,8 +217,10 @@ static void cpu_pressure_triclinic(
   }
 
   double h_old[9];
+  double h_old_inverse[9];
   for (int i = 0; i < 9; ++i) {
     h_old[i] = box.cpu_h[i];
+    h_old_inverse[i] = box.cpu_h[i + 9];
   }
   for (int r = 0; r < 3; ++r) {
     for (int c = 0; c < 3; ++c) {
@@ -229,6 +231,45 @@ static void cpu_pressure_triclinic(
       box.cpu_h[r * 3 + c] = tmp;
     }
   }
+
+  bool need_remap = false;
+  if (deform_x && box.cpu_h[0] != h_old[0]) {
+    box.cpu_h[0] = h_old[0];
+    need_remap = true;
+  }
+  if (deform_y && box.cpu_h[4] != h_old[4]) {
+    box.cpu_h[4] = h_old[4];
+    need_remap = true;
+  }
+  if (deform_z && box.cpu_h[8] != h_old[8]) {
+    box.cpu_h[8] = h_old[8];
+    need_remap = true;
+  }
+  if (deform_xy && box.cpu_h[1] != h_old[1]) {
+    box.cpu_h[1] = h_old[1];
+    need_remap = true;
+  }
+  if (deform_xz && box.cpu_h[2] != h_old[2]) {
+    box.cpu_h[2] = h_old[2];
+    need_remap = true;
+  }
+  if (deform_yz && box.cpu_h[5] != h_old[5]) {
+    box.cpu_h[5] = h_old[5];
+    need_remap = true;
+  }
+
+  if (need_remap) {
+    for (int r = 0; r < 3; ++r) {
+      for (int c = 0; c < 3; ++c) {
+        double tmp = 0.0;
+        for (int k = 0; k < 3; ++k) {
+          tmp += box.cpu_h[r * 3 + k] * h_old_inverse[k * 3 + c];
+        }
+        mu[r * 3 + c] = tmp;
+      }
+    }
+  }
+
   box.get_inverse();
 }
 

--- a/src/integrate/ensemble_npt_scr.cuh
+++ b/src/integrate/ensemble_npt_scr.cuh
@@ -20,7 +20,7 @@
 class Ensemble_NPT_SCR : public Ensemble
 {
 public:
-  Ensemble_NPT_SCR(int, double, double, double*, int, double*, int, int, int, double*);
+  Ensemble_NPT_SCR(int, double, double, double*, int, double*, int, int, int);
   virtual ~Ensemble_NPT_SCR(void);
 
   virtual void compute1(

--- a/src/integrate/ensemble_npt_scr.cuh
+++ b/src/integrate/ensemble_npt_scr.cuh
@@ -20,7 +20,7 @@
 class Ensemble_NPT_SCR : public Ensemble
 {
 public:
-  Ensemble_NPT_SCR(int, double, double, double*, int, double*, int, int, int);
+  Ensemble_NPT_SCR(int, double, double, double*, int, double*, int, int, int, int, int, int);
   virtual ~Ensemble_NPT_SCR(void);
 
   virtual void compute1(

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -115,8 +115,7 @@ void Integrate::initialize(
         pressure_coupling,
         deform_x,
         deform_y,
-        deform_z,
-        deform_rate));
+        deform_z));
       break;
     case 12: // NPT-SCR
       ensemble.reset(new Ensemble_NPT_SCR(
@@ -128,8 +127,7 @@ void Integrate::initialize(
         pressure_coupling,
         deform_x,
         deform_y,
-        deform_z,
-        deform_rate));
+        deform_z));
       break;
     case -1: // msst
       break;
@@ -1526,57 +1524,4 @@ void Integrate::parse_move(const char** param, int num_param, std::vector<Group>
   }
 }
 
-void Integrate::parse_deform(const char** param, int num_param)
-{
-  printf("Deform the box.\n");
 
-  if (num_param != 5 && num_param != 7) {
-    PRINT_INPUT_ERROR("Keyword 'deform' should have 4 or 6 parameters.");
-  }
-
-  // strain rate
-  if (!is_valid_real(param[1], &deform_rate[0])) {
-    PRINT_INPUT_ERROR("Defrom rate should be a number.");
-  }
-
-  int offset = 0;
-  if (num_param == 5) {
-    deform_rate[1] = deform_rate[0];
-    deform_rate[2] = deform_rate[0];
-    printf("    strain rate is %g A / step.\n", deform_rate[0]);
-  } else {
-    offset = 2;
-    if (!is_valid_real(param[2], &deform_rate[1])) {
-      PRINT_INPUT_ERROR("Defrom rate should be a number.");
-    }
-    if (!is_valid_real(param[3], &deform_rate[2])) {
-      PRINT_INPUT_ERROR("Defrom rate should be a number.");
-    }
-    printf(
-      "    strain rates are (%g, %g, %g) A / step.\n",
-      deform_rate[0],
-      deform_rate[1],
-      deform_rate[2]);
-  }
-
-  // direction
-  if (!is_valid_int(param[2 + offset], &deform_x)) {
-    PRINT_INPUT_ERROR("deform_x should be integer.\n");
-  }
-  if (!is_valid_int(param[3 + offset], &deform_y)) {
-    PRINT_INPUT_ERROR("deform_y should be integer.\n");
-  }
-  if (!is_valid_int(param[4 + offset], &deform_z)) {
-    PRINT_INPUT_ERROR("deform_z should be integer.\n");
-  }
-
-  if (deform_x) {
-    printf("    apply strain in x direction.\n");
-  }
-  if (deform_y) {
-    printf("    apply strain in y direction.\n");
-  }
-  if (deform_z) {
-    printf("    apply strain in z direction.\n");
-  }
-}

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -115,7 +115,10 @@ void Integrate::initialize(
         pressure_coupling,
         deform_x,
         deform_y,
-        deform_z));
+        deform_z,
+        deform_xy,
+        deform_xz,
+        deform_yz));
       break;
     case 12: // NPT-SCR
       ensemble.reset(new Ensemble_NPT_SCR(
@@ -127,7 +130,10 @@ void Integrate::initialize(
         pressure_coupling,
         deform_x,
         deform_y,
-        deform_z));
+        deform_z,
+        deform_xy,
+        deform_xz,
+        deform_yz));
       break;
     case -1: // msst
       break;
@@ -309,6 +315,9 @@ void Integrate::finalize()
   deform_x = 0;
   deform_y = 0;
   deform_z = 0;
+  deform_xy = 0;
+  deform_xz = 0;
+  deform_yz = 0;
 }
 
 void Integrate::compute1(

--- a/src/integrate/integrate.cu
+++ b/src/integrate/integrate.cu
@@ -1532,5 +1532,3 @@ void Integrate::parse_move(const char** param, int num_param, std::vector<Group>
     move_velocity[d] *= TIME_UNIT_CONVERSION; // natural to A/fs
   }
 }
-
-

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -65,7 +65,6 @@ public:
     Box& box,
     std::vector<Group>& group,
     GPU_Vector<double>& thermo);
-  void parse_deform(const char**, int);
   void parse_fix(const char**, int, std::vector<Group>& group);
   void parse_move(const char**, int, std::vector<Group>& group);
 
@@ -97,7 +96,6 @@ public:
   int deform_x = 0;
   int deform_y = 0;
   int deform_z = 0;
-  double deform_rate[3];
   
   // Dynamic arrays for multiple thermostats
   std::vector<int> heat_thermostat;  // Thermostat types (0=NHC, 1=Langevin)

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -99,7 +99,7 @@ public:
   int deform_xy = 0;
   int deform_xz = 0;
   int deform_yz = 0;
-  
+
   // Dynamic arrays for multiple thermostats
   std::vector<int> heat_thermostat;  // Thermostat types (0=NHC, 1=Langevin)
   std::vector<double> heat_coupling; // Coupling parameters for each thermostat

--- a/src/integrate/integrate.cuh
+++ b/src/integrate/integrate.cuh
@@ -96,6 +96,9 @@ public:
   int deform_x = 0;
   int deform_y = 0;
   int deform_z = 0;
+  int deform_xy = 0;
+  int deform_xz = 0;
+  int deform_yz = 0;
   
   // Dynamic arrays for multiple thermostats
   std::vector<int> heat_thermostat;  // Thermostat types (0=NHC, 1=Langevin)

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -260,6 +260,8 @@ void Run::perform_a_run()
     integrate.current_step = step;
     integrate.compute1(time_step, double(step) / number_of_steps, group, box, atom, thermo);
 
+    measure.post_integrate1(step, time_step, integrate, group, atom, box, force);
+
     force.temperature += force.delta_T;
 
     if (integrate.type >= 31) { // PIMD
@@ -290,6 +292,7 @@ void Run::perform_a_run()
     }
 
     atom.update_unwrapped_position(box);
+    measure.post_force(step, time_step, integrate, group, atom, box, force);
     electron_stop.compute(time_step, atom);
     add_force.compute(step, group, atom);
     add_spring.compute(step, group, atom);
@@ -299,6 +302,7 @@ void Run::perform_a_run()
     measure.process_dynamics(step + 1, box, atom);
 
     integrate.compute2(time_step, double(step) / number_of_steps, group, box, atom, thermo, force);
+    measure.post_integrate2(step, time_step, integrate, group, atom, box, force);
     atom.update_unwrapped_position(box);
 
     mc.compute(step, number_of_steps, atom, box, group);

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -34,6 +34,7 @@ Run simulation according to the inputs in the run.in file.
 #include "measure/compute_dpdt.cuh"
 #include "measure/compute_es.cuh"
 #include "measure/dos.cuh"
+#include "measure/deform.cuh"
 #include "measure/dump_beads.cuh"
 #include "measure/dump_dipole.cuh"
 #include "measure/dump_netcdf.cuh"
@@ -545,7 +546,13 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
     property.reset(new MODAL_ANALYSIS(param, num_param, number_of_types, 1, force));
     measure.properties.emplace_back(std::move(property));
   } else if (strcmp(param[0], "deform") == 0) {
-    integrate.parse_deform(param, num_param);
+    Deform* deform = new Deform(param, num_param);
+    integrate.deform_x = deform->get_deform_x();
+    integrate.deform_y = deform->get_deform_y();
+    integrate.deform_z = deform->get_deform_z();
+    std::unique_ptr<Property> property;
+    property.reset(deform);
+    measure.properties.emplace_back(std::move(property));
   } else if (strcmp(param[0], "compute_chunk") == 0) {
     std::unique_ptr<Property> property;
     property.reset(new ComputeChunk(param, num_param, box));

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -550,6 +550,9 @@ void Run::parse_one_keyword(std::vector<std::string>& tokens)
     integrate.deform_x = deform->get_deform_x();
     integrate.deform_y = deform->get_deform_y();
     integrate.deform_z = deform->get_deform_z();
+    integrate.deform_xy = deform->get_deform_xy();
+    integrate.deform_xz = deform->get_deform_xz();
+    integrate.deform_yz = deform->get_deform_yz();
     std::unique_ptr<Property> property;
     property.reset(deform);
     measure.properties.emplace_back(std::move(property));

--- a/src/makefile
+++ b/src/makefile
@@ -26,7 +26,7 @@ WARN_FLAGS += -Wformat -Wformat-security -Wformat-overflow -Wformat-truncation
 ifdef OS # For Windows with the cl.exe compiler
 CFLAGS = -O3 $(CUDA_ARCH)
 else # For linux
-CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)"
+CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)" -DDEBUG	
 endif
 INC = -I./
 LDFLAGS = 

--- a/src/measure/deform.cu
+++ b/src/measure/deform.cu
@@ -1,0 +1,204 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*----------------------------------------------------------------------------80
+Deform the simulation box during a run.
+------------------------------------------------------------------------------*/
+
+#include "deform.cuh"
+#include "integrate/integrate.cuh"
+#include "utilities/common.cuh"
+#include "utilities/gpu_macro.cuh"
+#include "utilities/read_file.cuh"
+
+static __global__ void gpu_deform_orthogonal(
+  const int number_of_atoms,
+  const double scale_factor_x,
+  const double scale_factor_y,
+  const double scale_factor_z,
+  double* x,
+  double* y,
+  double* z)
+{
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < number_of_atoms) {
+    x[i] *= scale_factor_x;
+    y[i] *= scale_factor_y;
+    z[i] *= scale_factor_z;
+  }
+}
+
+Deform::Deform(const char** param, int num_param)
+{
+  parse(param, num_param);
+  property_name = "deform";
+}
+
+void Deform::parse(const char** param, int num_param)
+{
+  printf("Deform the box.\n");
+
+  if (num_param != 5 && num_param != 7) {
+    PRINT_INPUT_ERROR("Keyword 'deform' should have 4 or 6 parameters.");
+  }
+
+  if (!is_valid_real(param[1], &deform_rate_[0])) {
+    PRINT_INPUT_ERROR("Defrom rate should be a number.");
+  }
+
+  int offset = 0;
+  if (num_param == 5) {
+    deform_rate_[1] = deform_rate_[0];
+    deform_rate_[2] = deform_rate_[0];
+    printf("    strain rate is %g A / step.\n", deform_rate_[0]);
+  } else {
+    offset = 2;
+    if (!is_valid_real(param[2], &deform_rate_[1])) {
+      PRINT_INPUT_ERROR("Defrom rate should be a number.");
+    }
+    if (!is_valid_real(param[3], &deform_rate_[2])) {
+      PRINT_INPUT_ERROR("Defrom rate should be a number.");
+    }
+    printf(
+      "    strain rates are (%g, %g, %g) A / step.\n",
+      deform_rate_[0],
+      deform_rate_[1],
+      deform_rate_[2]);
+  }
+
+  if (!is_valid_int(param[2 + offset], &deform_x_)) {
+    PRINT_INPUT_ERROR("deform_x should be integer.\n");
+  }
+  if (!is_valid_int(param[3 + offset], &deform_y_)) {
+    PRINT_INPUT_ERROR("deform_y should be integer.\n");
+  }
+  if (!is_valid_int(param[4 + offset], &deform_z_)) {
+    PRINT_INPUT_ERROR("deform_z should be integer.\n");
+  }
+
+  if (deform_x_) {
+    printf("    apply strain in x direction.\n");
+  }
+  if (deform_y_) {
+    printf("    apply strain in y direction.\n");
+  }
+  if (deform_z_) {
+    printf("    apply strain in z direction.\n");
+  }
+}
+
+int Deform::get_deform_x() const
+{
+  return deform_x_;
+}
+
+int Deform::get_deform_y() const
+{
+  return deform_y_;
+}
+
+int Deform::get_deform_z() const
+{
+  return deform_z_;
+}
+
+void Deform::preprocess(
+  const int number_of_steps,
+  const double time_step,
+  Integrate& integrate,
+  std::vector<Group>& group,
+  Atom& atom,
+  Box& box,
+  Force& force)
+{
+  box.set_is_orthogonal();
+  if (!box.is_orthogonal) {
+    PRINT_INPUT_ERROR("The current deform implementation only supports orthogonal boxes.");
+  }
+
+  if (!(integrate.type >= 0 && integrate.type <= 6) && integrate.type != 11 && integrate.type != 12) {
+    PRINT_INPUT_ERROR(
+      "The current deform implementation only supports NVE, standard NVT, NPT-Berendsen, and NPT-SCR ensembles.");
+  }
+
+  if ((integrate.type == 11 || integrate.type == 12) && integrate.num_target_pressure_components != 3) {
+    PRINT_INPUT_ERROR(
+      "The current deform implementation can only be combined with orthogonal NPT pressure control.");
+  }
+}
+
+void Deform::post_integrate1(
+  const int step,
+  const double time_step,
+  Integrate& integrate,
+  std::vector<Group>& group,
+  Atom& atom,
+  Box& box,
+  Force& force)
+{
+  double scale_factor[3] = {1.0, 1.0, 1.0};
+
+  if (deform_x_) {
+    scale_factor[0] = (box.cpu_h[0] + deform_rate_[0]) / box.cpu_h[0];
+    box.cpu_h[0] *= scale_factor[0];
+  }
+  if (deform_y_) {
+    scale_factor[1] = (box.cpu_h[4] + deform_rate_[1]) / box.cpu_h[4];
+    box.cpu_h[4] *= scale_factor[1];
+  }
+  if (deform_z_) {
+    scale_factor[2] = (box.cpu_h[8] + deform_rate_[2]) / box.cpu_h[8];
+    box.cpu_h[8] *= scale_factor[2];
+  }
+
+  box.get_inverse();
+
+  const int number_of_atoms = atom.number_of_atoms;
+  gpu_deform_orthogonal<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
+    number_of_atoms,
+    scale_factor[0],
+    scale_factor[1],
+    scale_factor[2],
+    atom.position_per_atom.data(),
+    atom.position_per_atom.data() + number_of_atoms,
+    atom.position_per_atom.data() + number_of_atoms * 2);
+  GPU_CHECK_KERNEL
+}
+
+void Deform::process(
+  const int number_of_steps,
+  int step,
+  const int fixed_group,
+  const int move_group,
+  const double global_time,
+  const double temperature,
+  Integrate& integrate,
+  Box& box,
+  std::vector<Group>& group,
+  GPU_Vector<double>& thermo,
+  Atom& atom,
+  Force& force)
+{
+}
+
+void Deform::postprocess(
+  Atom& atom,
+  Box& box,
+  Integrate& integrate,
+  const int number_of_steps,
+  const double time_step,
+  const double temperature)
+{
+}

--- a/src/measure/deform.cu
+++ b/src/measure/deform.cu
@@ -23,20 +23,29 @@ Deform the simulation box during a run.
 #include "utilities/gpu_macro.cuh"
 #include "utilities/read_file.cuh"
 
-static __global__ void gpu_deform_orthogonal(
-  const int number_of_atoms,
-  const double scale_factor_x,
-  const double scale_factor_y,
-  const double scale_factor_z,
-  double* x,
-  double* y,
-  double* z)
+static __global__ void gpu_deform_atom(
+  int N,
+  double mu0,
+  double mu1,
+  double mu2,
+  double mu3,
+  double mu4,
+  double mu5,
+  double mu6,
+  double mu7,
+  double mu8,
+  double* g_x,
+  double* g_y,
+  double* g_z)
 {
-  const int i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i < number_of_atoms) {
-    x[i] *= scale_factor_x;
-    y[i] *= scale_factor_y;
-    z[i] *= scale_factor_z;
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < N) {
+    double x_old = g_x[i];
+    double y_old = g_y[i];
+    double z_old = g_z[i];
+    g_x[i] = mu0 * x_old + mu1 * y_old + mu2 * z_old;
+    g_y[i] = mu3 * x_old + mu4 * y_old + mu5 * z_old;
+    g_z[i] = mu6 * x_old + mu7 * y_old + mu8 * z_old;
   }
 }
 
@@ -55,7 +64,7 @@ void Deform::parse(const char** param, int num_param)
   }
 
   if (!is_valid_real(param[1], &deform_rate_[0])) {
-    PRINT_INPUT_ERROR("Defrom rate should be a number.");
+    PRINT_INPUT_ERROR("Deform rate should be a number.");
   }
 
   int offset = 0;
@@ -66,10 +75,10 @@ void Deform::parse(const char** param, int num_param)
   } else {
     offset = 2;
     if (!is_valid_real(param[2], &deform_rate_[1])) {
-      PRINT_INPUT_ERROR("Defrom rate should be a number.");
+      PRINT_INPUT_ERROR("Deform rate should be a number.");
     }
     if (!is_valid_real(param[3], &deform_rate_[2])) {
-      PRINT_INPUT_ERROR("Defrom rate should be a number.");
+      PRINT_INPUT_ERROR("Deform rate should be a number.");
     }
     printf(
       "    strain rates are (%g, %g, %g) A / step.\n",
@@ -128,7 +137,9 @@ void Deform::preprocess(
     PRINT_INPUT_ERROR("The current deform implementation only supports orthogonal boxes.");
   }
 
-  if (!(integrate.type >= 0 && integrate.type <= 6) && integrate.type != 11 && integrate.type != 12) {
+  if (
+    !(integrate.type >= 0 && integrate.type <= 6) && integrate.type != 11 &&
+    integrate.type != 12) {
     PRINT_INPUT_ERROR(
       "The current deform implementation only supports NVE, standard NVT, NPT-Berendsen, and NPT-SCR ensembles.");
   }
@@ -148,29 +159,49 @@ void Deform::post_integrate1(
   Box& box,
   Force& force)
 {
-  double scale_factor[3] = {1.0, 1.0, 1.0};
+  double deformation_matrix[3][3] = {0.0};
+  deformation_matrix[0][0] = 1.0;
+  deformation_matrix[1][1] = 1.0;
+  deformation_matrix[2][2] = 1.0;
 
   if (deform_x_) {
-    scale_factor[0] = (box.cpu_h[0] + deform_rate_[0]) / box.cpu_h[0];
-    box.cpu_h[0] *= scale_factor[0];
+    deformation_matrix[0][0] = (box.cpu_h[0] + deform_rate_[0]) / box.cpu_h[0];
   }
   if (deform_y_) {
-    scale_factor[1] = (box.cpu_h[4] + deform_rate_[1]) / box.cpu_h[4];
-    box.cpu_h[4] *= scale_factor[1];
+    deformation_matrix[1][1] = (box.cpu_h[4] + deform_rate_[1]) / box.cpu_h[4];
   }
   if (deform_z_) {
-    scale_factor[2] = (box.cpu_h[8] + deform_rate_[2]) / box.cpu_h[8];
-    box.cpu_h[8] *= scale_factor[2];
+    deformation_matrix[2][2] = (box.cpu_h[8] + deform_rate_[2]) / box.cpu_h[8];
   }
 
+  double h_old[9];
+  for (int i = 0; i < 9; ++i) {
+    h_old[i] = box.cpu_h[i];
+  }
+
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      double tmp = 0.0;
+      for (int k = 0; k < 3; ++k) {
+        tmp += deformation_matrix[r][k] * h_old[k * 3 + c];
+      }
+      box.cpu_h[r * 3 + c] = tmp;
+    }
+  }
   box.get_inverse();
 
   const int number_of_atoms = atom.number_of_atoms;
-  gpu_deform_orthogonal<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
+  gpu_deform_atom<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
     number_of_atoms,
-    scale_factor[0],
-    scale_factor[1],
-    scale_factor[2],
+    deformation_matrix[0][0],
+    deformation_matrix[0][1],
+    deformation_matrix[0][2],
+    deformation_matrix[1][0],
+    deformation_matrix[1][1],
+    deformation_matrix[1][2],
+    deformation_matrix[2][0],
+    deformation_matrix[2][1],
+    deformation_matrix[2][2],
     atom.position_per_atom.data(),
     atom.position_per_atom.data() + number_of_atoms,
     atom.position_per_atom.data() + number_of_atoms * 2);

--- a/src/measure/deform.cu
+++ b/src/measure/deform.cu
@@ -22,6 +22,7 @@ Deform the simulation box during a run.
 #include "utilities/common.cuh"
 #include "utilities/gpu_macro.cuh"
 #include "utilities/read_file.cuh"
+#include <cstring>
 
 static __global__ void gpu_deform_atom(
   int N,
@@ -59,6 +60,17 @@ void Deform::parse(const char** param, int num_param)
 {
   printf("Deform the box.\n");
 
+  double value;
+  if (num_param > 1 && is_valid_real(param[1], &value)) {
+    use_legacy_format_ = true;
+    parse_legacy(param, num_param);
+  } else {
+    parse_general(param, num_param);
+  }
+}
+
+void Deform::parse_legacy(const char** param, int num_param)
+{
   if (num_param != 5 && num_param != 7) {
     PRINT_INPUT_ERROR("Keyword 'deform' should have 4 or 6 parameters.");
   }
@@ -87,40 +99,74 @@ void Deform::parse(const char** param, int num_param)
       deform_rate_[2]);
   }
 
-  if (!is_valid_int(param[2 + offset], &deform_x_)) {
+  if (!is_valid_int(param[2 + offset], &deform_component_[0])) {
     PRINT_INPUT_ERROR("deform_x should be integer.\n");
   }
-  if (!is_valid_int(param[3 + offset], &deform_y_)) {
+  if (!is_valid_int(param[3 + offset], &deform_component_[1])) {
     PRINT_INPUT_ERROR("deform_y should be integer.\n");
   }
-  if (!is_valid_int(param[4 + offset], &deform_z_)) {
+  if (!is_valid_int(param[4 + offset], &deform_component_[2])) {
     PRINT_INPUT_ERROR("deform_z should be integer.\n");
   }
 
-  if (deform_x_) {
+  if (deform_component_[0]) {
     printf("    apply strain in x direction.\n");
   }
-  if (deform_y_) {
+  if (deform_component_[1]) {
     printf("    apply strain in y direction.\n");
   }
-  if (deform_z_) {
+  if (deform_component_[2]) {
     printf("    apply strain in z direction.\n");
+  }
+}
+
+void Deform::parse_general(const char** param, int num_param)
+{
+  if (num_param < 3 || num_param > 13 || num_param % 2 == 0) {
+    PRINT_INPUT_ERROR(
+      "The general form of keyword 'deform' should contain component-rate pairs.");
+  }
+
+  const char* component_name[6] = {"xx", "yy", "zz", "xy", "xz", "yz"};
+
+  for (int n = 1; n < num_param; n += 2) {
+    int component = -1;
+    for (int d = 0; d < 6; ++d) {
+      if (strcmp(param[n], component_name[d]) == 0) {
+        component = d;
+        break;
+      }
+    }
+
+    if (component < 0) {
+      PRINT_INPUT_ERROR("Deform component should be xx, yy, zz, xy, xz, or yz.");
+    }
+    if (deform_component_[component]) {
+      PRINT_INPUT_ERROR("The same deform component cannot be specified more than once.");
+    }
+    if (!is_valid_real(param[n + 1], &deform_rate_[component])) {
+      PRINT_INPUT_ERROR("Deform rate should be a number.");
+    }
+
+    deform_component_[component] = 1;
+    printf(
+      "    deform %s at %g A / step.\n", component_name[component], deform_rate_[component]);
   }
 }
 
 int Deform::get_deform_x() const
 {
-  return deform_x_;
+  return deform_component_[0];
 }
 
 int Deform::get_deform_y() const
 {
-  return deform_y_;
+  return deform_component_[1];
 }
 
 int Deform::get_deform_z() const
 {
-  return deform_z_;
+  return deform_component_[2];
 }
 
 void Deform::preprocess(
@@ -133,9 +179,6 @@ void Deform::preprocess(
   Force& force)
 {
   box.set_is_orthogonal();
-  if (!box.is_orthogonal) {
-    PRINT_INPUT_ERROR("The current deform implementation only supports orthogonal boxes.");
-  }
 
   if (
     !(integrate.type >= 0 && integrate.type <= 6) && integrate.type != 11 &&
@@ -144,9 +187,40 @@ void Deform::preprocess(
       "The current deform implementation only supports NVE, standard NVT, NPT-Berendsen, and NPT-SCR ensembles.");
   }
 
-  if ((integrate.type == 11 || integrate.type == 12) && integrate.num_target_pressure_components != 3) {
-    PRINT_INPUT_ERROR(
-      "The current deform implementation can only be combined with orthogonal NPT pressure control.");
+  if (deform_component_[0] && box.pbc_x != 1) {
+    PRINT_INPUT_ERROR("The x direction must be periodic for xx deformation.");
+  }
+  if (deform_component_[1] && box.pbc_y != 1) {
+    PRINT_INPUT_ERROR("The y direction must be periodic for yy deformation.");
+  }
+  if (deform_component_[2] && box.pbc_z != 1) {
+    PRINT_INPUT_ERROR("The z direction must be periodic for zz deformation.");
+  }
+  if (deform_component_[3] && (box.pbc_x != 1 || box.pbc_y != 1)) {
+    PRINT_INPUT_ERROR("The x and y directions must be periodic for xy deformation.");
+  }
+  if (deform_component_[4] && (box.pbc_x != 1 || box.pbc_z != 1)) {
+    PRINT_INPUT_ERROR("The x and z directions must be periodic for xz deformation.");
+  }
+  if (deform_component_[5] && (box.pbc_y != 1 || box.pbc_z != 1)) {
+    PRINT_INPUT_ERROR("The y and z directions must be periodic for yz deformation.");
+  }
+
+  if (use_legacy_format_ && !box.is_orthogonal) {
+    PRINT_INPUT_ERROR("The legacy deform format only supports orthogonal boxes.");
+  }
+
+  if (integrate.type == 11 || integrate.type == 12) {
+    if (deform_component_[3] || deform_component_[4] || deform_component_[5]) {
+      PRINT_INPUT_ERROR("Shear deformation cannot currently be combined with NPT ensembles.");
+    }
+    if (!box.is_orthogonal) {
+      PRINT_INPUT_ERROR("Deformation with NPT currently requires an orthogonal box.");
+    }
+    if (integrate.num_target_pressure_components != 3) {
+      PRINT_INPUT_ERROR(
+        "The current deform implementation can only be combined with orthogonal NPT pressure control.");
+    }
   }
 }
 
@@ -159,36 +233,89 @@ void Deform::post_integrate1(
   Box& box,
   Force& force)
 {
-  double deformation_matrix[3][3] = {0.0};
-  deformation_matrix[0][0] = 1.0;
-  deformation_matrix[1][1] = 1.0;
-  deformation_matrix[2][2] = 1.0;
+  const bool has_shear = deform_component_[3] || deform_component_[4] || deform_component_[5];
 
-  if (deform_x_) {
-    deformation_matrix[0][0] = (box.cpu_h[0] + deform_rate_[0]) / box.cpu_h[0];
-  }
-  if (deform_y_) {
-    deformation_matrix[1][1] = (box.cpu_h[4] + deform_rate_[1]) / box.cpu_h[4];
-  }
-  if (deform_z_) {
-    deformation_matrix[2][2] = (box.cpu_h[8] + deform_rate_[2]) / box.cpu_h[8];
-  }
+  if (box.is_orthogonal && !has_shear) {
+    double deformation_matrix[3][3] = {0.0};
+    deformation_matrix[0][0] = 1.0;
+    deformation_matrix[1][1] = 1.0;
+    deformation_matrix[2][2] = 1.0;
 
-  double h_old[9];
-  for (int i = 0; i < 9; ++i) {
-    h_old[i] = box.cpu_h[i];
-  }
+    if (deform_component_[0]) {
+      deformation_matrix[0][0] = (box.cpu_h[0] + deform_rate_[0]) / box.cpu_h[0];
+    }
+    if (deform_component_[1]) {
+      deformation_matrix[1][1] = (box.cpu_h[4] + deform_rate_[1]) / box.cpu_h[4];
+    }
+    if (deform_component_[2]) {
+      deformation_matrix[2][2] = (box.cpu_h[8] + deform_rate_[2]) / box.cpu_h[8];
+    }
 
-  for (int r = 0; r < 3; ++r) {
-    for (int c = 0; c < 3; ++c) {
-      double tmp = 0.0;
-      for (int k = 0; k < 3; ++k) {
-        tmp += deformation_matrix[r][k] * h_old[k * 3 + c];
+    double h_old[9];
+    for (int i = 0; i < 9; ++i) {
+      h_old[i] = box.cpu_h[i];
+    }
+
+    for (int r = 0; r < 3; ++r) {
+      for (int c = 0; c < 3; ++c) {
+        double tmp = 0.0;
+        for (int k = 0; k < 3; ++k) {
+          tmp += deformation_matrix[r][k] * h_old[k * 3 + c];
+        }
+        box.cpu_h[r * 3 + c] = tmp;
       }
-      box.cpu_h[r * 3 + c] = tmp;
+    }
+    box.get_inverse();
+
+    const int number_of_atoms = atom.number_of_atoms;
+    gpu_deform_atom<<<(number_of_atoms - 1) / 128 + 1, 128>>>(
+      number_of_atoms,
+      deformation_matrix[0][0],
+      deformation_matrix[0][1],
+      deformation_matrix[0][2],
+      deformation_matrix[1][0],
+      deformation_matrix[1][1],
+      deformation_matrix[1][2],
+      deformation_matrix[2][0],
+      deformation_matrix[2][1],
+      deformation_matrix[2][2],
+      atom.position_per_atom.data(),
+      atom.position_per_atom.data() + number_of_atoms,
+      atom.position_per_atom.data() + number_of_atoms * 2);
+    GPU_CHECK_KERNEL
+    return;
+  }
+
+  box.get_inverse();
+
+  double h_old_inverse[9];
+  double h_new[9];
+  for (int i = 0; i < 9; ++i) {
+    h_old_inverse[i] = box.cpu_h[i + 9];
+    h_new[i] = box.cpu_h[i];
+  }
+
+  const int h_index[6] = {0, 4, 8, 1, 2, 5};
+  for (int d = 0; d < 6; ++d) {
+    if (deform_component_[d]) {
+      h_new[h_index[d]] += deform_rate_[d];
     }
   }
+
+  double deformation_matrix[3][3] = {0.0};
+  for (int r = 0; r < 3; ++r) {
+    for (int c = 0; c < 3; ++c) {
+      for (int k = 0; k < 3; ++k) {
+        deformation_matrix[r][c] += h_new[r * 3 + k] * h_old_inverse[k * 3 + c];
+      }
+    }
+  }
+
+  for (int i = 0; i < 9; ++i) {
+    box.cpu_h[i] = h_new[i];
+  }
   box.get_inverse();
+  box.set_is_orthogonal();
 
   const int number_of_atoms = atom.number_of_atoms;
   gpu_deform_atom<<<(number_of_atoms - 1) / 128 + 1, 128>>>(

--- a/src/measure/deform.cu
+++ b/src/measure/deform.cu
@@ -169,6 +169,21 @@ int Deform::get_deform_z() const
   return deform_component_[2];
 }
 
+int Deform::get_deform_xy() const
+{
+  return deform_component_[3];
+}
+
+int Deform::get_deform_xz() const
+{
+  return deform_component_[4];
+}
+
+int Deform::get_deform_yz() const
+{
+  return deform_component_[5];
+}
+
 void Deform::preprocess(
   const int number_of_steps,
   const double time_step,
@@ -211,15 +226,19 @@ void Deform::preprocess(
   }
 
   if (integrate.type == 11 || integrate.type == 12) {
-    if (deform_component_[3] || deform_component_[4] || deform_component_[5]) {
-      PRINT_INPUT_ERROR("Shear deformation cannot currently be combined with NPT ensembles.");
+    if (integrate.num_target_pressure_components == 1) {
+      PRINT_INPUT_ERROR("Deformation cannot be combined with isotropic NPT pressure control.");
     }
-    if (!box.is_orthogonal) {
-      PRINT_INPUT_ERROR("Deformation with NPT currently requires an orthogonal box.");
-    }
-    if (integrate.num_target_pressure_components != 3) {
+    if (integrate.num_target_pressure_components == 3) {
+      if (deform_component_[3] || deform_component_[4] || deform_component_[5]) {
+        PRINT_INPUT_ERROR("Shear deformation with NPT requires 6 target pressure components.");
+      }
+      if (!box.is_orthogonal) {
+        PRINT_INPUT_ERROR("Deformation with 3-component NPT requires an orthogonal box.");
+      }
+    } else if (integrate.num_target_pressure_components == 6 && use_legacy_format_) {
       PRINT_INPUT_ERROR(
-        "The current deform implementation can only be combined with orthogonal NPT pressure control.");
+        "The legacy deform format cannot be combined with 6-component NPT pressure control.");
     }
   }
 }
@@ -233,6 +252,7 @@ void Deform::post_integrate1(
   Box& box,
   Force& force)
 {
+  box.set_is_orthogonal();
   const bool has_shear = deform_component_[3] || deform_component_[4] || deform_component_[5];
 
   if (box.is_orthogonal && !has_shear) {

--- a/src/measure/deform.cuh
+++ b/src/measure/deform.cuh
@@ -67,9 +67,10 @@ public:
 
 private:
   void parse(const char** param, int num_param);
+  void parse_legacy(const char** param, int num_param);
+  void parse_general(const char** param, int num_param);
 
-  int deform_x_ = 0;
-  int deform_y_ = 0;
-  int deform_z_ = 0;
-  double deform_rate_[3] = {0.0, 0.0, 0.0};
+  bool use_legacy_format_ = false;
+  int deform_component_[6] = {0, 0, 0, 0, 0, 0};
+  double deform_rate_[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 };

--- a/src/measure/deform.cuh
+++ b/src/measure/deform.cuh
@@ -24,6 +24,9 @@ public:
   int get_deform_x() const;
   int get_deform_y() const;
   int get_deform_z() const;
+  int get_deform_xy() const;
+  int get_deform_xz() const;
+  int get_deform_yz() const;
 
   virtual void preprocess(
     const int number_of_steps,

--- a/src/measure/deform.cuh
+++ b/src/measure/deform.cuh
@@ -32,7 +32,7 @@ public:
     std::vector<Group>& group,
     Atom& atom,
     Box& box,
-    Force& force);
+    Force& force) override;
 
   virtual void process(
     const int number_of_steps,
@@ -46,7 +46,7 @@ public:
     std::vector<Group>& group,
     GPU_Vector<double>& thermo,
     Atom& atom,
-    Force& force);
+    Force& force) override;
 
   virtual void post_integrate1(
     const int step,
@@ -55,7 +55,7 @@ public:
     std::vector<Group>& group,
     Atom& atom,
     Box& box,
-    Force& force);
+    Force& force) override;
 
   virtual void postprocess(
     Atom& atom,
@@ -63,7 +63,7 @@ public:
     Integrate& integrate,
     const int number_of_steps,
     const double time_step,
-    const double temperature);
+    const double temperature) override;
 
 private:
   void parse(const char** param, int num_param);

--- a/src/measure/deform.cuh
+++ b/src/measure/deform.cuh
@@ -1,0 +1,75 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    GPUMD is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with GPUMD.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "property.cuh"
+
+class Deform : public Property
+{
+public:
+  Deform(const char** param, int num_param);
+
+  int get_deform_x() const;
+  int get_deform_y() const;
+  int get_deform_z() const;
+
+  virtual void preprocess(
+    const int number_of_steps,
+    const double time_step,
+    Integrate& integrate,
+    std::vector<Group>& group,
+    Atom& atom,
+    Box& box,
+    Force& force);
+
+  virtual void process(
+    const int number_of_steps,
+    int step,
+    const int fixed_group,
+    const int move_group,
+    const double global_time,
+    const double temperature,
+    Integrate& integrate,
+    Box& box,
+    std::vector<Group>& group,
+    GPU_Vector<double>& thermo,
+    Atom& atom,
+    Force& force);
+
+  virtual void post_integrate1(
+    const int step,
+    const double time_step,
+    Integrate& integrate,
+    std::vector<Group>& group,
+    Atom& atom,
+    Box& box,
+    Force& force);
+
+  virtual void postprocess(
+    Atom& atom,
+    Box& box,
+    Integrate& integrate,
+    const int number_of_steps,
+    const double time_step,
+    const double temperature);
+
+private:
+  void parse(const char** param, int num_param);
+
+  int deform_x_ = 0;
+  int deform_y_ = 0;
+  int deform_z_ = 0;
+  double deform_rate_[3] = {0.0, 0.0, 0.0};
+};

--- a/src/measure/measure.cu
+++ b/src/measure/measure.cu
@@ -128,3 +128,45 @@ void Measure::process_dynamics(
     prop->process_dynamics(md_step, box, atom);
   }
 }
+
+void Measure::post_integrate1(
+  const int step,
+  const double time_step,
+  Integrate& integrate,
+  std::vector<Group>& group,
+  Atom& atom,
+  Box& box,
+  Force& force)
+{
+  for (auto& prop : properties) {
+    prop->post_integrate1(step, time_step, integrate, group, atom, box, force);
+  }
+}
+
+void Measure::post_force(
+  const int step,
+  const double time_step,
+  Integrate& integrate,
+  std::vector<Group>& group,
+  Atom& atom,
+  Box& box,
+  Force& force)
+{
+  for (auto& prop : properties) {
+    prop->post_force(step, time_step, integrate, group, atom, box, force);
+  }
+}
+
+void Measure::post_integrate2(
+  const int step,
+  const double time_step,
+  Integrate& integrate,
+  std::vector<Group>& group,
+  Atom& atom,
+  Box& box,
+  Force& force)
+{
+  for (auto& prop : properties) {
+    prop->post_integrate2(step, time_step, integrate, group, atom, box, force);
+  }
+}

--- a/src/measure/measure.cuh
+++ b/src/measure/measure.cuh
@@ -64,5 +64,32 @@ public:
     Box& box,
     Atom& atom);
 
+  void post_integrate1(
+    const int step,
+    const double time_step,
+    Integrate& integrate,
+    std::vector<Group>& group,
+    Atom& atom,
+    Box& box,
+    Force& force);
+
+  void post_force(
+    const int step,
+    const double time_step,
+    Integrate& integrate,
+    std::vector<Group>& group,
+    Atom& atom,
+    Box& box,
+    Force& force);
+
+  void post_integrate2(
+    const int step,
+    const double time_step,
+    Integrate& integrate,
+    std::vector<Group>& group,
+    Atom& atom,
+    Box& box,
+    Force& force);
+
   std::vector<std::unique_ptr<Property>> properties;
 };

--- a/src/measure/property.cuh
+++ b/src/measure/property.cuh
@@ -64,6 +64,39 @@ public:
   {
   }
 
+  virtual void post_integrate1(
+    const int step,
+    const double time_step,
+    Integrate& integrate,
+    std::vector<Group>& group,
+    Atom& atom,
+    Box& box,
+    Force& force)
+  {
+  }
+
+  virtual void post_force(
+    const int step,
+    const double time_step,
+    Integrate& integrate,
+    std::vector<Group>& group,
+    Atom& atom,
+    Box& box,
+    Force& force)
+  {
+  }
+
+  virtual void post_integrate2(
+    const int step,
+    const double time_step,
+    Integrate& integrate,
+    std::vector<Group>& group,
+    Atom& atom,
+    Box& box,
+    Force& force)
+  {
+  }
+
   virtual void postprocess(
     Atom& atom,
     Box& box,


### PR DESCRIPTION
# **Summary** 

This PR makes deform an independent action instead of an operation embedded in NPT-Berendsen/NPT-SCR, and extends it to general triclinic box deformation.

# **Usage**

## Grammar

Old syntax remains supported:

```
deform 0.0001 1 0 0
```

```
deform 0.0001 0.0002 0.0003 1 1 1
```

New general syntax:

```
deform xx 0.0001
```

```
deform xy 0.0001
```

```
deform xx 0.0001 yy -0.00005 xy 0.0002
```

All rates are box-matrix increments in A/step, consistent with the existing `deform` convention.

For the general syntax, `xy`, `xz`, and `yz` refer to the corresponding GPUMD box-matrix components. They are geometric box/tilt components, not symmetric Voigt shear-strain components.


## NPT compatibility

- NVE + deform: supported.
- Standard NVT + deform: supported.
- 3-component NPT + diagonal `xx/yy/zz` deform: supported for orthogonal boxes.
- 3-component NPT + shear deform: rejected; use 6 target pressure components.
- 6-component NPT + general deform: supported.
- Isotropic NPT + deform: rejected.
- Legacy deform syntax + 6-component NPT: rejected; the general syntax should be used instead.

## Scope / known limitation

* This PR does not implement automatic lattice reduction / box flipping for very large cumulative shear. The current implementation is intended for finite deformations where the triclinic cell does not become excessively skewed. This can be added later if a practical need arises.
* Deform + NPT-MTTK is not supported. Use Berendsen/SCR instead.


# **Validation** (Describe how this pull request was tested)

Existing features not using deform are unchanged. The legacy `deform` syntax remains supported with the same prescribed deformation behavior.

# **Licensing** (Please read and confirm before submitting this pull request)

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.
