### PR TITLE
Compact multi-element NEP potentials

### DIFF
--- a/doc/gpumd/input_parameters/compute_adf.rst
+++ b/doc/gpumd/input_parameters/compute_adf.rst
@@ -32,7 +32,8 @@ The angle formed by the central atom I and neighboring atoms J and K is included
 - The type of atom K matches `ktypeN`.
 - Atoms I, J, and K are distinct.
 
-The type indices 0, 1, 2, ... refer to the active species for the current simulation. The active species follow their order in the potential file and are re-indexed from 0. GPUMD prints the active type mapping during initialization.
+When a multi-element NEP potential is compacted to the species required by the current simulation, `itypeN`, `jtypeN`, and `ktypeN` refer to the active atom types printed at initialization. For other potential models, the usual type numbering is unchanged.
+
 The :term:`ADF` value for a bin is computed by dividing the histogram count by the total number of triples that satisfy the criteria, ensuring that the integral of the :term:`ADF` with respect to the angle is 1. In other words, the :term:`ADF` is a probability density function.
 
 Example

--- a/doc/gpumd/input_parameters/compute_adf.rst
+++ b/doc/gpumd/input_parameters/compute_adf.rst
@@ -32,6 +32,7 @@ The angle formed by the central atom I and neighboring atoms J and K is included
 - The type of atom K matches `ktypeN`.
 - Atoms I, J, and K are distinct.
 
+The type indices 0, 1, 2, ... refer to the active species for the current simulation. The active species follow their order in the potential file and are re-indexed from 0. GPUMD prints the active type mapping during initialization.
 The :term:`ADF` value for a bin is computed by dividing the histogram count by the total number of triples that satisfy the criteria, ensuring that the integral of the :term:`ADF` with respect to the angle is 1. In other words, the :term:`ADF` is a probability density function.
 
 Example

--- a/doc/gpumd/input_parameters/compute_angular_rdf.rst
+++ b/doc/gpumd/input_parameters/compute_angular_rdf.rst
@@ -32,7 +32,7 @@ This means that the ARDF calculations will be performed every :attr:`interval` s
 Without the optional parameters, only the total :term:`ARDF` will be calculated.
 
 To additionally calculate the partial :term:`ARDF` for a pair of species, one can specify the types of the two species after the word "atom". 
-The types 0, 1, 2, ... correspond to the active species for the current simulation. The active species follow their order in the potential file and are re-indexed from 0. GPUMD prints the active type mapping during initialization. 
+For a compacted multi-element NEP potential, the types 0, 1, 2, ... refer to the active atom types printed at initialization, which preserve the species order in the original potential file. For other potential models, they correspond to the species in the potential file in order.
 Currently, one can specify at most 6 pairs. 
 
 Example

--- a/doc/gpumd/input_parameters/compute_angular_rdf.rst
+++ b/doc/gpumd/input_parameters/compute_angular_rdf.rst
@@ -32,7 +32,7 @@ This means that the ARDF calculations will be performed every :attr:`interval` s
 Without the optional parameters, only the total :term:`ARDF` will be calculated.
 
 To additionally calculate the partial :term:`ARDF` for a pair of species, one can specify the types of the two species after the word "atom". 
-The types 0, 1, 2, ... correspond to the species in the potential file in order. 
+The types 0, 1, 2, ... correspond to the active species for the current simulation. The active species follow their order in the potential file and are re-indexed from 0. GPUMD prints the active type mapping during initialization. 
 Currently, one can specify at most 6 pairs. 
 
 Example

--- a/doc/gpumd/input_parameters/compute_hnemdec.rst
+++ b/doc/gpumd/input_parameters/compute_hnemdec.rst
@@ -17,7 +17,7 @@ Syntax
 
 :attr:`driving_force` determines which type of driving force to use. It could be zero or non zero positive integer, which means thermal driving force or diffusive driving force.
 In the case of zero, heat flux is equivalent to dissipative flux, with driving force :math:`F_e` in the units of Å\ :sup:`-1`.
-For a non zero positive integer such as :math:`i`, a momentum flux of the :math:`ith` element in the order of the first line of nep.txt is produced as dissipative flux, with driving force :math:`F_e` in the units of eV/Å.
+For a non zero positive integer such as :math:`i`, a momentum flux of the :math:`ith` active element is produced as dissipative flux, with driving force :math:`F_e` in the units of eV/Å. The active species follow their order in the potential file. For this keyword, :math:`i` is one-based: active type 0 corresponds to :math:`i=1`, active type 1 corresponds to :math:`i=2`, and so on. GPUMD prints the active type mapping during initialization.
 
 :attr:`output_interval` is the interval to output the onsager coefficients.
 

--- a/doc/gpumd/input_parameters/compute_hnemdec.rst
+++ b/doc/gpumd/input_parameters/compute_hnemdec.rst
@@ -17,7 +17,7 @@ Syntax
 
 :attr:`driving_force` determines which type of driving force to use. It could be zero or non zero positive integer, which means thermal driving force or diffusive driving force.
 In the case of zero, heat flux is equivalent to dissipative flux, with driving force :math:`F_e` in the units of Å\ :sup:`-1`.
-For a non zero positive integer such as :math:`i`, a momentum flux of the :math:`ith` active element is produced as dissipative flux, with driving force :math:`F_e` in the units of eV/Å. The active species follow their order in the potential file. For this keyword, :math:`i` is one-based: active type 0 corresponds to :math:`i=1`, active type 1 corresponds to :math:`i=2`, and so on. GPUMD prints the active type mapping during initialization.
+For a non zero positive integer such as :math:`i`, a momentum flux of the :math:`ith` element is produced as dissipative flux, with driving force :math:`F_e` in the units of eV/Å. For a compacted multi-element NEP potential, the element order is the active atom type list printed at initialization; otherwise, it is the order in the first line of nep.txt.
 
 :attr:`output_interval` is the interval to output the onsager coefficients.
 

--- a/doc/gpumd/input_parameters/compute_ic.rst
+++ b/doc/gpumd/input_parameters/compute_ic.rst
@@ -19,7 +19,7 @@ with parameters defined as
 
 * :attr:`sample_interval`: Sampling interval of the position data
 * :attr:`Nc`: Maximum number of correlation steps
