### PR TITLE
simplify interface

### DIFF
--- a/src/measure/deform.cu
+++ b/src/measure/deform.cu
@@ -354,29 +354,3 @@ void Deform::post_integrate1(
     atom.position_per_atom.data() + number_of_atoms * 2);
   GPU_CHECK_KERNEL
 }
-
-void Deform::process(
-  const int number_of_steps,
-  int step,
-  const int fixed_group,
-  const int move_group,
-  const double global_time,
-  const double temperature,
-  Integrate& integrate,
-  Box& box,
-  std::vector<Group>& group,
-  GPU_Vector<double>& thermo,
-  Atom& atom,
-  Force& force)
-{
-}
-
-void Deform::postprocess(
-  Atom& atom,
-  Box& box,
-  Integrate& integrate,
-  const int number_of_steps,
-  const double time_step,
-  const double temperature)
-{
-}

--- a/src/measure/deform.cuh
+++ b/src/measure/deform.cuh
@@ -37,20 +37,6 @@ public:
     Box& box,
     Force& force) override;
 
-  virtual void process(
-    const int number_of_steps,
-    int step,
-    const int fixed_group,
-    const int move_group,
-    const double global_time,
-    const double temperature,
-    Integrate& integrate,
-    Box& box,
-    std::vector<Group>& group,
-    GPU_Vector<double>& thermo,
-    Atom& atom,
-    Force& force) override;
-
   virtual void post_integrate1(
     const int step,
     const double time_step,
@@ -59,14 +45,6 @@ public:
     Atom& atom,
     Box& box,
     Force& force) override;
-
-  virtual void postprocess(
-    Atom& atom,
-    Box& box,
-    Integrate& integrate,
-    const int number_of_steps,
-    const double time_step,
-    const double temperature) override;
 
 private:
   void parse(const char** param, int num_param);

--- a/src/measure/property.cuh
+++ b/src/measure/property.cuh
@@ -41,7 +41,9 @@ public:
     std::vector<Group>& group,
     Atom& atom,
     Box& box,
-    Force& force) = 0;
+    Force& force)
+  {
+  }
 
   virtual void process(
       const int number_of_steps,
@@ -55,7 +57,9 @@ public:
       std::vector<Group>& group,
       GPU_Vector<double>& thermo,
       Atom& atom,
-      Force& force) = 0;
+      Force& force)
+  {
+  }
 
   virtual void process_dynamics(
     const int md_step,
@@ -103,5 +107,7 @@ public:
     Integrate& integrate,
     const int number_of_steps,
     const double time_step,
-    const double temperature) = 0;
+    const double temperature)
+  {
+  }
 };


### PR DESCRIPTION
**Summary** (Briefly summarize the purpose of this pull request)

Simplify the `Property` callback interface.

**Modification** (Describe the main changes made in this pull request)

Provide default no-op implementations for optional callbacks in `Property`, so derived classes only need to override the callbacks they use.

Remove the now-unnecessary empty `process()` and `postprocess()` implementations from `Deform`.

No functional behavior is changed.

**Licensing** (Please read and confirm before submitting this pull request)

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.

**Validation** (Describe how this pull request was tested)

**Others**
