### PR TITLE
Fix column separators in loss.out and console loss table

### DIFF
--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -518,7 +518,7 @@ void Fitness::report_error(
       if (!(para.charge_mode || para.charge_vdw)) {
         // NEP models
         printf(
-          "%-8d%-11.5f%-11.5f%-11.5f%-13.5f%-13.5f%-13.5f%-13.5f%-13.5f%-13.5f\n",
+          "%-8d %-11.5f %-11.5f %-11.5f %-13.5f %-13.5f %-13.5f %-13.5f %-13.5f %-13.5f\n",
           generation + 1,
           loss_total,
           loss_L1,
@@ -531,7 +531,7 @@ void Fitness::report_error(
           rmse_virial_test);
         fprintf(
           fid_loss_out,
-          "%-8d%-11.5f%-11.5f%-11.5f%-13.5f%-13.5f%-13.5f%-13.5f%-13.5f%-13.5f\n",
+          "%-8d %-11.5f %-11.5f %-11.5f %-13.5f %-13.5f %-13.5f %-13.5f %-13.5f %-13.5f\n",
           generation + 1,
           loss_total,
           loss_L1,
@@ -545,7 +545,7 @@ void Fitness::report_error(
       } else {
         // qNEP models:
         printf(
-          "%-8d%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f\n",
+          "%-8d %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f\n",
           generation + 1,
           loss_total,
           loss_L1,
@@ -562,7 +562,7 @@ void Fitness::report_error(
           rmse_bec_test);
         fprintf(
           fid_loss_out,
-          "%-8d%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f%-9.5f\n",
+          "%-8d %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f %-9.5f\n",
           generation + 1,
           loss_total,
           loss_L1,
@@ -581,7 +581,7 @@ void Fitness::report_error(
     } else {
       // TNEP models:
       printf(
-        "%-8d%-11.5f%-11.5f%-11.5f%-13.5f%-13.5f\n",
+        "%-8d %-11.5f %-11.5f %-11.5f %-13.5f %-13.5f\n",
         generation + 1,
         loss_total,
         loss_L1,
@@ -590,7 +590,7 @@ void Fitness::report_error(
         rmse_virial_test);
       fprintf(
         fid_loss_out,
-        "%-8d%-11.5f%-11.5f%-11.5f%-13.5f%-13.5f\n",
+        "%-8d %-11.5f %-11.5f %-11.5f %-13.5f %-13.5f\n",
         generation + 1,
         loss_total,
         loss_L1,

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -379,7 +379,7 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
     if (para.train_mode == 0 || para.train_mode == 3) {
       if (!(para.charge_mode || para.charge_vdw)) {
         printf(
-          "%-8s%-11s%-11s%-11s%-13s%-13s%-13s%-13s%-13s%-13s\n",
+          "%-8s %-11s %-11s %-11s %-13s %-13s %-13s %-13s %-13s %-13s\n",
           "Step",
           "Total-Loss",
           "L1Reg-Loss",
@@ -392,7 +392,7 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
           "RMSE-V-Test");
       } else {
         printf(
-          "%-8s%-9s%-9s%-9s%-9s%-9s%-9s%-9s%-9s%-9s%-9s%-9s%-9s%-9s\n",
+          "%-8s %-9s %-9s %-9s %-9s %-9s %-9s %-9s %-9s %-9s %-9s %-9s %-9s %-9s\n",
           "Step",
           "Total",
           "L1Reg",
@@ -410,7 +410,7 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
       }
     } else {
       printf(
-        "%-8s%-11s%-11s%-11s%-13s%-13s\n",
+        "%-8s %-11s %-11s %-11s %-13s %-13s\n",
         "Step",
         "Total-Loss",
         "L1Reg-Loss",


### PR DESCRIPTION
**Summary**

The printf/fprintf format strings for the per-generation loss table
(console output and `loss.out`) had no literal separator between
consecutive `%-N.5f`/`%-Ns` specifiers, relying solely on each field's
minimum width for spacing. Once a printed value exceeded its field's
minimum width (e.g. a large total loss), it would butt directly against
the next column with zero separation, corrupting the column structure
for the rest of that row and breaking naive whitespace-based parsers
such as `numpy.loadtxt`.

**Modification**

- Added an explicit space between every field in all three loss-table
  variants in `fitness.cu` (plain NEP, charge/vdW "qNEP", and
  TNEP/dipole-polarizability) and their matching headers in `snes.cu`.
- The fix is unconditional (applies regardless of any loss-value
  magnitude), so columns stay separated no matter how large a value
  grows.

**Others**

- Verified with a real training run using an inflated `lambda_e` to
  force a very large total loss (into the millions), columns remain
  correctly separated (10 fields per row) where they previously merged
  into 9.
- No change to column count, order, or numeric precision, purely an
  output-formatting fix.