-* :attr:`type_iex`: Type index of the atom to be calculated. The indices 0, 1, 2, ... refer to the active species for the current simulation. The active species follow their order in the potential file and are re-indexed from 0. GPUMD prints the active type mapping during initialization.
+* :attr:`type_iex`: Type index of the atoms to be calculated. For a compacted multi-element NEP potential, this refers to the active atom types printed at initialization; otherwise, it refers to the type index in the potential file.
 * :attr:`charge`: Charge of the ion to compute the conductivity.
 
 
@@ -35,4 +35,4 @@ This means that you
 * want to calculate the ionic conductivity from the mean-square displacement function
 * the position data will be recorded every 5 steps
 * the maximum number of correlation steps is 200
-* you would like to compute only for the atom with active type 0 and charge 1.
+* you would like to compute only for the atom with type 0 according to the applicable type mapping and charge 1.

--- a/doc/gpumd/input_parameters/compute_ic.rst
+++ b/doc/gpumd/input_parameters/compute_ic.rst
@@ -19,7 +19,7 @@ with parameters defined as
 
 * :attr:`sample_interval`: Sampling interval of the position data
 * :attr:`Nc`: Maximum number of correlation steps
-* :attr:`type_iex`: Type index of atom to be calculated which in potential
+* :attr:`type_iex`: Type index of the atom to be calculated. The indices 0, 1, 2, ... refer to the active species for the current simulation. The active species follow their order in the potential file and are re-indexed from 0. GPUMD prints the active type mapping during initialization.
 * :attr:`charge`: Charge of the ion to compute the conductivity.
 
 
@@ -35,4 +35,4 @@ This means that you
 * want to calculate the ionic conductivity from the mean-square displacement function
 * the position data will be recorded every 5 steps
 * the maximum number of correlation steps is 200
-* you would like to compute only for the atom with type 0 in nep.txt and charge 1.
+* you would like to compute only for the atom with active type 0 and charge 1.

--- a/doc/gpumd/input_parameters/deposit.rst
+++ b/doc/gpumd/input_parameters/deposit.rst
@@ -25,11 +25,12 @@ This keyword is used in one of the following two ways::
   When :attr:`direction` is :attr:`-1`, the height value(s) are not used.
 * In the first usage, one or more triplets :attr:`<type> <num> <velocity>` are given.
   For each triplet, :attr:`num` atoms of type :attr:`type` are added at each deposition, at random lateral positions in the simulation box, with an initial velocity :attr:`velocity` along the deposition direction.
-  The atom types refer to those defined in the potential file, and the velocity is in units of Å/fs.
+  The deposited species can be specified either by its element symbol (recommended) or by its type index in the original potential file, and the velocity is in units of Å/fs.
 * In the second usage, the atoms to be added at each deposition are read from the file :attr:`add_atom_file`, which contains one atom per row with 7 columns::
 
     type x y z vx vy vz
 
+  The first column can contain either an element symbol (recommended) or the corresponding type index in the original potential file.
   The positions are in units of Ångstrom and the velocities are in units of Å/fs.
   With a non-negative :attr:`direction`, the coordinate along the deposition direction is replaced by the sampled height, and the optional :attr:`velocity` (in units of Å/fs) after the file name sets the velocity component along the deposition direction.
   With :attr:`direction` set to :attr:`-1`, no :attr:`velocity` is allowed after the file name and the file is used as it is.

--- a/doc/gpumd/input_parameters/deposit.rst
+++ b/doc/gpumd/input_parameters/deposit.rst
@@ -12,7 +12,7 @@ Syntax
 
 This keyword is used in one of the following two ways::
 
-  deposit <interval> <direction> <height_min> [height_max] atom <type_1> <num_1> <velocity_1> [<type_2> <num_2> <velocity_2> ...] # usage 1
+  deposit <interval> <direction> <height_min> [height_max] atom <element_1> <num_1> <velocity_1> [<element_2> <num_2> <velocity_2> ...] # usage 1
   deposit <interval> <direction> <height_min> [height_max] file <add_atom_file> [velocity]                                        # usage 2
 
 * :attr:`interval` is the deposition interval (number of steps) and must be a positive integer.
@@ -23,14 +23,14 @@ This keyword is used in one of the following two ways::
 * :attr:`height_min` and the optional :attr:`height_max` define the deposition height (in units of Ångstrom) along the deposition direction.
   If :attr:`height_max` is given, the height of each deposited atom is uniformly sampled between :attr:`height_min` and :attr:`height_max`; otherwise, all the atoms are deposited at :attr:`height_min`.
   When :attr:`direction` is :attr:`-1`, the height value(s) are not used.
-* In the first usage, one or more triplets :attr:`<type> <num> <velocity>` are given.
-  For each triplet, :attr:`num` atoms of type :attr:`type` are added at each deposition, at random lateral positions in the simulation box, with an initial velocity :attr:`velocity` along the deposition direction.
-  The deposited species can be specified either by its element symbol (recommended) or by its type index in the original potential file, and the velocity is in units of Å/fs.
+* In the first usage, one or more triplets :attr:`<element> <num> <velocity>` are given.
+  For each triplet, :attr:`num` atoms of element :attr:`element` are added at each deposition, at random lateral positions in the simulation box, with an initial velocity :attr:`velocity` along the deposition direction.
+  The deposited species must be specified by its element symbol, and the velocity is in units of Å/fs.
 * In the second usage, the atoms to be added at each deposition are read from the file :attr:`add_atom_file`, which contains one atom per row with 7 columns::
 
-    type x y z vx vy vz
+    element x y z vx vy vz
 
-  The first column can contain either an element symbol (recommended) or the corresponding type index in the original potential file.
+  The first column must contain the element symbol of the deposited atom.
   The positions are in units of Ångstrom and the velocities are in units of Å/fs.
   With a non-negative :attr:`direction`, the coordinate along the deposition direction is replaced by the sampled height, and the optional :attr:`velocity` (in units of Å/fs) after the file name sets the velocity component along the deposition direction.
   With :attr:`direction` set to :attr:`-1`, no :attr:`velocity` is allowed after the file name and the file is used as it is.
@@ -42,16 +42,16 @@ If the :ref:`simulation model file <model_xyz>` contains no velocity data, one e
 Example 1
 ---------
 
-Deposit 10 atoms of type 0 every 10000 steps, at a height of 30 Å in the z direction, with an initial velocity of -0.1 Å/fs (towards decreasing z)::
+Deposit 10 H atoms every 10000 steps, at a height of 30 Å in the z direction, with an initial velocity of -0.1 Å/fs (towards decreasing z)::
 
