### PR TITLE
fix fine_tune and change the access pattern of descriptor parameters internally

### DIFF
--- a/doc/nep/input_files/nep_in.rst
+++ b/doc/nep/input_files/nep_in.rst
@@ -105,7 +105,7 @@ Each mismatch is reported on its own line, naming the keyword, the value used by
       basis_size_radial: nep.in gives 6 (default), nep.txt gives 8.
       basis_size_angular: nep.in gives 6 (default), nep.txt gives 8.
 
-The same comparison is applied to the foundation model named by the :ref:`fine_tune keyword <kw_fine_tune>` and to the :ref:`nep.txt <nep_txt>` read by the :ref:`import_q_scaler keyword <kw_import_q_scaler>`, where a mismatch is always an error.
+The same comparison is applied to the :ref:`nep.txt <nep_txt>` read by the :ref:`import_q_scaler keyword <kw_import_q_scaler>`, where a mismatch is always an error.
 
 Example
 -------

--- a/doc/nep/input_parameters/fine_tune.rst
+++ b/doc/nep/input_parameters/fine_tune.rst
@@ -15,7 +15,7 @@ where :attr:`<nep_model_file>` is the potential file for the foundation model an
 Currently, we provide one foundation model in GPUMD/potentials/nep/nep89_20250409.
 
 The hyperparameters that define the architecture of the foundation model cannot be changed and must be repeated in :attr:`nep.in`, as shown below.
-:program:`nep` compares the whole header of :attr:`<nep_model_file>` against :attr:`nep.in`, including the model type and the list of species, and reports an error naming the keyword if any of them differs; see :ref:`the nep.in page <nep_in>` for the details.
+
 Note that the comparison uses the defaults for keywords that are left out, so omitting one of them is a mismatch unless its default happens to agree with the foundation model.
 
 For more details, see the following exemplary :attr:`nep.in` file::

--- a/doc/nep/input_parameters/fine_tune.rst
+++ b/doc/nep/input_parameters/fine_tune.rst
@@ -14,10 +14,7 @@ where :attr:`<nep_model_file>` is the potential file for the foundation model an
 
 Currently, we provide one foundation model in GPUMD/potentials/nep/nep89_20250409.
 
-The hyperparameters that define the architecture of the foundation model cannot be changed and must be repeated in :attr:`nep.in`, as shown below.
-
-Note that the comparison uses the defaults for keywords that are left out, so omitting one of them is a mismatch unless its default happens to agree with the foundation model.
-
+The hyperparameters that define the architecture of the foundation model cannot be changed and must be repeated in :attr:`nep.in`.
 For more details, see the following exemplary :attr:`nep.in` file::
 
   # for prediction

--- a/src/main_nep/fitness.cu
+++ b/src/main_nep/fitness.cu
@@ -28,6 +28,7 @@ Get the fitness
 #include "utilities/error.cuh"
 #include "utilities/gpu_macro.cuh"
 #include "utilities/gpu_vector.cuh"
+#include "utilities/nep_parameters.cuh"
 #include <algorithm>
 #include <chrono>
 #include <ctime>
@@ -421,8 +422,23 @@ void Fitness::write_nep_txt(FILE* fid_nep, Parameters& para, float* elite)
     fprintf(fid_nep, "ANN %d %d\n", para.num_neurons1, 0);
   }
 
+  std::vector<float> parameters_file(elite, elite + para.number_of_variables);
+  const int descriptor_offset = para.number_of_variables_ann * (para.train_mode == 2 ? 2 : 1);
+#ifdef USE_CJ
+  const int num_channels = para.num_types;
+#else
+  const int num_channels = para.num_types * para.num_types;
+#endif
+  descriptor_parameters_to_basis_major(
+    parameters_file.data(),
+    descriptor_offset,
+    num_channels,
+    para.n_max_radial,
+    para.n_max_angular,
+    para.basis_size_radial,
+    para.basis_size_angular);
   for (int m = 0; m < para.number_of_variables; ++m) {
-    fprintf(fid_nep, "%15.7e\n", elite[m]);
+    fprintf(fid_nep, "%15.7e\n", parameters_file[m]);
   }
   CHECK(gpuSetDevice(0));
   para.q_scaler_gpu[0].copy_to_host(para.q_scaler_cpu.data());

--- a/src/main_nep/nep.cu
+++ b/src/main_nep/nep.cu
@@ -71,11 +71,12 @@ static __global__ void find_descriptors_radial(
         float gn12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_radial; ++k) {
 #ifdef USE_CJ
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types + t2;
+          int c_index = t2 * ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
 #else
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2;
+          int c_index = (t1 * paramb.num_types + t2) *
+                        ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
 #endif
+          c_index += n * (paramb.basis_size_radial + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
         }
         q[n] += gn12;
@@ -128,12 +129,14 @@ static __global__ void find_descriptors_angular(
         find_fn(paramb.basis_size_angular, rcinv, d12, fc12, fn12);
         float gn12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_angular; ++k) {
+          int c_index = paramb.num_c_radial;
 #ifdef USE_CJ
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types + t2 + paramb.num_c_radial;
+          c_index += t2 * ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
 #else
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          c_index += (t1 * paramb.num_types + t2) *
+                     ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
 #endif
+          c_index += n * (paramb.basis_size_angular + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
         }
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
@@ -468,11 +471,12 @@ static __global__ void find_force_radial(
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_radial; ++k) {
 #ifdef USE_CJ
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types + t2;
+          int c_index = t2 * ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
 #else
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2;
+          int c_index = (t1 * paramb.num_types + t2) *
+                        ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
 #endif
+          c_index += n * (paramb.basis_size_radial + 1) + k;
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
         float tmp12 = g_Fp[n1 + n * N] * gnp12 * d12inv;
@@ -567,12 +571,14 @@ static __global__ void find_force_angular(
         float gn12 = 0.0f;
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_angular; ++k) {
+          int c_index = paramb.num_c_radial;
 #ifdef USE_CJ
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types + t2 + paramb.num_c_radial;
+          c_index += t2 * ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
 #else
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          c_index += (t1 * paramb.num_types + t2) *
+                     ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
 #endif
+          c_index += n * (paramb.basis_size_angular + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }

--- a/src/main_nep/nep_charge.cu
+++ b/src/main_nep/nep_charge.cu
@@ -67,8 +67,9 @@ static __global__ void find_descriptors_radial(
       for (int n = 0; n <= paramb.n_max_radial; ++n) {
         float gn12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_radial; ++k) {
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2;
+          int c_index = (t1 * paramb.num_types + t2) *
+                        ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
+          c_index += n * (paramb.basis_size_radial + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
         }
         q[n] += gn12;
@@ -118,8 +119,10 @@ static __global__ void find_descriptors_angular(
         find_fn(paramb.basis_size_angular, rcinv, d12, fc12, fn12);
         float gn12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_angular; ++k) {
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          int c_index = paramb.num_c_radial;
+          c_index += (t1 * paramb.num_types + t2) *
+                     ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
+          c_index += n * (paramb.basis_size_angular + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
         }
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
@@ -430,8 +433,9 @@ static __global__ void find_force_radial(
       for (int n = 0; n <= paramb.n_max_radial; ++n) {
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_radial; ++k) {
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2;
+          int c_index = (t1 * paramb.num_types + t2) *
+                        ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
+          c_index += n * (paramb.basis_size_radial + 1) + k;
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
         float tmp12 = g_Fp[n1 + n * N] + g_charge_derivative[n1 + n * N] * g_D_real[n1];
@@ -525,8 +529,10 @@ static __global__ void find_force_angular(
         float gn12 = 0.0f;
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_angular; ++k) {
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          int c_index = paramb.num_c_radial;
+          c_index += (t1 * paramb.num_types + t2) *
+                     ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
+          c_index += n * (paramb.basis_size_angular + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
@@ -594,8 +600,9 @@ static __global__ void find_bec_radial(
       for (int n = 0; n <= paramb.n_max_radial; ++n) {
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_radial; ++k) {
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2;
+          int c_index = (t1 * paramb.num_types + t2) *
+                        ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
+          c_index += n * (paramb.basis_size_radial + 1) + k;
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
         const float tmp12 = g_charge_derivative[n1 + n * N] * gnp12 * d12inv;
@@ -683,8 +690,10 @@ static __global__ void find_bec_angular(
         float gn12 = 0.0f;
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_angular; ++k) {
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          int c_index = paramb.num_c_radial;
+          c_index += (t1 * paramb.num_types + t2) *
+                     ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
+          c_index += n * (paramb.basis_size_angular + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }

--- a/src/main_nep/nep_charge_vdw.cu
+++ b/src/main_nep/nep_charge_vdw.cu
@@ -68,8 +68,9 @@ static __global__ void find_descriptors_radial(
       for (int n = 0; n <= paramb.n_max_radial; ++n) {
         float gn12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_radial; ++k) {
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2;
+          int c_index = (t1 * paramb.num_types + t2) *
+                        ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
+          c_index += n * (paramb.basis_size_radial + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
         }
         q[n] += gn12;
@@ -119,8 +120,10 @@ static __global__ void find_descriptors_angular(
         find_fn(paramb.basis_size_angular, rcinv, d12, fc12, fn12);
         float gn12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_angular; ++k) {
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          int c_index = paramb.num_c_radial;
+          c_index += (t1 * paramb.num_types + t2) *
+                     ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
+          c_index += n * (paramb.basis_size_angular + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
         }
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
@@ -451,8 +454,9 @@ static __global__ void find_force_radial(
       for (int n = 0; n <= paramb.n_max_radial; ++n) {
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_radial; ++k) {
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2;
+          int c_index = (t1 * paramb.num_types + t2) *
+                        ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
+          c_index += n * (paramb.basis_size_radial + 1) + k;
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
         float tmp12 = g_Fp[n1 + n * N] + g_charge_derivative[n1 + n * N] * g_D_real[n1];
@@ -550,8 +554,10 @@ static __global__ void find_force_angular(
         float gn12 = 0.0f;
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_angular; ++k) {
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          int c_index = paramb.num_c_radial;
+          c_index += (t1 * paramb.num_types + t2) *
+                     ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
+          c_index += n * (paramb.basis_size_angular + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
@@ -619,8 +625,9 @@ static __global__ void find_bec_radial(
       for (int n = 0; n <= paramb.n_max_radial; ++n) {
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_radial; ++k) {
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2;
+          int c_index = (t1 * paramb.num_types + t2) *
+                        ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
+          c_index += n * (paramb.basis_size_radial + 1) + k;
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
         const float tmp12 = g_charge_derivative[n1 + n * N] * gnp12 * d12inv;
@@ -708,8 +715,10 @@ static __global__ void find_bec_angular(
         float gn12 = 0.0f;
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_angular; ++k) {
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          int c_index = paramb.num_c_radial;
+          c_index += (t1 * paramb.num_types + t2) *
+                     ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
+          c_index += n * (paramb.basis_size_angular + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }

--- a/src/main_nep/nep_vdw.cu
+++ b/src/main_nep/nep_vdw.cu
@@ -69,11 +69,12 @@ static __global__ void find_descriptors_radial(
         float gn12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_radial; ++k) {
 #ifdef USE_CJ
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types + t2;
+          int c_index = t2 * ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
 #else
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2;
+          int c_index = (t1 * paramb.num_types + t2) *
+                        ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
 #endif
+          c_index += n * (paramb.basis_size_radial + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
         }
         q[n] += gn12;
@@ -123,12 +124,14 @@ static __global__ void find_descriptors_angular(
         find_fn(paramb.basis_size_angular, rcinv, d12, fc12, fn12);
         float gn12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_angular; ++k) {
+          int c_index = paramb.num_c_radial;
 #ifdef USE_CJ
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types + t2 + paramb.num_c_radial;
+          c_index += t2 * ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
 #else
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          c_index += (t1 * paramb.num_types + t2) *
+                     ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
 #endif
+          c_index += n * (paramb.basis_size_angular + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
         }
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
@@ -427,11 +430,12 @@ static __global__ void find_force_radial(
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_radial; ++k) {
 #ifdef USE_CJ
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types + t2;
+          int c_index = t2 * ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
 #else
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2;
+          int c_index = (t1 * paramb.num_types + t2) *
+                        ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
 #endif
+          c_index += n * (paramb.basis_size_radial + 1) + k;
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
         float tmp12 = g_Fp[n1 + n * N];
@@ -528,12 +532,14 @@ static __global__ void find_force_angular(
         float gn12 = 0.0f;
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_angular; ++k) {
+          int c_index = paramb.num_c_radial;
 #ifdef USE_CJ
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types + t2 + paramb.num_c_radial;
+          c_index += t2 * ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
 #else
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          c_index += (t1 * paramb.num_types + t2) *
+                     ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
 #endif
+          c_index += n * (paramb.basis_size_angular + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -745,8 +745,7 @@ void Parameters::check_existing_model()
   }
 
   if (fine_tune) {
-    check_nep_txt(fine_tune_nep_txt, true, "Correct nep.in to match the foundation model.");
-    return; // the restart file to fine-tune from is named by the fine_tune keyword
+    return; // Users are responsible for the consistency (we have provided template)
   }
 
   if (import_q_scaler) {

--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -18,6 +18,7 @@
 #include "utilities/error.cuh"
 #include "utilities/gpu_macro.cuh"
 #include "utilities/read_file.cuh"
+#include <algorithm>
 #include <cctype>
 #include <cmath>
 #include <cstring>
@@ -570,6 +571,213 @@ static void compare_float(
   }
 }
 
+static void compare_with_nep_txt_fine_tune(
+  Parameters& para, const std::string& filename, std::vector<std::string>& mismatches)
+{
+  NepTxtHeader header;
+  std::string error;
+  if (!read_nep_txt_header(filename, header, error)) {
+    mismatches.push_back(error);
+    return;
+  }
+  para.number_of_nep_txt_header_lines = header.number_of_header_lines;
+
+  std::vector<std::string> elements_nep89;
+  for (int n = 0; n < NUM_ELEMENTS; ++n) {
+    if (ELEMENTS[n] != "Po" && ELEMENTS[n] != "At" && ELEMENTS[n] != "Rn" &&
+        ELEMENTS[n] != "Fr" && ELEMENTS[n] != "Ra") {
+      elements_nep89.push_back(ELEMENTS[n]);
+    }
+  }
+  if (header.num_types != int(elements_nep89.size()) || header.elements != elements_nep89) {
+    mismatches.push_back(
+      "type: the fine-tune foundation model must contain the canonical 89 elements in the "
+      "expected order.");
+  }
+
+  std::vector<int> foundation_type_index(para.num_types, -1);
+  for (int n = 0; n < para.num_types; ++n) {
+    const auto it = std::find(header.elements.begin(), header.elements.end(), para.elements[n]);
+    if (it == header.elements.end()) {
+      mismatches.push_back(
+        "type: element " + para.elements[n] + " is not available in the foundation model.");
+    } else {
+      foundation_type_index[n] = int(it - header.elements.begin());
+    }
+  }
+
+  compare_int(
+    "version", para.version, para.is_version_set, header.version, filename, mismatches);
+  compare_int(
+    "model_type",
+    para.train_mode,
+    para.is_train_mode_set,
+    header.train_mode,
+    filename,
+    mismatches);
+  compare_int(
+    "charge_mode",
+    para.charge_mode,
+    para.is_charge_mode_set,
+    header.charge_mode,
+    filename,
+    mismatches);
+  compare_int("vdw", para.vdw, para.is_vdw_set, header.vdw, filename, mismatches);
+  compare_int(
+    "charge_vdw",
+    para.charge_vdw,
+    para.is_charge_vdw_set,
+    header.charge_vdw,
+    filename,
+    mismatches);
+
+  if (para.enable_zbl != header.enable_zbl) {
+    mismatches.push_back(
+      std::string("zbl: nep.in has ZBL ") + (para.enable_zbl ? "enabled" : "disabled") +
+      ", " + filename + " has it " + (header.enable_zbl ? "enabled" : "disabled") + ".");
+  } else if (para.enable_zbl) {
+    if (para.flexible_zbl != header.flexible_zbl) {
+      mismatches.push_back(
+        std::string("zbl: nep.in requests a ") +
+        (para.flexible_zbl ? "flexible" : "universal") + " ZBL potential, " + filename +
+        " holds a " + (header.flexible_zbl ? "flexible" : "universal") + " one.");
+    } else if (!para.flexible_zbl) {
+      compare_float(
+        "zbl (inner cutoff)",
+        para.zbl_rc_inner,
+        para.is_zbl_set,
+        header.zbl_rc_inner,
+        filename,
+        mismatches);
+      compare_float(
+        "zbl (outer cutoff)",
+        para.zbl_rc_outer,
+        para.is_zbl_set,
+        header.zbl_rc_outer,
+        filename,
+        mismatches);
+      compare_float(
+        "use_typewise_cutoff_zbl",
+        para.typewise_cutoff_zbl_factor,
+        para.is_use_typewise_cutoff_zbl_set,
+        header.typewise_cutoff_zbl_factor,
+        filename,
+        mismatches);
+    }
+  }
+
+  for (int n = 0; n < para.num_types; ++n) {
+    if (foundation_type_index[n] < 0) {
+      continue;
+    }
+    const int m = header.has_multiple_cutoffs ? foundation_type_index[n] : 0;
+    const std::string suffix = (para.num_types > 1) ? " for " + para.elements[n] : "";
+    compare_float(
+      "cutoff (radial)" + suffix,
+      para.rc_radial[n],
+      para.is_cutoff_set,
+      header.rc_radial[m],
+      filename,
+      mismatches);
+    compare_float(
+      "cutoff (angular)" + suffix,
+      para.rc_angular[n],
+      para.is_cutoff_set,
+      header.rc_angular[m],
+      filename,
+      mismatches);
+  }
+
+  compare_int(
+    "n_max_radial",
+    para.n_max_radial,
+    para.is_n_max_set,
+    header.n_max_radial,
+    filename,
+    mismatches);
+  compare_int(
+    "n_max_angular",
+    para.n_max_angular,
+    para.is_n_max_set,
+    header.n_max_angular,
+    filename,
+    mismatches);
+  compare_int(
+    "basis_size_radial",
+    para.basis_size_radial,
+    para.is_basis_size_set,
+    header.basis_size_radial,
+    filename,
+    mismatches);
+  compare_int(
+    "basis_size_angular",
+    para.basis_size_angular,
+    para.is_basis_size_set,
+    header.basis_size_angular,
+    filename,
+    mismatches);
+
+  compare_int(
+    "L_max", para.L_max, para.is_l_max_set, header.L_max, filename, mismatches);
+  compare_int(
+    "L_max_4body",
+    para.has_q_222 ? 2 : 0,
+    para.is_l_max_set,
+    header.has_q_222,
+    filename,
+    mismatches);
+  compare_int(
+    "L_max_5body",
+    para.has_q_1111,
+    para.is_l_max_set,
+    header.has_q_1111,
+    filename,
+    mismatches);
+  compare_int(
+    "has_q_112",
+    para.has_q_112,
+    para.is_l_max_set,
+    header.has_q_112,
+    filename,
+    mismatches);
+  compare_int(
+    "has_q_123",
+    para.has_q_123,
+    para.is_l_max_set,
+    header.has_q_123,
+    filename,
+    mismatches);
+  compare_int(
+    "has_q_233",
+    para.has_q_233,
+    para.is_l_max_set,
+    header.has_q_233,
+    filename,
+    mismatches);
+  compare_int(
+    "has_q_134",
+    para.has_q_134,
+    para.is_l_max_set,
+    header.has_q_134,
+    filename,
+    mismatches);
+
+  compare_int(
+    "neuron",
+    para.num_neurons1,
+    para.is_neuron_set,
+    header.num_neurons1,
+    filename,
+    mismatches);
+  compare_int(
+    "neuron (second hidden layer)",
+    (para.num_hidden_layers == 2) ? para.num_neurons2 : 0,
+    para.is_neuron_set,
+    header.num_neurons2,
+    filename,
+    mismatches);
+}
+
 void Parameters::compare_with_nep_txt(
   const std::string& filename, std::vector<std::string>& mismatches)
 {
@@ -745,7 +953,20 @@ void Parameters::check_existing_model()
   }
 
   if (fine_tune) {
-    return; // Users are responsible for the consistency (we have provided template)
+    std::vector<std::string> mismatches;
+    compare_with_nep_txt_fine_tune(*this, fine_tune_nep_txt, mismatches);
+    if (!mismatches.empty()) {
+      printf(
+        "The model in nep.in is inconsistent with the fine-tune foundation model %s:\n",
+        fine_tune_nep_txt.c_str());
+      for (const auto& mismatch : mismatches) {
+        printf("    %s\n", mismatch.c_str());
+      }
+      printf("Correct nep.in or use the matching fine-tune template.\n");
+      PRINT_INPUT_ERROR(
+        ("nep.in is inconsistent with " + fine_tune_nep_txt + ".").c_str());
+    }
+    return; // the restart file to fine-tune from is named by the fine_tune keyword
   }
 
   if (import_q_scaler) {

--- a/src/main_nep/snes.cu
+++ b/src/main_nep/snes.cu
@@ -28,6 +28,7 @@ https://doi.org/10.1145/2001576.2001692
 #include "snes.cuh"
 #include "utilities/error.cuh"
 #include "utilities/gpu_macro.cuh"
+#include "utilities/nep_parameters.cuh"
 #include <chrono>
 #include <cmath>
 #include <iostream>
@@ -125,6 +126,28 @@ void SNES::initialize_mu_and_sigma(Parameters& para)
       int count = fscanf(fid_restart, "%f%f", &mu[n], &sigma[n]);
       PRINT_SCANF_ERROR(count, 2, "Reading error for nep.restart.");
     }
+    const int descriptor_offset = para.number_of_variables_ann * (para.train_mode == 2 ? 2 : 1);
+#ifdef USE_CJ
+    const int num_channels = para.num_types;
+#else
+    const int num_channels = para.num_types * para.num_types;
+#endif
+    descriptor_parameters_to_channel_major(
+      mu.data(),
+      descriptor_offset,
+      num_channels,
+      para.n_max_radial,
+      para.n_max_angular,
+      para.basis_size_radial,
+      para.basis_size_angular);
+    descriptor_parameters_to_channel_major(
+      sigma.data(),
+      descriptor_offset,
+      num_channels,
+      para.n_max_radial,
+      para.n_max_angular,
+      para.basis_size_radial,
+      para.basis_size_angular);
     // flip the charges if needed
     if ((para.charge_mode || para.charge_vdw) && para.flip_charge) {
       const int num1 = (para.dim + 2) * para.num_neurons1;
@@ -201,11 +224,11 @@ void SNES::initialize_mu_and_sigma_fine_tune(Parameters& para)
 #ifdef USE_CJ
 
   // radial descriptors
-  for (int n = 0; n <= para.n_max_radial; ++n) {
-    for (int k = 0; k <= para.basis_size_radial; ++k) {
-      int nk = n * (para.basis_size_radial + 1) + k;
-      for (int t2 = 0; t2 < para.num_types; ++t2) {
-        int element_index_2 = element_map[para.atomic_numbers[t2] - 1];
+  for (int t2 = 0; t2 < para.num_types; ++t2) {
+    int element_index_2 = element_map[para.atomic_numbers[t2] - 1];
+    for (int n = 0; n <= para.n_max_radial; ++n) {
+      for (int k = 0; k <= para.basis_size_radial; ++k) {
+        int nk = n * (para.basis_size_radial + 1) + k;
         mu[count] = restart_mu[nk * NUM89 + element_index_2 + num_ann];
         if (para.fine_tune_descriptor) {
           sigma[count] = restart_sigma[nk * NUM89 + element_index_2 + num_ann];
@@ -218,11 +241,11 @@ void SNES::initialize_mu_and_sigma_fine_tune(Parameters& para)
   }
 
   // angular descriptors
-  for (int n = 0; n <= para.n_max_angular; ++n) {
-    for (int k = 0; k <= para.basis_size_angular; ++k) {
-      int nk = n * (para.basis_size_angular + 1) + k;
-      for (int t2 = 0; t2 < para.num_types; ++t2) {
-        int element_index_2 = element_map[para.atomic_numbers[t2] - 1];
+  for (int t2 = 0; t2 < para.num_types; ++t2) {
+    int element_index_2 = element_map[para.atomic_numbers[t2] - 1];
+    for (int n = 0; n <= para.n_max_angular; ++n) {
+      for (int k = 0; k <= para.basis_size_angular; ++k) {
+        int nk = n * (para.basis_size_angular + 1) + k;
         mu[count] = restart_mu[nk * NUM89 + element_index_2 + num_ann + num_cnk_radial];
         if (para.fine_tune_descriptor) {
           sigma[count] = restart_sigma[nk * NUM89 + element_index_2 + num_ann + num_cnk_radial];
@@ -237,14 +260,14 @@ void SNES::initialize_mu_and_sigma_fine_tune(Parameters& para)
 #else
 
   // radial descriptors
-  for (int n = 0; n <= para.n_max_radial; ++n) {
-    for (int k = 0; k <= para.basis_size_radial; ++k) {
-      int nk = n * (para.basis_size_radial + 1) + k;
-      for (int t1 = 0; t1 < para.num_types; ++t1) {
-        for (int t2 = 0; t2 < para.num_types; ++t2) {
-          int element_index_1 = element_map[para.atomic_numbers[t1] - 1];
-          int element_index_2 = element_map[para.atomic_numbers[t2] - 1];
-          int t12 = element_index_1 * NUM89 + element_index_2;
+  for (int t1 = 0; t1 < para.num_types; ++t1) {
+    for (int t2 = 0; t2 < para.num_types; ++t2) {
+      int element_index_1 = element_map[para.atomic_numbers[t1] - 1];
+      int element_index_2 = element_map[para.atomic_numbers[t2] - 1];
+      int t12 = element_index_1 * NUM89 + element_index_2;
+      for (int n = 0; n <= para.n_max_radial; ++n) {
+        for (int k = 0; k <= para.basis_size_radial; ++k) {
+          int nk = n * (para.basis_size_radial + 1) + k;
           mu[count] = restart_mu[nk * NUM89 * NUM89 + t12 + num_ann];
           if (para.fine_tune_descriptor) {
             sigma[count] = restart_sigma[nk * NUM89 * NUM89 + t12 + num_ann];
@@ -258,14 +281,14 @@ void SNES::initialize_mu_and_sigma_fine_tune(Parameters& para)
   }
 
   // angular descriptors
-  for (int n = 0; n <= para.n_max_angular; ++n) {
-    for (int k = 0; k <= para.basis_size_angular; ++k) {
-      int nk = n * (para.basis_size_angular + 1) + k;
-      for (int t1 = 0; t1 < para.num_types; ++t1) {
-        for (int t2 = 0; t2 < para.num_types; ++t2) {
-          int element_index_1 = element_map[para.atomic_numbers[t1] - 1];
-          int element_index_2 = element_map[para.atomic_numbers[t2] - 1];
-          int t12 = element_index_1 * NUM89 + element_index_2;
+  for (int t1 = 0; t1 < para.num_types; ++t1) {
+    for (int t2 = 0; t2 < para.num_types; ++t2) {
+      int element_index_1 = element_map[para.atomic_numbers[t1] - 1];
+      int element_index_2 = element_map[para.atomic_numbers[t2] - 1];
+      int t12 = element_index_1 * NUM89 + element_index_2;
+      for (int n = 0; n <= para.n_max_angular; ++n) {
+        for (int k = 0; k <= para.basis_size_angular; ++k) {
+          int nk = n * (para.basis_size_angular + 1) + k;
           mu[count] = restart_mu[nk * NUM89 * NUM89 + t12 + num_ann + num_cnk_radial];
           if (para.fine_tune_descriptor) {
             sigma[count] = restart_sigma[nk * NUM89 * NUM89 + t12 + num_ann + num_cnk_radial];
@@ -316,46 +339,36 @@ void SNES::find_type_of_variable(Parameters& para)
 
   // descriptor part
 #ifdef USE_CJ
-  for (int n = 0; n <= para.n_max_radial; ++n) {
-    for (int k = 0; k <= para.basis_size_radial; ++k) {
-      int nk = n * (para.basis_size_radial + 1) + k;
-      for (int t1 = 0; t1 < para.num_types; ++t1) {
-          type_of_variable[nk * para.num_types + t1 + offset] = t1;
-      }
+  const int num_radial_basis = (para.n_max_radial + 1) * (para.basis_size_radial + 1);
+  for (int t1 = 0; t1 < para.num_types; ++t1) {
+    for (int basis = 0; basis < num_radial_basis; ++basis) {
+      type_of_variable[t1 * num_radial_basis + basis + offset] = t1;
     }
   }
-  offset +=
-    (para.n_max_radial + 1) * (para.basis_size_radial + 1) * para.num_types;
-  for (int n = 0; n <= para.n_max_angular; ++n) {
-    for (int k = 0; k <= para.basis_size_angular; ++k) {
-      int nk = n * (para.basis_size_angular + 1) + k;
-      for (int t1 = 0; t1 < para.num_types; ++t1) {
-          type_of_variable[nk * para.num_types + t1 + offset] = t1;
-      }
+  offset += num_radial_basis * para.num_types;
+  const int num_angular_basis = (para.n_max_angular + 1) * (para.basis_size_angular + 1);
+  for (int t1 = 0; t1 < para.num_types; ++t1) {
+    for (int basis = 0; basis < num_angular_basis; ++basis) {
+      type_of_variable[t1 * num_angular_basis + basis + offset] = t1;
     }
   }
 #else
-  for (int n = 0; n <= para.n_max_radial; ++n) {
-    for (int k = 0; k <= para.basis_size_radial; ++k) {
-      int nk = n * (para.basis_size_radial + 1) + k;
-      for (int t1 = 0; t1 < para.num_types; ++t1) {
-        for (int t2 = 0; t2 < para.num_types; ++t2) {
-          int t12 = t1 * para.num_types + t2;
-          type_of_variable[nk * para.num_types * para.num_types + t12 + offset] = t1;
-        }
+  const int num_radial_basis = (para.n_max_radial + 1) * (para.basis_size_radial + 1);
+  for (int t1 = 0; t1 < para.num_types; ++t1) {
+    for (int t2 = 0; t2 < para.num_types; ++t2) {
+      int t12 = t1 * para.num_types + t2;
+      for (int basis = 0; basis < num_radial_basis; ++basis) {
+        type_of_variable[t12 * num_radial_basis + basis + offset] = t1;
       }
     }
   }
-  offset +=
-    (para.n_max_radial + 1) * (para.basis_size_radial + 1) * para.num_types * para.num_types;
-  for (int n = 0; n <= para.n_max_angular; ++n) {
-    for (int k = 0; k <= para.basis_size_angular; ++k) {
-      int nk = n * (para.basis_size_angular + 1) + k;
-      for (int t1 = 0; t1 < para.num_types; ++t1) {
-        for (int t2 = 0; t2 < para.num_types; ++t2) {
-          int t12 = t1 * para.num_types + t2;
-          type_of_variable[nk * para.num_types * para.num_types + t12 + offset] = t1;
-        }
+  offset += num_radial_basis * para.num_types * para.num_types;
+  const int num_angular_basis = (para.n_max_angular + 1) * (para.basis_size_angular + 1);
+  for (int t1 = 0; t1 < para.num_types; ++t1) {
+    for (int t2 = 0; t2 < para.num_types; ++t2) {
+      int t12 = t1 * para.num_types + t2;
+      for (int basis = 0; basis < num_angular_basis; ++basis) {
+        type_of_variable[t12 * num_angular_basis + basis + offset] = t1;
       }
     }
   }
@@ -449,14 +462,14 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
       update_mu_and_sigma();
       if (0 == (n + 1) % para.output_interval) {
         const char* filename = "nep.restart";
-        output_mu_and_sigma(filename);
+        output_mu_and_sigma(para, filename);
       }
       // Optionally save the nep.restart file at the same time as save_potential
       if (0 == (n + 1) % para.save_potential && para.save_potential_restart) {
         std::string restart_file;
         fitness_function->get_save_potential_label(para, n, restart_file);
         restart_file += ".restart";
-        output_mu_and_sigma(restart_file.c_str());
+        output_mu_and_sigma(para, restart_file.c_str());
       }
     }
   } else {
@@ -477,6 +490,20 @@ void SNES::compute(Parameters& para, Fitness* fitness_function)
       tokens = get_tokens(input);
       population[n] = get_double_from_token(tokens[0], __FILE__, __LINE__);
     }
+    const int descriptor_offset = para.number_of_variables_ann * (para.train_mode == 2 ? 2 : 1);
+#ifdef USE_CJ
+    const int num_channels = para.num_types;
+#else
+    const int num_channels = para.num_types * para.num_types;
+#endif
+    descriptor_parameters_to_channel_major(
+      population.data(),
+      descriptor_offset,
+      num_channels,
+      para.n_max_radial,
+      para.n_max_angular,
+      para.basis_size_radial,
+      para.basis_size_angular);
     for (int d = 0; d < para.dim; ++d) {
       tokens = get_tokens(input);
       para.q_scaler_cpu[d] = get_double_from_token(tokens[0], __FILE__, __LINE__);
@@ -673,14 +700,38 @@ void SNES::update_mu_and_sigma()
   GPU_CHECK_KERNEL;
 }
 
-void SNES::output_mu_and_sigma(const char* filename)
+void SNES::output_mu_and_sigma(Parameters& para, const char* filename)
 {
   gpuSetDevice(0); // normally use GPU-0
   gpu_mu.copy_to_host(mu.data());
   gpu_sigma.copy_to_host(sigma.data());
+  std::vector<float> mu_file = mu;
+  std::vector<float> sigma_file = sigma;
+  const int descriptor_offset = para.number_of_variables_ann * (para.train_mode == 2 ? 2 : 1);
+#ifdef USE_CJ
+  const int num_channels = para.num_types;
+#else
+  const int num_channels = para.num_types * para.num_types;
+#endif
+  descriptor_parameters_to_basis_major(
+    mu_file.data(),
+    descriptor_offset,
+    num_channels,
+    para.n_max_radial,
+    para.n_max_angular,
+    para.basis_size_radial,
+    para.basis_size_angular);
+  descriptor_parameters_to_basis_major(
+    sigma_file.data(),
+    descriptor_offset,
+    num_channels,
+    para.n_max_radial,
+    para.n_max_angular,
+    para.basis_size_radial,
+    para.basis_size_angular);
   FILE* fid_restart = my_fopen(filename, "w");
   for (int n = 0; n < number_of_variables; ++n) {
-    fprintf(fid_restart, "%15.7e %15.7e\n", mu[n], sigma[n]);
+    fprintf(fid_restart, "%15.7e %15.7e\n", mu_file[n], sigma_file[n]);
   }
   fclose(fid_restart);
 }

--- a/src/main_nep/snes.cuh
+++ b/src/main_nep/snes.cuh
@@ -77,5 +77,5 @@ protected:
   void regularize_NEP4(Parameters& para);
   void sort_population(Parameters& para);
   void update_mu_and_sigma();
-  void output_mu_and_sigma(const char* filename);
+  void output_mu_and_sigma(Parameters& para, const char* filename);
 };

--- a/src/main_nep/tnep.cu
+++ b/src/main_nep/tnep.cu
@@ -69,8 +69,9 @@ static __global__ void find_descriptors_radial(
       for (int n = 0; n <= paramb.n_max_radial; ++n) {
         float gn12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_radial; ++k) {
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2;
+          int c_index = (t1 * paramb.num_types + t2) *
+                        ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
+          c_index += n * (paramb.basis_size_radial + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
         }
         q[n] += gn12;
@@ -120,8 +121,10 @@ static __global__ void find_descriptors_angular(
         find_fn(paramb.basis_size_angular, rcinv, d12, fc12, fn12);
         float gn12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_angular; ++k) {
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          int c_index = paramb.num_c_radial;
+          c_index += (t1 * paramb.num_types + t2) *
+                     ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
+          c_index += n * (paramb.basis_size_angular + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
         }
         accumulate_s(paramb.L_max, d12, x12, y12, z12, gn12, s);
@@ -487,8 +490,9 @@ static __global__ void find_force_radial(
       for (int n = 0; n <= paramb.n_max_radial; ++n) {
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_radial; ++k) {
-          int c_index = (n * (paramb.basis_size_radial + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2;
+          int c_index = (t1 * paramb.num_types + t2) *
+                        ((paramb.n_max_radial + 1) * (paramb.basis_size_radial + 1));
+          c_index += n * (paramb.basis_size_radial + 1) + k;
           gnp12 += fnp12[k] * annmb.c[c_index];
         }
         float tmp12 = g_Fp[n1 + n * N] * gnp12 * d12inv;
@@ -585,8 +589,10 @@ static __global__ void find_force_angular(
         float gn12 = 0.0f;
         float gnp12 = 0.0f;
         for (int k = 0; k <= paramb.basis_size_angular; ++k) {
-          int c_index = (n * (paramb.basis_size_angular + 1) + k) * paramb.num_types_sq;
-          c_index += t1 * paramb.num_types + t2 + paramb.num_c_radial;
+          int c_index = paramb.num_c_radial;
+          c_index += (t1 * paramb.num_types + t2) *
+                     ((paramb.n_max_angular + 1) * (paramb.basis_size_angular + 1));
+          c_index += n * (paramb.basis_size_angular + 1) + k;
           gn12 += fn12[k] * annmb.c[c_index];
           gnp12 += fnp12[k] * annmb.c[c_index];
         }

--- a/src/utilities/nep_parameters.cuh
+++ b/src/utilities/nep_parameters.cuh
@@ -48,3 +48,66 @@ inline std::vector<float> get_descriptor_parameters_type_pair(
 
   return descriptor_parameters;
 }
+// Training keeps descriptor parameters as [channel][basis] internally while
+// nep.txt and nep.restart keep the historical [basis][channel] order.
+inline void descriptor_parameters_to_channel_major(
+  float* parameters,
+  const int descriptor_offset,
+  const int num_channels,
+  const int n_max_radial,
+  const int n_max_angular,
+  const int basis_size_radial,
+  const int basis_size_angular)
+{
+  const int num_radial_basis = (n_max_radial + 1) * (basis_size_radial + 1);
+  const int num_angular_basis = (n_max_angular + 1) * (basis_size_angular + 1);
+  const int num_c_radial = num_channels * num_radial_basis;
+  const int num_descriptor_parameters = num_c_radial + num_channels * num_angular_basis;
+  std::vector<float> descriptor_parameters(num_descriptor_parameters);
+
+  for (int channel = 0; channel < num_channels; ++channel) {
+    for (int basis = 0; basis < num_radial_basis; ++basis) {
+      descriptor_parameters[channel * num_radial_basis + basis] =
+        parameters[descriptor_offset + basis * num_channels + channel];
+    }
+    for (int basis = 0; basis < num_angular_basis; ++basis) {
+      descriptor_parameters[num_c_radial + channel * num_angular_basis + basis] =
+        parameters[descriptor_offset + num_c_radial + basis * num_channels + channel];
+    }
+  }
+
+  for (int n = 0; n < num_descriptor_parameters; ++n) {
+    parameters[descriptor_offset + n] = descriptor_parameters[n];
+  }
+}
+
+inline void descriptor_parameters_to_basis_major(
+  float* parameters,
+  const int descriptor_offset,
+  const int num_channels,
+  const int n_max_radial,
+  const int n_max_angular,
+  const int basis_size_radial,
+  const int basis_size_angular)
+{
+  const int num_radial_basis = (n_max_radial + 1) * (basis_size_radial + 1);
+  const int num_angular_basis = (n_max_angular + 1) * (basis_size_angular + 1);
+  const int num_c_radial = num_channels * num_radial_basis;
+  const int num_descriptor_parameters = num_c_radial + num_channels * num_angular_basis;
+  std::vector<float> descriptor_parameters(num_descriptor_parameters);
+
+  for (int channel = 0; channel < num_channels; ++channel) {
+    for (int basis = 0; basis < num_radial_basis; ++basis) {
+      descriptor_parameters[basis * num_channels + channel] =
+        parameters[descriptor_offset + channel * num_radial_basis + basis];
+    }
+    for (int basis = 0; basis < num_angular_basis; ++basis) {
+      descriptor_parameters[num_c_radial + basis * num_channels + channel] =
+        parameters[descriptor_offset + num_c_radial + channel * num_angular_basis + basis];
+    }
+  }
+
+  for (int n = 0; n < num_descriptor_parameters; ++n) {
+    parameters[descriptor_offset + n] = descriptor_parameters[n];
+  }
+}


### PR DESCRIPTION
# **Summary**

Improve the internal access pattern of descriptor parameters and fix NEP89 fine-tuning.

# **Modification**

- Store descriptor parameters in channel-major order internally while preserving the existing `nep.txt` and `nep.restart` formats.
- Update all related NEP training paths.
- Add dedicated compatibility checks for fine-tuning.
- Update the documentation.

# **Validation**

Standard training, restart, and NEP89 fine-tuning were tested.

# **Licensing** (Please read and confirm before submitting this pull request)

By submitting this pull request, I agree that my contribution will be included in GPUMD and redistributed under the existing GPUMD license. Newly added source files follow the existing GPUMD license-header style when applicable. No external source code with incompatible licensing has been copied into this pull request.