-   deposit 10000 2 30 atom 0 10 -0.1
+   deposit 10000 2 30 atom H 10 -0.1
 
 Example 2
 ---------
 
-Deposit 5 atoms of type 0 and 5 atoms of type 1 every 5000 steps, at heights uniformly sampled between 30 Å and 40 Å in the z direction::
+Deposit 5 H atoms and 5 C atoms every 5000 steps, at heights uniformly sampled between 30 Å and 40 Å in the z direction::
 
-   deposit 5000 2 30 40 atom 0 5 -0.1 1 5 -0.1
+   deposit 5000 2 30 40 atom H 5 -0.1 C 5 -0.1
 
 Example 3
 ---------

--- a/doc/gpumd/input_parameters/dump_netcdf.rst
+++ b/doc/gpumd/input_parameters/dump_netcdf.rst
@@ -150,7 +150,9 @@ Requirements and specifications
   :ref:`model.xyz <model_xyz>`.
 * The ``type`` and ``mass`` variables both carry a frame dimension, so the species and the mass
   of an atom always refer to the same frame. A trajectory sampled alongside :term:`MC` trials is
-  therefore self-consistent.
+  therefore self-consistent. For a compacted multi-element NEP potential, the ``type`` variable
+  uses the active atom type mapping printed at initialization; for other potential models, the
+  type numbering is unchanged.
 
 Examples
 --------

--- a/doc/gpumd/input_parameters/electron_stop.rst
+++ b/doc/gpumd/input_parameters/electron_stop.rst
@@ -21,9 +21,9 @@ The first line of the file should have 3 values:
 * the third is the maximum of the energy range :math:`E_{\rm max}`.
 
 The stopping power data listed after this line should have :math:`N` lines, each corresponding to one energy, which increases linearly from :math:`E_{\rm min}` to :math:`E_{\rm max}` with a spacing of :math:`(E_{\rm max} - E_{\rm min})/(N-1)`.
-For these :math:`N` lines, the number of columns is the number of species for the potential energy model used.
-That is, there should be one column with the stopping power for each species.
-The order of the species should follow that as defined in the potential file.
+For these :math:`N` lines, the number of columns is the number of active species for the current simulation.
+That is, there should be one column with the stopping power for each active species.
+The active species follow their order in the potential file and are re-indexed from 0. GPUMD prints the active type mapping during initialization.
 
 Example
 -------

--- a/doc/gpumd/input_parameters/electron_stop.rst
+++ b/doc/gpumd/input_parameters/electron_stop.rst
@@ -21,9 +21,9 @@ The first line of the file should have 3 values:
 * the third is the maximum of the energy range :math:`E_{\rm max}`.
 
 The stopping power data listed after this line should have :math:`N` lines, each corresponding to one energy, which increases linearly from :math:`E_{\rm min}` to :math:`E_{\rm max}` with a spacing of :math:`(E_{\rm max} - E_{\rm min})/(N-1)`.
-For these :math:`N` lines, the number of columns is the number of active species for the current simulation.
-That is, there should be one column with the stopping power for each active species.
-The active species follow their order in the potential file and are re-indexed from 0. GPUMD prints the active type mapping during initialization.
+For these :math:`N` lines, the number of columns is the number of species used by the potential energy model.
+For a compacted multi-element NEP potential, there should be one column with the stopping power for each active species, in the active atom type order printed at initialization.
+For other potential models, there should be one column for each species in the order defined in the potential file.
 
 Example
 -------

--- a/src/force/dftd3.cu
+++ b/src/force/dftd3.cu
@@ -32,6 +32,7 @@ J. Comput. Chem., 32, 1456 (2011).
 #include "model/box.cuh"
 #include "neighbor.cuh"
 #include "utilities/common.cuh"
+#include "utilities/compact_nep.cuh"
 #include "utilities/gpu_macro.cuh"
 #include <algorithm>
 #include <cctype>
@@ -429,7 +430,7 @@ std::string get_potential_file_name()
   }
 
   input_run.close();
-  return potential_file_name;
+  return get_compact_nep_filename(potential_file_name);
 }
 
 void find_atomic_number(std::string& potential_file_name, int* atomic_number)

--- a/src/force/nep_multigpu.cu
+++ b/src/force/nep_multigpu.cu
@@ -1754,10 +1754,14 @@ void NEP_MULTIGPU::compute(
     }
   }
 
+#ifdef ZHEYONG
+  CHECK(gpuDeviceSynchronize());
+#else
   for (int gpu = 0; gpu < paramb.num_gpus; ++gpu) {
     CHECK(gpuSetDevice(gpu));
     CHECK(gpuDeviceSynchronize());
   }
+#endif
 
   CHECK(gpuSetDevice(0));
 
@@ -2251,10 +2255,14 @@ void NEP_MULTIGPU::compute(
     }
   }
 
+#ifdef ZHEYONG
+  CHECK(gpuDeviceSynchronize());
+#else
   for (int gpu = 0; gpu < paramb.num_gpus; ++gpu) {
     CHECK(gpuSetDevice(gpu));
     CHECK(gpuDeviceSynchronize());
   }
+#endif
 
   CHECK(gpuSetDevice(0));
 

--- a/src/main_gpumd/deposition.cu
+++ b/src/main_gpumd/deposition.cu
@@ -21,6 +21,7 @@ keyword and perform deposition between consecutive sub-runs.
 #include "deposition.cuh"
 #include "model/read_xyz.cuh"
 #include "utilities/error.cuh"
+#include "utilities/compact_nep.cuh"
 #include "utilities/read_file.cuh"
 #include <algorithm>
 #include <chrono>
@@ -43,6 +44,28 @@ void Deposition::copy_file(const std::string& in_file, const std::string& out_fi
     exit(1);
   }
   out << in.rdbuf();
+}
+
+static int get_deposit_atom_type(
+  const std::string& token, const std::vector<std::string>& atom_symbols)
+{
+  int atom_type = 0;
+  if (is_valid_int(token.c_str(), &atom_type)) {
+    if (atom_type < 0 || atom_type >= static_cast<int>(atom_symbols.size())) {
+      PRINT_INPUT_ERROR("deposit atom_type is outside the range defined by the potential file.\n");
+    }
+    return atom_type;
+  }
+
+  for (int n = 0; n < static_cast<int>(atom_symbols.size()); ++n) {
+    if (atom_symbols[n] == token) {
+      return n;
+    }
+  }
+
+  std::string error = "deposit atom species " + token + " is not supported by the potential file.";
+  PRINT_INPUT_ERROR(error.c_str());
+  return -1;
 }
 
 void Deposition::parse_deposition(const char** param, int num_param)
@@ -113,13 +136,8 @@ void Deposition::parse_deposition(const char** param, int num_param)
         PRINT_INPUT_ERROR("deposit atom species requires type, number, and velocity.\n");
       }
 
-      int atom_type = 0;
-      if (!is_valid_int(param[idx], &atom_type)) {
-        PRINT_INPUT_ERROR("deposit atom_type should be an integer.\n");
-      }
-      if (atom_type < 0) {
-        PRINT_INPUT_ERROR("deposit atom_type should >= 0.\n");
-      }
+      int atom_type = get_deposit_atom_type(param[idx], atom_symbols);
+      register_compact_nep_required_species(atom_symbols[atom_type]);
       ++idx;
 
       int number = 0;
@@ -296,12 +314,8 @@ void Deposition::read_file_atoms()
     }
 
     FileAtom fa;
-    if (!is_valid_int(tokens[0].c_str(), &fa.type)) {
-      PRINT_INPUT_ERROR("deposit file atom_type should be an integer.\n");
-    }
-    if (fa.type < 0) {
-      PRINT_INPUT_ERROR("deposit file atom_type should >= 0.\n");
-    }
+    fa.type = get_deposit_atom_type(tokens[0], atom_symbols);
+    register_compact_nep_required_species(atom_symbols[fa.type]);
     for (int d = 0; d < 3; ++d) {
       if (!is_valid_real(tokens[1 + d].c_str(), &fa.pos[d])) {
         PRINT_INPUT_ERROR("deposit file position should be a real number.\n");
@@ -477,6 +491,9 @@ void Deposition::initialize()
   copy_file("model.xyz", "model.xyz.original");
 
   initialize_rng();
+
+  std::string potential_filename = get_filename_potential();
+  atom_symbols = get_atom_symbols(potential_filename);
 
   std::ifstream model_input("model.xyz");
   if (model_input.is_open()) {

--- a/src/main_gpumd/deposition.cu
+++ b/src/main_gpumd/deposition.cu
@@ -51,10 +51,7 @@ static int get_deposit_atom_type(
 {
   int atom_type = 0;
   if (is_valid_int(token.c_str(), &atom_type)) {
-    if (atom_type < 0 || atom_type >= static_cast<int>(atom_symbols.size())) {
-      PRINT_INPUT_ERROR("deposit atom_type is outside the range defined by the potential file.\n");
-    }
-    return atom_type;
+    PRINT_INPUT_ERROR("deposit atom species should be specified using an element symbol.\n");
   }
 
   for (int n = 0; n < static_cast<int>(atom_symbols.size()); ++n) {
@@ -133,7 +130,7 @@ void Deposition::parse_deposition(const char** param, int num_param)
     velocities.clear();
     while (idx < num_param) {
       if (idx + 3 > num_param) {
-        PRINT_INPUT_ERROR("deposit atom species requires type, number, and velocity.\n");
+        PRINT_INPUT_ERROR("deposit atom species requires element, number, and velocity.\n");
       }
 
       int atom_type = get_deposit_atom_type(param[idx], atom_symbols);
@@ -310,7 +307,7 @@ void Deposition::read_file_atoms()
     }
 
     if (tokens.size() != 7) {
-      PRINT_INPUT_ERROR("deposit file should have 7 columns: type x y z vx vy vz.\n");
+      PRINT_INPUT_ERROR("deposit file should have 7 columns: element x y z vx vy vz.\n");
     }
 
     FileAtom fa;

--- a/src/main_gpumd/deposition.cuh
+++ b/src/main_gpumd/deposition.cuh
@@ -34,6 +34,7 @@ public:
   double height_max = 0.0;
   bool has_height_range = false;
   std::vector<int> atom_types;
+  std::vector<std::string> atom_symbols;
   std::vector<int> num_atoms;
   std::vector<double> velocities;
   bool has_file = false;

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -69,6 +69,7 @@ Run simulation according to the inputs in the run.in file.
 #include "replicate.cuh"
 #include "run.cuh"
 #include "utilities/error.cuh"
+#include "utilities/compact_nep.cuh"
 #include "utilities/gpu_macro.cuh"
 #include "utilities/read_file.cuh"
 #include "velocity.cuh"
@@ -172,6 +173,7 @@ Run::Run()
   print_line_2();
 
   execute_run_in();
+  remove_compact_nep_files();
 }
 
 void Run::execute_run_in()
@@ -318,6 +320,9 @@ void Run::perform_a_run()
 
 void Run::parse_one_keyword(std::vector<std::string>& tokens)
 {
+  if (tokens.size() >= 2 && tokens[0] == "potential") {
+    tokens[1] = get_compact_nep_filename(tokens[1]);
+  }
   int num_param = tokens.size();
   const int max_num_param = 32;
   if (num_param > max_num_param)

--- a/src/main_gpumd/run.cu
+++ b/src/main_gpumd/run.cu
@@ -173,7 +173,6 @@ Run::Run()
   print_line_2();
 
   execute_run_in();
-  remove_compact_nep_files();
 }
 
 void Run::execute_run_in()

--- a/src/mc/mc.cu
+++ b/src/mc/mc.cu
@@ -22,6 +22,7 @@ The driver class for the various MC ensembles.
 #include "mc_ensemble_sgc.cuh"
 #include "model/atom.cuh"
 #include "utilities/common.cuh"
+#include "utilities/compact_nep.cuh"
 #include "utilities/gpu_macro.cuh"
 #include "utilities/read_file.cuh"
 #include <cstring>
@@ -160,7 +161,7 @@ static std::string get_potential_file_name()
   }
 
   input_run.close();
-  return potential_file_name;
+  return get_compact_nep_filename(potential_file_name);
 }
 
 static std::vector<std::string> get_atom_symbols_in_nep()

--- a/src/mc/mc_ensemble.cu
+++ b/src/mc/mc_ensemble.cu
@@ -19,6 +19,7 @@ The abstract base class (ABC) for the MC_Ensemble classes.
 
 #include "mc_ensemble.cuh"
 #include "utilities/common.cuh"
+#include "utilities/compact_nep.cuh"
 #include "utilities/gpu_macro.cuh"
 #include <chrono>
 #include <fstream>
@@ -46,7 +47,7 @@ static std::string get_potential_file_name()
   }
 
   input_run.close();
-  return potential_file_name;
+  return get_compact_nep_filename(potential_file_name);
 }
 
 static void check_is_nep(std::string& potential_file_name)

--- a/src/model/read_xyz.cu
+++ b/src/model/read_xyz.cu
@@ -22,6 +22,7 @@ The class defining the simulation model.
 #include "group.cuh"
 #include "read_xyz.cuh"
 #include "utilities/common.cuh"
+#include "utilities/compact_nep.cuh"
 #include "utilities/error.cuh"
 #include "utilities/gpu_macro.cuh"
 #include <algorithm>
@@ -520,6 +521,16 @@ void initialize_position(
     group);
 
   input.close();
+
+  prepare_compact_nep_files(atom.cpu_atom_symbol);
+  const std::vector<std::string>& compact_species = get_compact_nep_species();
+  if (compact_species.size() > 0 && compact_species.size() < atom_symbols.size()) {
+    atom_symbols = compact_species;
+    number_of_types = atom_symbols.size();
+    for (int n = 0; n < atom.number_of_atoms; ++n) {
+      atom.cpu_type[n] = get_compact_nep_type(atom.cpu_atom_symbol[n]);
+    }
+  }
 
   for (int m = 0; m < group.size(); ++m) {
     group[m].find_size(atom.number_of_atoms, m);

--- a/src/utilities/compact_nep.cu
+++ b/src/utilities/compact_nep.cu
@@ -427,8 +427,7 @@ void prepare_compact_nep_files(const std::vector<std::string>& atom_symbols)
   for (int n = 0; n < static_cast<int>(compact_species.size()); ++n) {
     printf("    type %d = %s.\n", n, compact_species[n].c_str());
   }
-  printf("    Atom type indices in run.in refer to the active atom types above, except deposit.\n");
-  printf("    deposit accepts element symbols or original potential type indices.\n");
+  printf("    Atom type indices in run.in refer to the active atom types above.\n");
 
   for (int n = 0; n < static_cast<int>(potential_files.size()); ++n) {
     std::vector<std::string> tokens = get_first_line(potential_files[n]);

--- a/src/utilities/compact_nep.cu
+++ b/src/utilities/compact_nep.cu
@@ -1,0 +1,441 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version. GPUMD is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+   PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have
+   received a copy of the GNU General Public License along with GPUMD.  If not, see
+   <http://www.gnu.org/licenses/>.
+*/
+
+#include "compact_nep.cuh"
+#include "error.cuh"
+#include "read_file.cuh"
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+struct CompactPotentialFile
+{
+  std::string original;
+  std::string compact;
+};
+
+static std::vector<CompactPotentialFile> compact_files;
+static std::vector<std::string> compact_species;
+
+static int find_species(const std::vector<std::string>& species, const std::string& symbol)
+{
+  for (int n = 0; n < static_cast<int>(species.size()); ++n) {
+    if (species[n] == symbol) {
+      return n;
+    }
+  }
+  return -1;
+}
+
+static bool is_compactable_nep(const std::vector<std::string>& tokens)
+{
+  if (tokens.size() < 3) {
+    return false;
+  }
+  return tokens[0].substr(0, 4) == "nep4" || tokens[0].substr(0, 4) == "nep5";
+}
+
+static std::vector<std::string> get_potential_files()
+{
+  std::ifstream input_run("run.in");
+  if (!input_run.is_open()) {
+    PRINT_INPUT_ERROR("No run.in.");
+  }
+
+  std::vector<std::string> files;
+  std::string line;
+  while (std::getline(input_run, line)) {
+    std::vector<std::string> tokens = get_tokens(line);
+    if (tokens.size() >= 2 && tokens[0] == "potential") {
+      files.push_back(tokens[1]);
+    }
+  }
+  input_run.close();
+  return files;
+}
+
+static std::vector<std::string> get_first_line(const std::string& filename)
+{
+  std::ifstream input(filename);
+  if (!input.is_open()) {
+    std::string error = "Cannot open potential file " + filename + ".";
+    PRINT_INPUT_ERROR(error.c_str());
+  }
+  std::vector<std::string> tokens = get_tokens(input);
+  input.close();
+  return tokens;
+}
+
+static std::vector<std::string> get_species(const std::vector<std::string>& tokens)
+{
+  int num_types = get_int_from_token(tokens[1], __FILE__, __LINE__);
+  if (static_cast<int>(tokens.size()) != num_types + 2) {
+    PRINT_INPUT_ERROR("The number of atom symbols in the potential file is incorrect.");
+  }
+  std::vector<std::string> species(num_types);
+  for (int n = 0; n < num_types; ++n) {
+    species[n] = tokens[n + 2];
+  }
+  return species;
+}
+
+static void add_required_species(
+  const std::vector<std::string>& species_full,
+  const std::string& symbol,
+  std::vector<int>& required)
+{
+  int type = find_species(species_full, symbol);
+  if (type < 0) {
+    std::string error = "The active species " + symbol + " is not supported by the potential.";
+    PRINT_INPUT_ERROR(error.c_str());
+  }
+  required[type] = 1;
+}
+
+static void add_mc_species(
+  const std::vector<std::string>& species_full, std::vector<int>& required)
+{
+  std::ifstream input_run("run.in");
+  if (!input_run.is_open()) {
+    PRINT_INPUT_ERROR("No run.in.");
+  }
+
+  std::string line;
+  while (std::getline(input_run, line)) {
+    std::vector<std::string> tokens = get_tokens(line);
+    if (tokens.size() < 7 || tokens[0] != "mc") {
+      continue;
+    }
+    if (tokens[1] != "sgc" && tokens[1] != "vcsgc") {
+      continue;
+    }
+    int num_types_mc = 0;
+    if (!is_valid_int(tokens[6].c_str(), &num_types_mc) || num_types_mc < 1) {
+      continue;
+    }
+    for (int n = 0; n < num_types_mc; ++n) {
+      int index = 7 + n * 2;
+      if (index >= static_cast<int>(tokens.size())) {
+        break;
+      }
+      add_required_species(species_full, tokens[index], required);
+    }
+  }
+  input_run.close();
+}
+
+static int triangular_pair_index(int type1, int type2, int num_types)
+{
+  if (type1 > type2) {
+    int temp = type1;
+    type1 = type2;
+    type2 = temp;
+  }
+  return type1 * num_types - type1 * (type1 - 1) / 2 + type2 - type1;
+}
+
+static void write_line(std::ofstream& output, const std::vector<std::string>& tokens)
+{
+  for (int n = 0; n < static_cast<int>(tokens.size()); ++n) {
+    if (n > 0) {
+      output << " ";
+    }
+    output << tokens[n];
+  }
+  output << "\n";
+}
+
+static std::string make_compact_file(
+  const std::string& filename,
+  const std::vector<std::string>& active_species,
+  const int file_index)
+{
+  std::ifstream input(filename);
+  if (!input.is_open()) {
+    std::string error = "Cannot open potential file " + filename + ".";
+    PRINT_INPUT_ERROR(error.c_str());
+  }
+
+  std::vector<std::string> lines;
+  std::string line;
+  while (std::getline(input, line)) {
+    lines.push_back(line);
+  }
+  input.close();
+  if (lines.size() < 6) {
+    PRINT_INPUT_ERROR("The NEP potential file is incomplete.");
+  }
+
+  int line_index = 0;
+  std::vector<std::string> first = get_tokens(lines[line_index++]);
+  if (!is_compactable_nep(first)) {
+    return filename;
+  }
+  std::vector<std::string> species_full = get_species(first);
+  int num_types_full = species_full.size();
+  int num_types = active_species.size();
+  std::vector<int> active_to_full(num_types);
+  for (int n = 0; n < num_types; ++n) {
+    active_to_full[n] = find_species(species_full, active_species[n]);
+    if (active_to_full[n] < 0) {
+      std::string error =
+        "The active species " + active_species[n] + " is not supported by the potential.";
+      PRINT_INPUT_ERROR(error.c_str());
+    }
+  }
+
+  bool has_zbl = first[0].find("zbl") != std::string::npos;
+  bool is_charge = first[0].find("charge") != std::string::npos;
+  bool is_nep5 = first[0].substr(0, 4) == "nep5";
+  bool is_polarizability = first[0].find("polarizability") != std::string::npos;
+  bool is_temperature = first[0].find("temperature") != std::string::npos;
+
+  std::vector<std::string> zbl_line;
+  bool flexible_zbl = false;
+  if (has_zbl) {
+    zbl_line = get_tokens(lines[line_index++]);
+    if (zbl_line.size() < 3) {
+      PRINT_INPUT_ERROR("Invalid ZBL line in the NEP potential file.");
+    }
+    flexible_zbl =
+      get_double_from_token(zbl_line[1], __FILE__, __LINE__) == 0.0 &&
+      get_double_from_token(zbl_line[2], __FILE__, __LINE__) == 0.0;
+  }
+
+  std::vector<std::string> cutoff = get_tokens(lines[line_index++]);
+  std::vector<std::string> n_max = get_tokens(lines[line_index++]);
+  std::vector<std::string> basis_size = get_tokens(lines[line_index++]);
+  std::vector<std::string> l_max = get_tokens(lines[line_index++]);
+  std::vector<std::string> ann = get_tokens(lines[line_index++]);
+
+  int n_max_radial = get_int_from_token(n_max[1], __FILE__, __LINE__);
+  int n_max_angular = get_int_from_token(n_max[2], __FILE__, __LINE__);
+  int basis_size_radial = get_int_from_token(basis_size[1], __FILE__, __LINE__);
+  int basis_size_angular = get_int_from_token(basis_size[2], __FILE__, __LINE__);
+  int num_L = get_int_from_token(l_max[1], __FILE__, __LINE__);
+  for (int n = 2; n < static_cast<int>(l_max.size()); ++n) {
+    if (get_int_from_token(l_max[n], __FILE__, __LINE__) != 0) {
+      ++num_L;
+    }
+  }
+  int dim = n_max_radial + 1 + (n_max_angular + 1) * num_L;
+  if (is_temperature) {
+    ++dim;
+  }
+  int num_neurons = get_int_from_token(ann[1], __FILE__, __LINE__);
+
+  int ann_type_size;
+  int ann_global_size;
+  int ann_blocks = is_polarizability ? 2 : 1;
+  if (is_charge) {
+    ann_type_size = (dim + 3) * num_neurons;
+    ann_global_size = 2;
+  } else if (is_nep5) {
+    ann_type_size = (dim + 2) * num_neurons + 1;
+    ann_global_size = 1;
+  } else {
+    ann_type_size = (dim + 2) * num_neurons;
+    ann_global_size = 1;
+  }
+
+  int ann_block_size_full = num_types_full * ann_type_size + ann_global_size;
+  int ann_size_full = ann_blocks * ann_block_size_full;
+  int num_types_sq_full = num_types_full * num_types_full;
+  int num_radial_basis = (n_max_radial + 1) * (basis_size_radial + 1);
+  int num_angular_basis = (n_max_angular + 1) * (basis_size_angular + 1);
+  int num_c_radial_full = num_types_sq_full * num_radial_basis;
+  int num_c_angular_full = num_types_sq_full * num_angular_basis;
+  int parameter_count_full = ann_size_full + num_c_radial_full + num_c_angular_full + dim;
+  if (line_index + parameter_count_full > static_cast<int>(lines.size())) {
+    PRINT_INPUT_ERROR("Unexpected number of NEP parameters while creating the compact potential.");
+  }
+
+  std::string compact_filename =
+    ".gpumd_nep_" + std::to_string(static_cast<long long>(getpid())) + "_" +
+    std::to_string(file_index) + ".tmp";
+  std::ofstream output(compact_filename);
+  if (!output.is_open()) {
+    PRINT_INPUT_ERROR("Cannot create the compact NEP potential file.");
+  }
+
+  std::vector<std::string> compact_first;
+  compact_first.push_back(first[0]);
+  compact_first.push_back(std::to_string(num_types));
+  for (int n = 0; n < num_types; ++n) {
+    compact_first.push_back(active_species[n]);
+  }
+  write_line(output, compact_first);
+  if (has_zbl) {
+    write_line(output, zbl_line);
+  }
+
+  if (!is_charge && static_cast<int>(cutoff.size()) == num_types_full * 2 + 3) {
+    std::vector<std::string> compact_cutoff;
+    compact_cutoff.push_back(cutoff[0]);
+    for (int n = 0; n < num_types; ++n) {
+      int full_type = active_to_full[n];
+      compact_cutoff.push_back(cutoff[1 + full_type * 2]);
+      compact_cutoff.push_back(cutoff[2 + full_type * 2]);
+    }
+    compact_cutoff.push_back(cutoff[cutoff.size() - 2]);
+    compact_cutoff.push_back(cutoff[cutoff.size() - 1]);
+    write_line(output, compact_cutoff);
+  } else {
+    write_line(output, cutoff);
+  }
+  write_line(output, n_max);
+  write_line(output, basis_size);
+  write_line(output, l_max);
+  write_line(output, ann);
+
+  int parameter_start = line_index;
+  for (int block = 0; block < ann_blocks; ++block) {
+    int block_start = parameter_start + block * ann_block_size_full;
+    for (int n = 0; n < num_types; ++n) {
+      int type_start = block_start + active_to_full[n] * ann_type_size;
+      for (int m = 0; m < ann_type_size; ++m) {
+        output << lines[type_start + m] << "\n";
+      }
+    }
+    int global_start = block_start + num_types_full * ann_type_size;
+    for (int m = 0; m < ann_global_size; ++m) {
+      output << lines[global_start + m] << "\n";
+    }
+  }
+
+  int radial_start = parameter_start + ann_size_full;
+  for (int basis = 0; basis < num_radial_basis; ++basis) {
+    for (int t1 = 0; t1 < num_types; ++t1) {
+      for (int t2 = 0; t2 < num_types; ++t2) {
+        int pair = active_to_full[t1] * num_types_full + active_to_full[t2];
+        output << lines[radial_start + basis * num_types_sq_full + pair] << "\n";
+      }
+    }
+  }
+
+  int angular_start = radial_start + num_c_radial_full;
+  for (int basis = 0; basis < num_angular_basis; ++basis) {
+    for (int t1 = 0; t1 < num_types; ++t1) {
+      for (int t2 = 0; t2 < num_types; ++t2) {
+        int pair = active_to_full[t1] * num_types_full + active_to_full[t2];
+        output << lines[angular_start + basis * num_types_sq_full + pair] << "\n";
+      }
+    }
+  }
+
+  int scaler_start = angular_start + num_c_angular_full;
+  for (int n = 0; n < dim; ++n) {
+    output << lines[scaler_start + n] << "\n";
+  }
+
+  line_index = parameter_start + parameter_count_full;
+  if (flexible_zbl) {
+    int num_pairs_full = num_types_full * (num_types_full + 1) / 2;
+    int zbl_count_full = num_pairs_full * 10;
+    if (line_index + zbl_count_full > static_cast<int>(lines.size())) {
+      PRINT_INPUT_ERROR("Unexpected number of flexible ZBL parameters.");
+    }
+    for (int t1 = 0; t1 < num_types; ++t1) {
+      for (int t2 = t1; t2 < num_types; ++t2) {
+        int pair = triangular_pair_index(active_to_full[t1], active_to_full[t2], num_types_full);
+        for (int n = 0; n < 10; ++n) {
+          output << lines[line_index + pair * 10 + n] << "\n";
+        }
+      }
+    }
+    line_index += zbl_count_full;
+  }
+
+  for (; line_index < static_cast<int>(lines.size()); ++line_index) {
+    output << lines[line_index] << "\n";
+  }
+  output.close();
+  return compact_filename;
+}
+
+void prepare_compact_nep_files(const std::vector<std::string>& atom_symbols)
+{
+  remove_compact_nep_files();
+  compact_species.clear();
+
+  std::vector<std::string> potential_files = get_potential_files();
+  if (potential_files.size() == 0) {
+    PRINT_INPUT_ERROR("There is no 'potential' keyword in run.in.");
+  }
+
+  std::vector<std::string> first = get_first_line(potential_files.back());
+  if (!is_compactable_nep(first)) {
+    return;
+  }
+  std::vector<std::string> species_full = get_species(first);
+  std::vector<int> required(species_full.size(), 0);
+  for (int n = 0; n < static_cast<int>(atom_symbols.size()); ++n) {
+    add_required_species(species_full, atom_symbols[n], required);
+  }
+  add_mc_species(species_full, required);
+  for (int n = 0; n < static_cast<int>(species_full.size()); ++n) {
+    if (required[n]) {
+      compact_species.push_back(species_full[n]);
+    }
+  }
+
+  if (compact_species.size() == species_full.size()) {
+    return;
+  }
+
+  for (int n = 0; n < static_cast<int>(potential_files.size()); ++n) {
+    std::vector<std::string> tokens = get_first_line(potential_files[n]);
+    if (!is_compactable_nep(tokens)) {
+      continue;
+    }
+    std::string compact = make_compact_file(potential_files[n], compact_species, n);
+    if (compact != potential_files[n]) {
+      CompactPotentialFile file;
+      file.original = potential_files[n];
+      file.compact = compact;
+      compact_files.push_back(file);
+    }
+  }
+}
+
+std::string get_compact_nep_filename(const std::string& filename)
+{
+  for (int n = 0; n < static_cast<int>(compact_files.size()); ++n) {
+    if (compact_files[n].original == filename) {
+      return compact_files[n].compact;
+    }
+  }
+  return filename;
+}
+
+const std::vector<std::string>& get_compact_nep_species() { return compact_species; }
+
+int get_compact_nep_type(const std::string& atom_symbol)
+{
+  int type = find_species(compact_species, atom_symbol);
+  if (type < 0) {
+    std::string error = "The active species " + atom_symbol + " is not initialized.";
+    PRINT_INPUT_ERROR(error.c_str());
+  }
+  return type;
+}
+
+void remove_compact_nep_files()
+{
+  for (int n = 0; n < static_cast<int>(compact_files.size()); ++n) {
+    std::remove(compact_files[n].compact.c_str());
+  }
+  compact_files.clear();
+}

--- a/src/utilities/compact_nep.cu
+++ b/src/utilities/compact_nep.cu
@@ -15,6 +15,7 @@
 #include "error.cuh"
 #include "read_file.cuh"
 #include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <string>
 #ifdef _WIN32
@@ -32,6 +33,7 @@ struct CompactPotentialFile
 
 static std::vector<CompactPotentialFile> compact_files;
 static std::vector<std::string> compact_species;
+static bool cleanup_registered = false;
 
 static int find_species(const std::vector<std::string>& species, const std::string& symbol)
 {
@@ -354,6 +356,8 @@ static std::string make_compact_file(
     int num_pairs_full = num_types_full * (num_types_full + 1) / 2;
     int zbl_count_full = num_pairs_full * 10;
     if (line_index + zbl_count_full > static_cast<int>(lines.size())) {
+      output.close();
+      std::remove(compact_filename.c_str());
       PRINT_INPUT_ERROR("Unexpected number of flexible ZBL parameters.");
     }
     for (int t1 = 0; t1 < num_types; ++t1) {
@@ -376,6 +380,10 @@ static std::string make_compact_file(
 
 void prepare_compact_nep_files(const std::vector<std::string>& atom_symbols)
 {
+  if (!cleanup_registered) {
+    std::atexit(remove_compact_nep_files);
+    cleanup_registered = true;
+  }
   remove_compact_nep_files();
   compact_species.clear();
 

--- a/src/utilities/compact_nep.cu
+++ b/src/utilities/compact_nep.cu
@@ -33,6 +33,7 @@ struct CompactPotentialFile
 
 static std::vector<CompactPotentialFile> compact_files;
 static std::vector<std::string> compact_species;
+static std::vector<std::string> registered_required_species;
 static bool cleanup_registered = false;
 
 static int find_species(const std::vector<std::string>& species, const std::string& symbol)
@@ -43,6 +44,13 @@ static int find_species(const std::vector<std::string>& species, const std::stri
     }
   }
   return -1;
+}
+
+void register_compact_nep_required_species(const std::string& atom_symbol)
+{
+  if (find_species(registered_required_species, atom_symbol) < 0) {
+    registered_required_species.push_back(atom_symbol);
+  }
 }
 
 static bool is_compactable_nep(const std::vector<std::string>& tokens)
@@ -402,6 +410,9 @@ void prepare_compact_nep_files(const std::vector<std::string>& atom_symbols)
     add_required_species(species_full, atom_symbols[n], required);
   }
   add_mc_species(species_full, required);
+  for (int n = 0; n < static_cast<int>(registered_required_species.size()); ++n) {
+    add_required_species(species_full, registered_required_species[n], required);
+  }
   for (int n = 0; n < static_cast<int>(species_full.size()); ++n) {
     if (required[n]) {
       compact_species.push_back(species_full[n]);
@@ -416,7 +427,8 @@ void prepare_compact_nep_files(const std::vector<std::string>& atom_symbols)
   for (int n = 0; n < static_cast<int>(compact_species.size()); ++n) {
     printf("    type %d = %s.\n", n, compact_species[n].c_str());
   }
-  printf("    Atom type indices in run.in refer to the active atom types above.\n");
+  printf("    Atom type indices in run.in refer to the active atom types above, except deposit.\n");
+  printf("    deposit accepts element symbols or original potential type indices.\n");
 
   for (int n = 0; n < static_cast<int>(potential_files.size()); ++n) {
     std::vector<std::string> tokens = get_first_line(potential_files[n]);

--- a/src/utilities/compact_nep.cu
+++ b/src/utilities/compact_nep.cu
@@ -404,6 +404,12 @@ void prepare_compact_nep_files(const std::vector<std::string>& atom_symbols)
     return;
   }
 
+  printf("Active atom types for this simulation:\n");
+  for (int n = 0; n < static_cast<int>(compact_species.size()); ++n) {
+    printf("    type %d = %s.\n", n, compact_species[n].c_str());
+  }
+  printf("    Atom type indices in run.in refer to the active atom types above.\n");
+
   for (int n = 0; n < static_cast<int>(potential_files.size()); ++n) {
     std::vector<std::string> tokens = get_first_line(potential_files[n]);
     if (!is_compactable_nep(tokens)) {

--- a/src/utilities/compact_nep.cu
+++ b/src/utilities/compact_nep.cu
@@ -17,7 +17,11 @@
 #include <cstdio>
 #include <fstream>
 #include <string>
+#ifdef _WIN32
+#include <process.h>
+#else
 #include <unistd.h>
+#endif
 #include <vector>
 
 struct CompactPotentialFile
@@ -262,8 +266,13 @@ static std::string make_compact_file(
     PRINT_INPUT_ERROR("Unexpected number of NEP parameters while creating the compact potential.");
   }
 
+#ifdef _WIN32
+  const int process_id = _getpid();
+#else
+  const int process_id = getpid();
+#endif
   std::string compact_filename =
-    ".gpumd_nep_" + std::to_string(static_cast<long long>(getpid())) + "_" +
+    ".gpumd_nep_" + std::to_string(static_cast<long long>(process_id)) + "_" +
     std::to_string(file_index) + ".tmp";
   std::ofstream output(compact_filename);
   if (!output.is_open()) {

--- a/src/utilities/compact_nep.cuh
+++ b/src/utilities/compact_nep.cuh
@@ -1,0 +1,23 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    This file is part of GPUMD.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version. GPUMD is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+   PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have
+   received a copy of the GNU General Public License along with GPUMD.  If not, see
+   <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+void prepare_compact_nep_files(const std::vector<std::string>& atom_symbols);
+std::string get_compact_nep_filename(const std::string& filename);
+const std::vector<std::string>& get_compact_nep_species();
+int get_compact_nep_type(const std::string& atom_symbol);
+void remove_compact_nep_files();

--- a/src/utilities/compact_nep.cuh
+++ b/src/utilities/compact_nep.cuh
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+void register_compact_nep_required_species(const std::string& atom_symbol);
 void prepare_compact_nep_files(const std::vector<std::string>& atom_symbols);
 std::string get_compact_nep_filename(const std::string& filename);
 const std::vector<std::string>& get_compact_nep_species();


### PR DESCRIPTION
# **Summary**

This PR improves the usability of large multi-element NEP models when only a subset of elements is active in a simulation.

GPUMD now determines the required elements from `model.xyz`, MC species, and deposition species, and creates a temporary compact NEP potential in the working directory containing only these active elements while preserving their original order in the full potential.

# **Modification**

- Added temporary compact NEP generation based on the active elements required by the simulation.
- Active elements are collected from:
  - `model.xyz`
  - SGC/VCSGC MC species
  - deposition species
- When a compact potential is generated, GPUMD prints the active type mapping, for example:

```text
Active atom types for this simulation:
    type 0 = H.
    type 1 = O.
```

- The deposit keyword now requires element symbols instead of numeric type indices.

# **Validation**

The implementation does not change existing results with equivalent inputs.

# **Licensing**

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.
