### PR TITLE
Add deterministic single-node multi-GPU training for GNEP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
 find_package(CUDAToolkit REQUIRED)
+find_package(Threads REQUIRED)
 
 # MSVC host compiler flags: /utf-8 for Unicode source, /Zc:preprocessor for standards-conforming preprocessor.
 if(MSVC)
@@ -44,7 +45,15 @@ file(GLOB GNEP_SOURCES
     src/utilities/*.cu)
 add_executable(gnep EXCLUDE_FROM_ALL ${GNEP_SOURCES})
 target_include_directories(gnep PRIVATE src)
-target_link_libraries(gnep PRIVATE CUDA::cublas CUDA::cusolver CUDA::cufft)
+target_link_libraries(gnep PRIVATE CUDA::cublas CUDA::cusolver CUDA::cufft Threads::Threads)
+option(GNEP_TEST_DIAGNOSTICS "Export deterministic GNEP training diagnostics" OFF)
+if(GNEP_TEST_DIAGNOSTICS)
+    target_compile_definitions(gnep PRIVATE GNEP_TEST_DIAGNOSTICS)
+endif()
+option(GNEP_TEST_FIXED_SCALER "Keep the GNEP descriptor scaler fixed for gradient tests" OFF)
+if(GNEP_TEST_FIXED_SCALER)
+    target_compile_definitions(gnep PRIVATE USE_FIXED_SCALER)
+endif()
 
 
 # --- NNAP support (enable with -D PKG_NNAP=yes) ---

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -123,8 +123,64 @@ Below we use an explicit example with default parameters (except for the ``type`
   start_lr     1e-3         # new keyword to set the starting learning rate, which should be a non-negative floating-point number
   stop_lr      1e-7         # new keyword to set the stopping learning rate, which should be a non-negative floating-point number
   weight_decay 0.0          # new keyword to set the weight decay parameter, which should be a non-negative floating-point number
-  batch        2            # same usage as in nep.in but favors small values
+  batch        2            # global batch size; it does not grow with the number of visible GPUs
   epoch        50           # one epoch equals #structures/#batchsize training steps
+  seed         20260831     # optional non-negative seed for parameter initialization and batch shuffling
+
+GNEP uses every GPU made visible through ``CUDA_VISIBLE_DEVICES`` on one node.
+Each complete configuration belongs to exactly one GPU shard; configurations
+are never split across devices. A training step still performs one global Adam
+update, so ``batch`` has the same meaning for one, two, or more GPUs. For
+example, the following commands run an otherwise identical deterministic job
+on one, two, and four GPUs::
+
+  CUDA_VISIBLE_DEVICES=0 ./gnep
+  CUDA_VISIBLE_DEVICES=0,1 ./gnep
+  CUDA_VISIBLE_DEVICES=0,1,2,3 ./gnep
+
+Global batch size and multi-GPU efficiency
+------------------------------------------
+
+The ``batch`` keyword is the number of complete configurations used by one
+global Adam update across all visible GPUs. It is a global batch size, not a
+per-GPU batch size, and it must be kept unchanged when comparing otherwise
+identical one-, two-, and four-GPU runs. Changing ``batch`` changes the
+optimization problem seen by each Adam step and can therefore change the
+training trajectory.
+
+GNEP distributes complete configurations and never splits the atoms or
+neighbor graph of one configuration across GPUs. Consequently, the number of
+active GPUs in a step is::
+
+  min(number of visible GPUs, number of configurations in the current batch)
+
+``batch 1`` is valid and follows the same training algorithm, but only one GPU
+can perform useful work in each step. To allow every visible GPU to participate,
+use a global batch of at least 2 for two GPUs or at least 4 for four GPUs. The
+last incomplete batch of an epoch can use fewer GPUs when it contains fewer
+configurations. For example, a global batch of 4 is analogous to assigning one
+configuration to each of four GPUs before one synchronized Adam update; it is
+not equivalent to four independent ``batch 1`` updates.
+
+Multi-GPU efficiency depends on the amount of work in each global batch. Very
+small configurations or a small global batch can be slower on multiple GPUs
+because host worker startup, gradient reduction, and synchronization dominate
+the GPU computation. Increase ``batch`` only as permitted by GPU memory and the
+desired optimization behavior. Benchmark with the same global batch, dataset,
+seed, and number of epochs on every GPU count, and exclude the first warm-up
+step when reporting step time.
+
+As a reference rather than a hardware-independent guarantee, a validation run
+with 3810 training configurations, 100 test configurations, global ``batch 80``,
+and RTX 4090 GPUs measured median step times of 0.462856, 0.263450, and 0.151553
+seconds on one, two, and four GPUs, respectively. These correspond to 1.76x and
+3.05x speedups, while the serialized loss and RMSE trajectories were identical
+for all three runs.
+
+When ``seed`` is omitted, GNEP retains the historical behavior: parameter
+initialization uses its existing default seed and epoch batch shuffling obtains
+entropy from ``std::random_device``. Model, restart, prediction, and training
+output formats are unchanged.
 
 .. _netcdf_setup:
 .. index::

--- a/src/main_gnep/adam.cu
+++ b/src/main_gnep/adam.cu
@@ -22,6 +22,7 @@
 ------------------------------------------------------------------------------*/
  
 #include "adam.cuh"
+#include "device_guard.cuh"
 #include "parameters.cuh"
 #include "utilities/error.cuh"
 #include <chrono>
@@ -129,12 +130,10 @@ __global__ void apply_gradient_clipping(float* grad, int n, float norm, float ma
   }
 }
 
-void clip_gradients(int step, float* d_grad, int size) 
+void clip_gradients(float* d_grad, int size, float* d_norm)
 {
   static float avg_norm = -1.0f; 
 
-  float* d_norm;
-  CHECK(cudaMalloc(&d_norm, sizeof(float)));
   CHECK(cudaMemset(d_norm, 0, sizeof(float)));
   
   // calculate the norm of the gradient
@@ -160,11 +159,11 @@ void clip_gradients(int step, float* d_grad, int size)
   
   apply_gradient_clipping<<<grid_size, block_size>>>(d_grad, size, h_norm, max_norm);
   
-  CHECK(cudaFree(d_norm));
 }
 
 Adam::Adam(Parameters& para)
 {
+  DeviceGuard guard(0);
   // initialize the parameters
   number_of_variables = para.number_of_variables;
   weight_decay = para.weight_decay;
@@ -175,13 +174,20 @@ Adam::Adam(Parameters& para)
   v.resize(number_of_variables, 0.0f);
 
   // initialize the GPU vectors
-  cudaSetDevice(0);
   gpu_parameters.resize(number_of_variables);
-  gpu_m.resize(number_of_variables);
-  gpu_v.resize(number_of_variables);
+  gpu_m.resize(number_of_variables, 0.0f);
+  gpu_v.resize(number_of_variables, 0.0f);
+  gpu_gradient.resize(number_of_variables);
+  gpu_gradient_norm.resize(1);
   curand_states.resize(number_of_variables);
-  initialize_curand_states<<<(number_of_variables - 1) / 128 + 1, 128>>>(curand_states.data(), number_of_variables, 1234567);
+  initialize_curand_states<<<(number_of_variables - 1) / 128 + 1, 128>>>(
+    curand_states.data(), number_of_variables, para.seed);
   GPU_CHECK_KERNEL
+}
+
+Adam::~Adam()
+{
+  cudaSetDevice(0);
 }
 
 static __global__ void gpu_create_paramters(
@@ -222,9 +228,9 @@ static __global__ void gpu_create_paramters(
 
 void Adam::initialize_parameters(Parameters& para)
 {
+  DeviceGuard guard(0);
   FILE* fid_restart = fopen("gnep.restart", "r");
   if (fid_restart == NULL) {
-    cudaSetDevice(0); // normally use GPU-0
     gpu_create_paramters<<<(number_of_variables - 1) / 128 + 1, 128>>>(
       para.dim,
       para.num_types,
@@ -242,21 +248,25 @@ void Adam::initialize_parameters(Parameters& para)
         PRINT_SCANF_ERROR(count, 1, "Reading error for gnep.restart.");
     }
     fclose(fid_restart);
-    cudaSetDevice(0); // normally use GPU-0
     gpu_parameters.copy_from_host(parameters.data());
   }
 }
 
-void Adam::update(float lr, float* gradients) {
+void Adam::update(float lr, const std::vector<float>& gradients) {
+  DeviceGuard guard(0);
+  if (static_cast<int>(gradients.size()) != number_of_variables) {
+    PRINT_INPUT_ERROR("Global gradient size does not match the number of variables.");
+  }
   const int block_size = 256;
   const int grid_size = (number_of_variables + block_size - 1) / block_size + 1;
 
-  clip_gradients(step, gradients, number_of_variables);
+  gpu_gradient.copy_from_host(gradients.data());
+  clip_gradients(gpu_gradient.data(), number_of_variables, gpu_gradient_norm.data());
   update_moments<<<grid_size, block_size>>>(
     number_of_variables,
     beta1,
     beta2,
-    gradients,
+    gpu_gradient.data(),
     gpu_m.data(),
     gpu_v.data()
   );
@@ -285,7 +295,7 @@ void Adam::update(float lr, float* gradients) {
 }
 
 void Adam::output_parameters(Parameters& para) {
-  cudaSetDevice(0); 
+  DeviceGuard guard(0);
   gpu_parameters.copy_to_host(parameters.data());
   FILE* fid = fopen("gnep.restart", "w");
   for (int i = 0; i < number_of_variables; ++i) {
@@ -296,5 +306,17 @@ void Adam::output_parameters(Parameters& para) {
 
 float* Adam::get_parameters()
 {
+  CHECK(cudaSetDevice(0));
   return parameters.data();
 }
+
+#ifdef GNEP_TEST_DIAGNOSTICS
+void Adam::copy_moments_to_host(std::vector<float>& first, std::vector<float>& second)
+{
+  DeviceGuard guard(0);
+  first.resize(number_of_variables);
+  second.resize(number_of_variables);
+  gpu_m.copy_to_host(first.data());
+  gpu_v.copy_to_host(second.data());
+}
+#endif

--- a/src/main_gnep/adam.cuh
+++ b/src/main_gnep/adam.cuh
@@ -26,12 +26,16 @@ class Adam
 {
 public:
   Adam(Parameters&);
+  ~Adam();
 
   // void zero_gradients();
-  void update(float lr, float* gradients); // Update moments and parameters
+  void update(float lr, const std::vector<float>& gradients); // Update moments and parameters
   float* get_parameters(); // get current parameters pointer
   void output_parameters(Parameters& para); // Output parameters
   void initialize_parameters(Parameters& para); // Initialize optimizer parameters
+#ifdef GNEP_TEST_DIAGNOSTICS
+  void copy_moments_to_host(std::vector<float>& first, std::vector<float>& second);
+#endif
 
 protected:
   // random number generator
@@ -56,5 +60,7 @@ protected:
   GPU_Vector<float> gpu_parameters; // Parameters to be optimized θ
   GPU_Vector<float> gpu_m; // First moment m
   GPU_Vector<float> gpu_v; // Second moment v
+  GPU_Vector<float> gpu_gradient; // Host-reduced global gradient
+  GPU_Vector<float> gpu_gradient_norm; // Clipping workspace
 
 };

--- a/src/main_gnep/dataset.cu
+++ b/src/main_gnep/dataset.cu
@@ -21,6 +21,13 @@
 #include "utilities/gnep_utilities.cuh"
 #include <algorithm> 
 
+Dataset::~Dataset()
+{
+  if (device_id >= 0) {
+    cudaSetDevice(device_id);
+  }
+}
+
 void Dataset::copy_structures(std::vector<Structure>& structures_input, int n1, int n2)
 {
   Nc = n2 - n1;
@@ -348,6 +355,7 @@ void Dataset::find_neighbor(Parameters& para)
 void Dataset::construct(
   Parameters& para, std::vector<Structure>& structures_input, bool require_grad, int n1, int n2, int device_id)
 {
+  this->device_id = device_id;
   CHECK(cudaSetDevice(device_id));
   copy_structures(structures_input, n1, n2);
   find_has_type(para);

--- a/src/main_gnep/dataset.cuh
+++ b/src/main_gnep/dataset.cuh
@@ -22,6 +22,10 @@ class Parameters;
 class Dataset
 {
 public:
+  Dataset() = default;
+  ~Dataset();
+
+  int device_id = -1;
   int Nc;             // number of configurations
   int N;              // total number of atoms (sum of Na[])
   int max_Na;         // number of atoms in the largest configuration

--- a/src/main_gnep/device_guard.cuh
+++ b/src/main_gnep/device_guard.cuh
@@ -1,0 +1,42 @@
+/*
+    Copyright 2017 Zheyong Fan and GPUMD development team
+    @author: Hongfu Huang
+    @mail: hfhuang@buaa.edu.cn
+    This file is part of GNEP.
+    GPUMD is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+*/
+
+#pragma once
+
+#include "utilities/error.cuh"
+#include <cuda_runtime.h>
+
+class DeviceGuard
+{
+public:
+  explicit DeviceGuard(const int device_id)
+  {
+    CHECK(cudaGetDevice(&previous_device_));
+    if (previous_device_ != device_id) {
+      CHECK(cudaSetDevice(device_id));
+      changed_ = true;
+    }
+  }
+
+  ~DeviceGuard()
+  {
+    if (changed_) {
+      cudaSetDevice(previous_device_);
+    }
+  }
+
+  DeviceGuard(const DeviceGuard&) = delete;
+  DeviceGuard& operator=(const DeviceGuard&) = delete;
+
+private:
+  int previous_device_ = 0;
+  bool changed_ = false;
+};

--- a/src/main_gnep/fitness.cu
+++ b/src/main_gnep/fitness.cu
@@ -26,7 +26,53 @@
 #include <iostream>
 #include <random>
 #include <sstream>
+#include <thread>
 #include <vector>
+
+#ifdef GNEP_TEST_DIAGNOSTICS
+static void write_diagnostic_values(
+  const char* filename, const float* values, const int count)
+{
+  FILE* output = my_fopen(filename, "w");
+  for (int i = 0; i < count; ++i) {
+    fprintf(output, "%.9e\n", values[i]);
+  }
+  fclose(output);
+}
+
+static void write_diagnostic_values(
+  const char* filename, const std::vector<float>& values)
+{
+  write_diagnostic_values(filename, values.data(), static_cast<int>(values.size()));
+}
+
+static void write_diagnostic_values(
+  const char* filename, const std::vector<double>& values)
+{
+  FILE* output = my_fopen(filename, "w");
+  for (const double value : values) {
+    fprintf(output, "%.17e\n", value);
+  }
+  fclose(output);
+}
+#endif
+
+static __global__ void reduce_configuration_gradients(
+  const int num_configurations,
+  const int num_variables,
+  const double* configuration_gradients,
+  double* local_gradient)
+{
+  const int variable = threadIdx.x + blockIdx.x * blockDim.x;
+  if (variable >= num_variables) {
+    return;
+  }
+  double sum = 0.0;
+  for (int configuration = 0; configuration < num_configurations; ++configuration) {
+    sum += configuration_gradients[configuration * num_variables + variable];
+  }
+  local_gradient[variable] = sum;
+}
 
 Fitness::Fitness(Parameters& para, Adam* adam)
   : optimizer(adam)
@@ -41,6 +87,10 @@ Fitness::Fitness(Parameters& para, Adam* adam)
   int deviceCount;
   CHECK(cudaGetDeviceCount(&deviceCount));
 
+#ifdef GNEP_TEST_DIAGNOSTICS
+  std::remove("gnep_diagnostic_shards.tsv");
+#endif
+
   std::vector<Structure> structures_train;
   read_structures(true, para, structures_train);
   num_batches = (structures_train.size() - 1) / para.batch_size + 1;
@@ -54,9 +104,10 @@ Fitness::Fitness(Parameters& para, Adam* adam)
   }
 
   train_set.resize(num_batches);
-  for (int batch_id = 0; batch_id < num_batches; ++batch_id) {
-    train_set[batch_id].resize(deviceCount);
-  }
+  batch_indices.resize(num_batches);
+  batch_type_sums.resize(num_batches);
+  batch_energies.resize(num_batches);
+  std::vector<GNEPDeviceCapacity> capacities(deviceCount);
   int count = 0;
   for (int batch_id = 0; batch_id < num_batches; ++batch_id) {
     const int batch_size_minimal = structures_train.size() / num_batches;
@@ -64,29 +115,131 @@ Fitness::Fitness(Parameters& para, Adam* adam)
       batch_id + batch_size_minimal * num_batches < structures_train.size();
     const int batch_size = is_larger_batch ? batch_size_minimal + 1 : batch_size_minimal;
     count += batch_size;
+    const int batch_begin = count - batch_size;
+    const int active_devices = std::min(deviceCount, batch_size);
+    GNEPTrainingBatch& batch = train_set[batch_id];
+    batch.num_configurations = batch_size;
+    batch.shards.resize(active_devices);
+    batch.configuration_indices.resize(active_devices);
+    batch.output_structures.insert(
+      batch.output_structures.end(),
+      structures_train.begin() + batch_begin,
+      structures_train.begin() + count);
+
+    std::vector<int> ranked_indices(batch_size);
+    for (int i = 0; i < batch_size; ++i) {
+      ranked_indices[i] = batch_begin + i;
+    }
+    std::stable_sort(
+      ranked_indices.begin(), ranked_indices.end(), [&](const int lhs, const int rhs) {
+        if (structures_train[lhs].num_atom != structures_train[rhs].num_atom) {
+          return structures_train[lhs].num_atom > structures_train[rhs].num_atom;
+        }
+        return lhs < rhs;
+      });
+    std::vector<int> atom_load(active_devices, 0);
+    for (const int configuration_index : ranked_indices) {
+      int target = 0;
+      for (int device_id = 1; device_id < active_devices; ++device_id) {
+        if (atom_load[device_id] < atom_load[target]) {
+          target = device_id;
+        }
+      }
+      batch.configuration_indices[target].push_back(configuration_index);
+      atom_load[target] += structures_train[configuration_index].num_atom;
+    }
+    for (int device_id = 0; device_id < active_devices; ++device_id) {
+      std::sort(
+        batch.configuration_indices[device_id].begin(),
+        batch.configuration_indices[device_id].end());
+#ifdef GNEP_TEST_DIAGNOSTICS
+      FILE* shard_output = my_fopen("gnep_diagnostic_shards.tsv", "a");
+      for (const int configuration_index : batch.configuration_indices[device_id]) {
+        fprintf(
+          shard_output,
+          "%d\t%d\t%d\t%d\n",
+          batch_id,
+          device_id,
+          configuration_index,
+          structures_train[configuration_index].num_atom);
+      }
+      fclose(shard_output);
+#endif
+    }
+
     printf("\nBatch %d:\n", batch_id);
-    printf("Number of configurations = %d.\n", batch_size);
-    for (int device_id = 0; device_id < deviceCount; ++device_id) {
+    printf(
+      "Number of configurations = %d; active devices = %d.\n",
+      batch_size,
+      active_devices);
+    for (int device_id = 0; device_id < active_devices; ++device_id) {
       print_line_1();
-      printf("Constructing train_set in device  %d.\n", device_id);
+      printf(
+        "Constructing shard on device %d: %zu configurations, %d atoms.\n",
+        device_id,
+        batch.configuration_indices[device_id].size(),
+        atom_load[device_id]);
       CHECK(cudaSetDevice(device_id));
-      train_set[batch_id][device_id].construct(
-        para, structures_train, true, count - batch_size, count, device_id);
+      std::vector<Structure> shard_structures;
+      shard_structures.reserve(batch.configuration_indices[device_id].size());
+      for (const int configuration_index : batch.configuration_indices[device_id]) {
+        shard_structures.push_back(structures_train[configuration_index]);
+      }
+      batch.shards[device_id].construct(
+        para, shard_structures, true, 0, shard_structures.size(), device_id);
+      const Dataset& shard = batch.shards[device_id];
+      capacities[device_id].max_atoms = std::max(capacities[device_id].max_atoms, shard.N);
+      capacities[device_id].max_training_atoms =
+        std::max(capacities[device_id].max_training_atoms, shard.N);
+      capacities[device_id].max_configurations =
+        std::max(capacities[device_id].max_configurations, shard.Nc);
+      capacities[device_id].max_radial_pairs =
+        std::max(capacities[device_id].max_radial_pairs, shard.N * shard.max_NN_radial);
+      capacities[device_id].max_angular_pairs =
+        std::max(capacities[device_id].max_angular_pairs, shard.N * shard.max_NN_angular);
       print_line_2();
     }
+
+    batch_type_sums[batch_id].assign(para.num_types, 0);
+    for (int configuration_index = batch_begin; configuration_index < count; ++configuration_index) {
+      const Structure& structure = structures_train[configuration_index];
+      batch.num_atoms += structure.num_atom;
+      batch.virial_components += structure.has_virial ? 6 : 0;
+      batch_energies[batch_id] += structure.energy;
+      for (const int type : structure.type) {
+        ++batch_type_sums[batch_id][type];
+      }
+    }
+    int batch_max_radial_neighbors = 0;
+    int batch_max_angular_neighbors = 0;
+    for (const Dataset& shard : batch.shards) {
+      batch_max_radial_neighbors =
+        std::max(batch_max_radial_neighbors, shard.max_NN_radial);
+      batch_max_angular_neighbors =
+        std::max(batch_max_angular_neighbors, shard.max_NN_angular);
+    }
+    capacities[0].max_atoms = std::max(capacities[0].max_atoms, batch.num_atoms);
+    capacities[0].max_radial_pairs = std::max(
+      capacities[0].max_radial_pairs, batch.num_atoms * batch_max_radial_neighbors);
+    capacities[0].max_angular_pairs = std::max(
+      capacities[0].max_angular_pairs, batch.num_atoms * batch_max_angular_neighbors);
+    batch_indices[batch_id] = batch_id;
   }
 
   std::vector<Structure> structures_test;
   has_test_set = read_structures(false, para, structures_test);
   if (has_test_set) {
-    test_set.resize(deviceCount);
-    for (int device_id = 0; device_id < deviceCount; ++device_id) {
-      print_line_1();
-      printf("Constructing test_set in device  %d.\n", device_id);
-      CHECK(cudaSetDevice(device_id));
-      test_set[device_id].construct(para, structures_test, false, 0, structures_test.size(), device_id);
-      print_line_2();
-    }
+    test_set.resize(1);
+    print_line_1();
+    printf("Constructing test_set on device 0.\n");
+    CHECK(cudaSetDevice(0));
+    test_set[0].construct(para, structures_test, false, 0, structures_test.size(), 0);
+    capacities[0].max_atoms = std::max(capacities[0].max_atoms, test_set[0].N);
+    capacities[0].max_radial_pairs =
+      std::max(capacities[0].max_radial_pairs, test_set[0].N * test_set[0].max_NN_radial);
+    capacities[0].max_angular_pairs =
+      std::max(capacities[0].max_angular_pairs, test_set[0].N * test_set[0].max_NN_angular);
+    print_line_2();
   }
 
   N = -1;
@@ -95,9 +248,6 @@ Fitness::Fitness(Parameters& para, Adam* adam)
   max_NN_radial = -1;
   max_NN_angular = -1;
 
-  batch_indices.resize(num_batches);
-  batch_type_sums.resize(num_batches);
-  batch_energies.resize(num_batches);
   if (has_test_set) {
     N = test_set[0].N;
     N_times_max_NN_radial = test_set[0].N * test_set[0].max_NN_radial;
@@ -106,31 +256,34 @@ Fitness::Fitness(Parameters& para, Adam* adam)
     max_NN_angular = test_set[0].max_NN_angular;
   }
   for (int n = 0; n < num_batches; ++n) {
-    if (train_set[n][0].N > N) {
-      N = train_set[n][0].N;
+    GNEPTrainingBatch& batch = train_set[n];
+    int batch_max_radial_neighbors = 0;
+    int batch_max_angular_neighbors = 0;
+    for (const Dataset& shard : batch.shards) {
+      batch_max_radial_neighbors =
+        std::max(batch_max_radial_neighbors, shard.max_NN_radial);
+      batch_max_angular_neighbors =
+        std::max(batch_max_angular_neighbors, shard.max_NN_angular);
+    }
+    if (batch.num_atoms > N) {
+      N = batch.num_atoms;
     };
-    if (train_set[n][0].N * train_set[n][0].max_NN_radial > N_times_max_NN_radial) {
-      N_times_max_NN_radial = train_set[n][0].N * train_set[n][0].max_NN_radial;
+    if (batch.num_atoms * batch_max_radial_neighbors > N_times_max_NN_radial) {
+      N_times_max_NN_radial = batch.num_atoms * batch_max_radial_neighbors;
     };
-    if (train_set[n][0].N * train_set[n][0].max_NN_angular > N_times_max_NN_angular) {
-      N_times_max_NN_angular = train_set[n][0].N * train_set[n][0].max_NN_angular;
+    if (batch.num_atoms * batch_max_angular_neighbors > N_times_max_NN_angular) {
+      N_times_max_NN_angular = batch.num_atoms * batch_max_angular_neighbors;
     };
 
-    if (train_set[n][0].max_NN_radial > max_NN_radial) {
-      max_NN_radial = train_set[n][0].max_NN_radial;
+    if (batch_max_radial_neighbors > max_NN_radial) {
+      max_NN_radial = batch_max_radial_neighbors;
     }
-    if (train_set[n][0].max_NN_angular > max_NN_angular) {
-      max_NN_angular = train_set[n][0].max_NN_angular;
+    if (batch_max_angular_neighbors > max_NN_angular) {
+      max_NN_angular = batch_max_angular_neighbors;
     }
-    batch_indices[n] = n;
-    std::vector<int> type_sum_host(para.num_types);
-    train_set[n][0].type_sum.copy_to_host(type_sum_host.data());
-    batch_type_sums[n] = type_sum_host;
-    batch_energies[n] = train_set[n][0].sum_energy_ref;
   }
 
-  potential.reset(
-    new GNEP(para, N, N_times_max_NN_radial, N_times_max_NN_angular, deviceCount));
+  potential.reset(new GNEP(para, capacities));
     
   if (para.prediction == 0) {
     fid_loss_out = my_fopen("loss.out", "a");
@@ -159,6 +312,7 @@ void Fitness::compute(Parameters& para)
 
   if (para.prediction == 0) {
     if (para.energy_shift) {
+      CHECK(cudaSetDevice(0));
       computeMultiBatchEnergyShiftUniform(
         para.num_types,
         num_batches,
@@ -190,79 +344,221 @@ void Fitness::compute(Parameters& para)
 
     optimizer->initialize_parameters(para);
     float* parameters = optimizer->get_parameters();
-    for (int n = 0; n < num_batches; ++n) {
-      potential->find_force(
-        para,
-        parameters,
-        false,
-        train_set[n],
-#ifdef USE_FIXED_SCALER
-        false,
-#else
-        true,
+#ifdef GNEP_TEST_DIAGNOSTICS
+    write_diagnostic_values(
+      "gnep_diagnostic_initial_parameters.txt", parameters, number_of_variables);
 #endif
-        true,
-        1);
+    for (int n = 0; n < num_batches; ++n) {
+      GNEPTrainingBatch& batch = train_set[n];
+      std::vector<std::thread> workers;
+      for (int device_id = 0; device_id < static_cast<int>(batch.shards.size()); ++device_id) {
+        workers.emplace_back([&, device_id]() {
+          potential->find_force(
+            para,
+            parameters,
+            false,
+            batch.shards,
+#ifdef USE_FIXED_SCALER
+            false,
+#else
+            true,
+#endif
+            true,
+            device_id,
+            1,
+            batch.num_configurations,
+            batch.num_atoms,
+            batch.virial_components);
+        });
+      }
+      for (std::thread& worker : workers) {
+        worker.join();
+      }
     }
-    float mse_energy;
-    float mse_force;
-    float mse_virial;
-    int count;
-    int count_virial;
+    para.reduce_and_broadcast_scaler();
+#ifdef GNEP_TEST_DIAGNOSTICS
+    write_diagnostic_values("gnep_diagnostic_scaler.txt", para.q_scaler_cpu);
+#endif
+    double energy_squared_error = 0.0;
+    double force_squared_error = 0.0;
+    double virial_squared_error = 0.0;
+    int count = 0;
+    int count_force = 0;
+    int count_virial = 0;
     int epoch = 0;
-    clock_t time_begin;
-    clock_t time_finish;
+    std::chrono::steady_clock::time_point time_begin;
     static float track_total_time = 0.0f; 
+    std::mt19937 shuffle_rng;
+    if (para.is_seed_set) {
+      shuffle_rng.seed(static_cast<unsigned int>(para.seed));
+    } else {
+      std::random_device rd;
+      shuffle_rng.seed(rd());
+    }
     for (int step = 0; step < maximum_steps; ++step) {
       int batch_id = step % num_batches;
       if (batch_id == 0) {
-        std::random_device rd;
-        std::mt19937 g(rd());
-        std::shuffle(batch_indices.begin(), batch_indices.end(), g);
-        time_begin = clock();
-        mse_energy = 0.0f;
-        mse_force = 0.0f;
-        mse_virial = 0.0f;
+        std::shuffle(batch_indices.begin(), batch_indices.end(), shuffle_rng);
+        time_begin = std::chrono::steady_clock::now();
+        energy_squared_error = 0.0;
+        force_squared_error = 0.0;
+        virial_squared_error = 0.0;
         count = 0;
+        count_force = 0;
         count_virial = 0;
       }
       batch_id = batch_indices[batch_id];
-      int Nc = train_set[batch_id][0].Nc;
-      int virial_Nc = train_set[batch_id][0].sum_virial_Nc;
+      GNEPTrainingBatch& batch = train_set[batch_id];
+      int Nc = batch.num_configurations;
       if (para.lr_restart_enable) {
         update_learning_rate_cos_restart(lr, step, num_batches, para);
       } else {
         update_learning_rate_cos(lr, step, num_batches, para);
       }
-      potential->find_force(
-      para,
-      parameters,
-      true,
-      train_set[batch_id],
-      false,
-      true,
-      deviceCount);
-      auto mse_energy_array = train_set[batch_id][0].get_mse_energy(para, true, 0);
-      auto mse_force_array = train_set[batch_id][0].get_mse_force(para, true, 0);
-      auto mse_virial_array = train_set[batch_id][0].get_mse_virial(para, true, 0);
-      float mse_energy_train = mse_energy_array.back();
-      float mse_force_train = mse_force_array.back();
-      float mse_virial_train = mse_virial_array.back();
-      mse_energy += mse_energy_train * Nc;
-      mse_force += mse_force_train * Nc;
-      mse_virial += mse_virial_train * virial_Nc;
+      const auto step_begin = std::chrono::steady_clock::now();
+      std::vector<std::thread> workers;
+      for (int device_id = 0; device_id < static_cast<int>(batch.shards.size()); ++device_id) {
+        workers.emplace_back([&, device_id]() {
+          potential->find_force(
+            para,
+            parameters,
+            true,
+            batch.shards,
+            false,
+            true,
+            device_id,
+            1,
+            batch.num_configurations,
+            batch.num_atoms,
+            batch.virial_components);
+        });
+      }
+      for (std::thread& worker : workers) {
+        worker.join();
+      }
+
+      double energy_error_sum = 0.0;
+      double force_error_sum = 0.0;
+      double virial_error_sum = 0.0;
+      std::vector<double> reduced_gradient(number_of_variables, 0.0);
+      for (int device_id = 0; device_id < static_cast<int>(batch.shards.size()); ++device_id) {
+        Dataset& shard = batch.shards[device_id];
+        const auto mse_energy_array = shard.get_mse_energy(para, true, device_id);
+        shard.get_mse_force(para, true, device_id);
+        const auto mse_virial_array = shard.get_mse_virial(para, true, device_id);
+        energy_error_sum += mse_energy_array.back() * shard.Nc;
+        // Rebuild the global force numerator from complete configuration
+        // shards. Division by 3*N_global happens only after all shards have
+        // contributed.
+        for (int configuration = 0; configuration < shard.Nc; ++configuration) {
+          const double weight = shard.weight_cpu[configuration];
+          force_error_sum += weight * weight * shard.error_cpu_f[configuration];
+        }
+        virial_error_sum += mse_virial_array.back() * shard.sum_virial_Nc * 6;
+
+        CHECK(cudaSetDevice(device_id));
+        Gradients& gradients = potential->getGradients(device_id);
+        const int reduction_block_size = 256;
+        const int reduction_grid_size =
+          (number_of_variables + reduction_block_size - 1) / reduction_block_size;
+        reduce_configuration_gradients<<<reduction_grid_size, reduction_block_size>>>(
+          shard.Nc,
+          number_of_variables,
+          gradients.grad_sum.data(),
+          gradients.local_sum.data());
+        GPU_CHECK_KERNEL
+        std::vector<double> local_gradient(number_of_variables, 0.0);
+        gradients.local_sum.copy_to_host(local_gradient.data());
+#ifdef GNEP_TEST_DIAGNOSTICS
+        if (step == 0) {
+          const std::string filename =
+            "gnep_diagnostic_gradient_device" + std::to_string(device_id) + ".txt";
+          write_diagnostic_values(filename.c_str(), local_gradient);
+        }
+#endif
+        for (int variable = 0; variable < number_of_variables; ++variable) {
+          reduced_gradient[variable] += local_gradient[variable];
+        }
+      }
+      std::vector<float> global_gradient(number_of_variables);
+      for (int variable = 0; variable < number_of_variables; ++variable) {
+        global_gradient[variable] = static_cast<float>(reduced_gradient[variable]);
+      }
+#ifdef GNEP_TEST_DIAGNOSTICS
+      if (step == 0) {
+        write_diagnostic_values("gnep_diagnostic_global_gradient.txt", global_gradient);
+      }
+#endif
+
+      float mse_energy_train = static_cast<float>(energy_error_sum / batch.num_configurations);
+      float mse_force_train = static_cast<float>(
+        force_error_sum / (batch.num_atoms * 3.0));
+      float mse_virial_train = batch.virial_components > 0
+        ? static_cast<float>(virial_error_sum / batch.virial_components)
+        : 0.0f;
+#ifdef GNEP_TEST_DIAGNOSTICS
+      if (step == 0) {
+        FILE* metrics = my_fopen("gnep_diagnostic_metrics.tsv", "w");
+        fprintf(
+          metrics,
+          "global\t%d\t%d\t%d\t%.17e\t%.17e\t%.17e\n",
+          batch.num_configurations,
+          batch.num_atoms,
+          batch.virial_components,
+          mse_energy_train,
+          mse_force_train,
+          mse_virial_train);
+        for (int device_id = 0; device_id < static_cast<int>(batch.shards.size()); ++device_id) {
+          const Dataset& shard = batch.shards[device_id];
+          fprintf(
+            metrics,
+            "device%d\t%d\t%d\t%d\n",
+            device_id,
+            shard.Nc,
+            shard.N,
+            shard.sum_virial_Nc * 6);
+        }
+        fclose(metrics);
+      }
+#endif
+      energy_squared_error += energy_error_sum;
+      force_squared_error += force_error_sum;
+      virial_squared_error += virial_error_sum;
       count += Nc;
-      count_virial += virial_Nc;
-      auto& grad = potential->getGradients();
-      optimizer->update(lr, grad.grad_sum.data());
+      count_force += batch.num_atoms * 3;
+      count_virial += batch.virial_components;
+      optimizer->update(lr, global_gradient);
+#ifdef GNEP_TEST_DIAGNOSTICS
+      if (step == 0) {
+        write_diagnostic_values(
+          "gnep_diagnostic_updated_parameters.txt", parameters, number_of_variables);
+        std::vector<float> first_moment;
+        std::vector<float> second_moment;
+        optimizer->copy_moments_to_host(first_moment, second_moment);
+        write_diagnostic_values("gnep_diagnostic_first_moment.txt", first_moment);
+        write_diagnostic_values("gnep_diagnostic_second_moment.txt", second_moment);
+      }
+#endif
+      const float step_seconds = std::chrono::duration<float>(
+        std::chrono::steady_clock::now() - step_begin).count();
+      printf(
+        "GNEP step %d: visible_gpus=%d active_gpus=%zu configurations=%d atoms=%d wall_time=%.6f s\n",
+        step + 1,
+        deviceCount,
+        batch.shards.size(),
+        batch.num_configurations,
+        batch.num_atoms,
+        step_seconds);
 
       if ((step + 1) % num_batches == 0) {
-        time_finish = clock();
-        float time_used = (time_finish - time_begin) / float(CLOCKS_PER_SEC);
+        float time_used = std::chrono::duration<float>(
+          std::chrono::steady_clock::now() - time_begin).count();
         track_total_time += time_used; 
-        float rmse_energy_train = sqrt(mse_energy / count);
-        float rmse_force_train = sqrt(mse_force / count);
-        float rmse_virial_train = count_virial > 0 ? sqrt(mse_virial / count_virial) : 0.0f;
+        float rmse_energy_train = sqrt(energy_squared_error / count);
+        float rmse_force_train = sqrt(force_squared_error / count_force);
+        float rmse_virial_train = count_virial > 0
+          ? sqrt(virial_squared_error / count_virial)
+          : 0.0f;
         float total_loss_train = para.lambda_e * rmse_energy_train + para.lambda_f * rmse_force_train + para.lambda_v * rmse_virial_train;
         report_error(
           para,
@@ -309,7 +605,7 @@ void Fitness::compute(Parameters& para)
       tokens = get_tokens(input);
       para.q_scaler_cpu[d] = get_double_from_token(tokens[0], __FILE__, __LINE__);
     }
-    para.q_scaler_gpu[0].copy_from_host(para.q_scaler_cpu.data());
+    para.q_scaler_gpu(0).copy_from_host(para.q_scaler_cpu.data());
     predict(para, parameters.data());
   }
 }
@@ -447,7 +743,7 @@ void Fitness::write_gnep_txt(FILE* fid_gnep, Parameters& para, float* parameters
     fprintf(fid_gnep, "%15.7e\n", parameters[m]);
   }
   CHECK(cudaSetDevice(0));
-  para.q_scaler_gpu[0].copy_to_host(para.q_scaler_cpu.data());
+  para.q_scaler_gpu(0).copy_to_host(para.q_scaler_cpu.data());
   for (int d = 0; d < para.q_scaler_cpu.size(); ++d) {
     fprintf(fid_gnep, "%15.7e\n", para.q_scaler_cpu[d]);
   }
@@ -473,7 +769,18 @@ void Fitness::report_error(
   float rmse_force_test = 0.0f;
   float rmse_virial_test = 0.0f;
   if (has_test_set) {
-    potential->find_force(para, parameters, false, test_set, false, true, 1);
+    potential->find_force(
+      para,
+      parameters,
+      false,
+      test_set,
+      false,
+      true,
+      0,
+      1,
+      test_set[0].Nc,
+      test_set[0].N,
+      test_set[0].sum_virial_Nc * 6);
     auto mse_energy_test_array = test_set[0].get_mse_energy(para, false, 0);
     auto mse_force_test_array = test_set[0].get_mse_force(para, false, 0);
     auto mse_virial_test_array = test_set[0].get_mse_virial(para, false, 0);
@@ -597,9 +904,24 @@ void Fitness::predict(Parameters& para, float* parameters)
   FILE* fid_virial = my_fopen("virial_train.out", "w");
   FILE* fid_stress = my_fopen("stress_train.out", "w");
   for (int batch_id = 0; batch_id < num_batches; ++batch_id) {
-    potential->find_force(para, parameters, false, train_set[batch_id], false, true, 1);
+    GNEPTrainingBatch& batch = train_set[batch_id];
+    std::vector<Dataset> output_dataset(1);
+    output_dataset[0].construct(
+      para, batch.output_structures, false, 0, batch.output_structures.size(), 0);
+    potential->find_force(
+      para,
+      parameters,
+      false,
+      output_dataset,
+      false,
+      true,
+      0,
+      1,
+      batch.num_configurations,
+      batch.num_atoms,
+      batch.virial_components);
     update_energy_force_virial(
-      fid_energy, fid_force, fid_virial, fid_stress, train_set[batch_id][0]);
+      fid_energy, fid_force, fid_virial, fid_stress, output_dataset[0]);
   }
   fclose(fid_energy);
   fclose(fid_force);

--- a/src/main_gnep/fitness.cuh
+++ b/src/main_gnep/fitness.cuh
@@ -24,6 +24,16 @@
 
 class Parameters;
 
+struct GNEPTrainingBatch
+{
+  std::vector<Dataset> shards;
+  std::vector<Structure> output_structures;
+  std::vector<std::vector<int>> configuration_indices;
+  int num_configurations = 0;
+  int num_atoms = 0;
+  int virial_components = 0;
+};
+
 class Fitness
 {
 public:
@@ -60,7 +70,7 @@ protected:
   Adam* optimizer;
   FILE* fid_loss_out = NULL;
   std::unique_ptr<Potential> potential;
-  std::vector<std::vector<Dataset>> train_set;
+  std::vector<GNEPTrainingBatch> train_set;
   std::vector<Dataset> test_set;
   std::vector<int> batch_indices;
   std::vector<std::vector<int>> batch_type_sums;

--- a/src/main_gnep/gnep.cu
+++ b/src/main_gnep/gnep.cu
@@ -27,11 +27,13 @@ heat transport, Phys. Rev. B. 104, 104309 (2021).
 #include "dataset.cuh"
 #include "mic.cuh"
 #include "gnep.cuh"
+#include "device_guard.cuh"
 #include "parameters.cuh"
 #include "utilities/common.cuh"
 #include "utilities/error.cuh"
 #include "utilities/gpu_vector.cuh"
 #include "utilities/gnep_utilities.cuh"
+#include <algorithm>
 
 static __global__ void gpu_find_neighbor_list(
   const GNEP::ParaMB paramb,
@@ -218,10 +220,7 @@ static __global__ void find_descriptors_angular(
 
 GNEP::GNEP(
   Parameters& para,
-  int N,
-  int N_times_max_NN_radial,
-  int N_times_max_NN_angular,
-  int deviceCount)
+  const std::vector<GNEPDeviceCapacity>& capacities)
 {
   paramb.use_typewise_cutoff_zbl = para.use_typewise_cutoff_zbl;
   paramb.typewise_cutoff_zbl_factor = para.typewise_cutoff_zbl_factor;
@@ -233,8 +232,6 @@ GNEP::GNEP(
   paramb.n_max_radial = para.n_max_radial;
   paramb.n_max_angular = para.n_max_angular;
   paramb.L_max = para.L_max;
-  paramb.N_times_max_NN_radial = N_times_max_NN_radial;
-  paramb.N_times_max_NN_angular = N_times_max_NN_angular;
   paramb.dim_angular = para.dim_angular;
 
   paramb.basis_size_radial = para.basis_size_radial;
@@ -258,28 +255,62 @@ GNEP::GNEP(
     }
   }
 
-  for (int device_id = 0; device_id < deviceCount; device_id++) {
-    cudaSetDevice(device_id);
-    annmb[device_id].dim = para.dim;
-    annmb[device_id].num_neurons1 = para.num_neurons1;
-    annmb[device_id].num_para = para.number_of_variables;
-    annmb[device_id].num_ann = para.number_of_variables_ann;
+  contexts.reserve(capacities.size());
+  for (int device_id = 0; device_id < static_cast<int>(capacities.size()); ++device_id) {
+    DeviceGuard guard(device_id);
+    std::unique_ptr<DeviceContext> context(new DeviceContext(device_id));
+    context->ann.dim = para.dim;
+    context->ann.num_neurons1 = para.num_neurons1;
+    context->ann.num_para = para.number_of_variables;
+    context->ann.num_ann = para.number_of_variables_ann;
 
-    gnep_data[device_id].NN_radial.resize(N);
-    gnep_data[device_id].NN_angular.resize(N);
-    gnep_data[device_id].NL_radial.resize(N_times_max_NN_radial);
-    gnep_data[device_id].NL_angular.resize(N_times_max_NN_angular);
-    gnep_data[device_id].x12_radial.resize(N_times_max_NN_radial);
-    gnep_data[device_id].y12_radial.resize(N_times_max_NN_radial);
-    gnep_data[device_id].z12_radial.resize(N_times_max_NN_radial);
-    gnep_data[device_id].x12_angular.resize(N_times_max_NN_angular);
-    gnep_data[device_id].y12_angular.resize(N_times_max_NN_angular);
-    gnep_data[device_id].z12_angular.resize(N_times_max_NN_angular);
-    gnep_data[device_id].descriptors.resize(N * annmb[device_id].dim);
-    gnep_data[device_id].Fp.resize(N * annmb[device_id].dim);
-    gnep_data[device_id].sum_fxyz.resize(N * (paramb.n_max_angular + 1) * NUM_OF_ABC);
-    gnep_data[device_id].parameters.resize(annmb[device_id].num_para);
+    const int max_atoms = std::max(1, capacities[device_id].max_atoms);
+    const int max_training_atoms =
+      std::max(1, capacities[device_id].max_training_atoms);
+    const int max_configurations = std::max(1, capacities[device_id].max_configurations);
+    const int max_radial_pairs = std::max(1, capacities[device_id].max_radial_pairs);
+    const int max_angular_pairs = std::max(1, capacities[device_id].max_angular_pairs);
+    GNEP_Data& data = context->data;
+    data.NN_radial.resize(max_atoms);
+    data.NN_angular.resize(max_atoms);
+    data.NL_radial.resize(max_radial_pairs);
+    data.NL_angular.resize(max_angular_pairs);
+    data.x12_radial.resize(max_radial_pairs);
+    data.y12_radial.resize(max_radial_pairs);
+    data.z12_radial.resize(max_radial_pairs);
+    data.x12_angular.resize(max_angular_pairs);
+    data.y12_angular.resize(max_angular_pairs);
+    data.z12_angular.resize(max_angular_pairs);
+    data.descriptors.resize(
+      static_cast<size_t>(max_atoms) * static_cast<size_t>(context->ann.dim));
+    data.Fp.resize(
+      static_cast<size_t>(max_atoms) * static_cast<size_t>(context->ann.dim));
+    data.Fp2.resize(
+      static_cast<size_t>(max_training_atoms) * static_cast<size_t>(context->ann.dim) *
+      static_cast<size_t>(context->ann.dim));
+    data.sum_fxyz.resize(
+      static_cast<size_t>(max_atoms) * static_cast<size_t>(paramb.n_max_angular + 1) *
+      NUM_OF_ABC);
+    data.sum_s2xyz.resize(
+      static_cast<size_t>(max_atoms) * static_cast<size_t>(paramb.n_max_angular + 1) *
+      NUM_OF_ABC * 3);
+    data.sum_s2xyz123.resize(
+      static_cast<size_t>(max_atoms) * static_cast<size_t>(paramb.n_max_angular + 1) *
+      NUM_OF_ABC * 6);
+    data.parameters.resize(context->ann.num_para);
+    context->gradients.allocate(
+      max_training_atoms,
+      max_configurations,
+      para.number_of_variables,
+      para.number_of_variables_ann,
+      para.dim);
+    contexts.emplace_back(std::move(context));
   }
+}
+
+GNEP::DeviceContext::~DeviceContext()
+{
+  cudaSetDevice(device_id);
 }
 
 void GNEP::update_potential(Parameters& para, const float* parameters, ANN& ann)
@@ -295,11 +326,6 @@ void GNEP::update_potential(Parameters& para, const float* parameters, ANN& ann)
     pointer += 1; // type bias stored in ann.w1[t]
   }
   ann.c = pointer;
-}
-
-void GNEP::initialize_gradients(Parameters& para, const int N)
-{
-  gradients.resize(N, para.number_of_variables, para.number_of_variables_ann, para.dim);
 }
 
 static void __global__ find_max_min(const int N, const float* g_q, float* g_s_max, float* g_s_min, float* g_q_scaler)
@@ -359,9 +385,9 @@ static __global__ void apply_ann(
   float* g_E_wb_grad = nullptr)
 {
   int n1 = threadIdx.x + blockIdx.x * blockDim.x;
-  int type = g_type[n1];
 
   if (n1 < N) {
+    const int type = g_type[n1];
     // get descriptors
     float q[MAX_DIM] = {0.0f};
     for (int d = 0; d < annmb.dim; ++d) {
@@ -371,8 +397,14 @@ static __global__ void apply_ann(
     float F = 0.0f, Fp[MAX_DIM] = {0.0f};
     
     if (IsTraining) {
-      int type_offset = n1 * annmb.num_ann + type * ((annmb.dim + 2) * annmb.num_neurons1 + 1); 
-      int type_offset_2 = n1 * annmb.num_ann * annmb.dim + type * ((annmb.dim + 2) * annmb.num_neurons1 + 1) * annmb.dim;
+      const int type_offset =
+        n1 * annmb.num_ann + type * ((annmb.dim + 2) * annmb.num_neurons1 + 1);
+      const size_t type_offset_2 =
+        static_cast<size_t>(n1) * static_cast<size_t>(annmb.num_ann) *
+          static_cast<size_t>(annmb.dim) +
+        static_cast<size_t>(type) *
+          static_cast<size_t>((annmb.dim + 2) * annmb.num_neurons1 + 1) *
+          static_cast<size_t>(annmb.dim);
       apply_ann_one_layer_w2nd(
         annmb.dim,
         annmb.num_neurons1,
@@ -521,6 +553,7 @@ static __global__ void compute_grad_e_without_neighbor(
   const int N,
   const GNEP::ParaMB paramb,
   const GNEP::ANN annmb,
+  const int* __restrict__ g_Na,
   const int Nc,
   const float lambda_e,
   const int* __restrict__ g_batch_idx,
@@ -528,16 +561,22 @@ static __global__ void compute_grad_e_without_neighbor(
   float* __restrict__ g_E_wb_grad,
   const float* __restrict__ g_diff_gpu_e,
   const float* __restrict__ g_weight,
-  float* g_grad_sum)
+  double* g_grad_sum)
 {
   int n1 = threadIdx.x + blockIdx.x * blockDim.x;
   const int w0_index = annmb.dim * annmb.num_neurons1;
   const int b0_index = w0_index + annmb.num_neurons1;
   if (n1 >= N) return;
   int batch_idx = g_batch_idx[n1];
+  g_grad_sum += batch_idx * annmb.num_para;
+  const int Na = g_Na[batch_idx];
   int t1 = g_type[n1];
   float weight = g_weight[batch_idx];
-  const float per_Nc_e = g_diff_gpu_e[batch_idx] * weight * 2.0f * lambda_e / Nc;
+  const float squared_weight = weight * weight;
+  // diff_gpu_e is an error per atom.  The extra 1/Na is therefore the
+  // chain-rule factor for the configuration's mean predicted energy.
+  const float per_Nc_e =
+    g_diff_gpu_e[batch_idx] * squared_weight * 2.0f * lambda_e / Nc / Na;
 
   int t1_net_index = t1 * ((annmb.dim + 2) * annmb.num_neurons1 + 1);
   int n1_net_index = n1 * annmb.num_ann + t1_net_index;
@@ -569,6 +608,7 @@ static __global__ void compute_grad_radial_NM(
   const GNEP::ANN annmb,
   const int* __restrict__ g_Na,
   const int Nc,
+  const int N_global,
   const float lambda_e,
   const float lambda_f,
   const float lambda_v,
@@ -599,7 +639,7 @@ static __global__ void compute_grad_radial_NM(
   const float* __restrict__ g_fz,
   const float* __restrict__ g_q_scaler,
   const float* __restrict__ g_ep_wb,
-  float* g_grad_sum)
+  double* g_grad_sum)
 {
   int NM = N * M;
   int Idx = threadIdx.x + blockIdx.x * blockDim.x;
@@ -611,16 +651,27 @@ static __global__ void compute_grad_radial_NM(
   int neighbor_number = g_NN[n1];
   int neighbor_number_ang = g_NN_ang[n1];
   int batch_idx = g_batch_idx[n1];
+  g_grad_sum += batch_idx * annmb.num_para;
   int Na = g_Na[batch_idx];
   bool no_neighbor_isolated_atom = ((Na == 1) && neighbor_number == 0);
   if (i1 >= neighbor_number && !no_neighbor_isolated_atom) return;
   int t1 = g_type[n1];
   float weight = g_weight[batch_idx];
-  const float per_Nc_e = g_diff_gpu_e[batch_idx] * weight * 2.0f * lambda_e / Nc;
+  const float squared_weight = weight * weight;
+  // These are the complete loss-gradient prefactors: lambda_e is applied here
+  // and must not be applied again during host reduction.  The 1/Na below is a
+  // different factor--the chain rule for the mean configuration energy--
+  // because E_wb_grad stores derivatives of individual atomic energies.
+  // Nc is global across all shards, while Na is configuration-specific.
+  const float per_Nc_e =
+    g_diff_gpu_e[batch_idx] * squared_weight * 2.0f * lambda_e / Nc / Na;
   
   int t1_net_index = t1 * ((annmb.dim + 2) * annmb.num_neurons1 + 1);
   int n1_net_index = n1 * annmb.num_ann + t1_net_index;
-  int n1_net_index_wb = n1 * annmb.num_ann * annmb.dim + t1_net_index * annmb.dim;
+  const size_t n1_net_index_wb =
+    static_cast<size_t>(n1) * static_cast<size_t>(annmb.num_ann) *
+      static_cast<size_t>(annmb.dim) +
+    static_cast<size_t>(t1_net_index) * static_cast<size_t>(annmb.dim);
   float* e_wb_grad = g_E_wb_grad + n1_net_index;
   float grad_w0_sum, grad_w1_sum, grad_b0_sum;
   if (no_neighbor_isolated_atom) {
@@ -639,8 +690,14 @@ static __global__ void compute_grad_radial_NM(
       atomicAdd(&g_grad_sum[t1_net_index + annmb.num_neurons1 * annmb.dim + annmb.num_neurons1 + annmb.num_neurons1], e_b1_n1);
     }
   } else {
-    const float per_Nc = weight * 2.0f * lambda_f / Na / 3 / Nc;
-    const float per_Nc_v = ((g_has_virial[batch_idx] && virial_nums > 0) ? weight * 2.0f * lambda_v / virial_nums : 0.0f);
+    // lambda_f and lambda_v are likewise applied exactly once here. Eq. (11)
+    // averages force errors over every atom in the global batch.
+    // The configuration still selects its residual weights, but it must not
+    // introduce a separate 1/(Nc*Na) normalization.
+    const float force_factor = squared_weight * 2.0f * lambda_f / 3 / N_global;
+    const float per_Nc_v = ((g_has_virial[batch_idx] && virial_nums > 0)
+      ? squared_weight * 2.0f * lambda_v / virial_nums / Na
+      : 0.0f);
 
     float fx_ref_n1 = g_fx_ref[n1];
     float fy_ref_n1 = g_fy_ref[n1];
@@ -653,6 +710,8 @@ static __global__ void compute_grad_radial_NM(
       float force_magnitude = sqrt(fx_ref_n1 * fx_ref_n1 + fy_ref_n1 * fy_ref_n1 + fz_ref_n1 * fz_ref_n1);
       type_weight *= sqrt(force_delta / (force_delta + force_magnitude));
     }
+    // The reported force loss squares the effective type/force-delta weight.
+    type_weight *= type_weight;
     dx_n1 *= type_weight;
     dy_n1 *= type_weight;
     dz_n1 *= type_weight;
@@ -681,12 +740,13 @@ static __global__ void compute_grad_radial_NM(
       float force_magnitude = sqrt(fx_ref_n2 * fx_ref_n2 + fy_ref_n2 * fy_ref_n2 + fz_ref_n2 * fz_ref_n2);
       type_weight_n2 *= sqrt(force_delta / (force_delta + force_magnitude));
     }
+    type_weight_n2 *= type_weight_n2;
     dx_n2 *= type_weight_n2;
     dy_n2 *= type_weight_n2;
     dz_n2 *= type_weight_n2;
-    const float dx_diff = per_Nc * (dx_n1 - dx_n2);
-    const float dy_diff = per_Nc * (dy_n1 - dy_n2);
-    const float dz_diff = per_Nc * (dz_n1 - dz_n2);
+    const float dx_diff = force_factor * (dx_n1 - dx_n2);
+    const float dy_diff = force_factor * (dy_n1 - dy_n2);
+    const float dz_diff = force_factor * (dz_n1 - dz_n2);
     float r12[3] = {g_x12[index], g_y12[index], g_z12[index]};
     float d12 = sqrt(r12[0] * r12[0] + r12[1] * r12[1] + r12[2] * r12[2]);
     float d12inv = 1.0f / d12;
@@ -856,7 +916,7 @@ static __global__ void compute_grad_radial_NM(
         }
       }
     }
-    int w0_index_dim, w1_index_dim, b0_index_dim;
+    size_t w0_index_dim, w1_index_dim, b0_index_dim;
     float scale, g_ep_w1b, g_ep_wb0, g_ep_w0b;
     for (int j = 0; j < annmb.num_neurons1; ++j) {
       float sum_dfeat_w1b0[6] = {0.0f};
@@ -956,6 +1016,7 @@ static __global__ void compute_grad_angular_NM(
   const GNEP::ANN annmb,
   const int* __restrict__ g_Na,
   const int Nc,
+  const int N_global,
   const float lambda_e,
   const float lambda_f,
   const float lambda_v,
@@ -987,7 +1048,7 @@ static __global__ void compute_grad_angular_NM(
   const float* __restrict__ g_fz,
   const float* __restrict__ g_q_scaler,
   const float* __restrict__ g_ep_wb,
-  float* g_grad_sum)
+  double* g_grad_sum)
 {
   const int NM = N * M;
   int Idx = threadIdx.x + blockIdx.x * blockDim.x;
@@ -1005,11 +1066,19 @@ static __global__ void compute_grad_angular_NM(
   }
   int t1 = g_type[n1];
   int batch_idx = g_batch_idx[n1];
+  g_grad_sum += batch_idx * annmb.num_para;
   int Na = g_Na[batch_idx];
   float weight = g_weight[batch_idx];
-  float per_Nc_e = g_diff_gpu_e[batch_idx] * weight * 2.0f * lambda_e / Nc;
-  float per_Nc = weight * 2.0f * lambda_f / Na / 3 / Nc;
-  float per_Nc_v = (g_has_virial[batch_idx] && virial_nums > 0) ? weight * 2.0f * lambda_v / virial_nums : 0.0f;
+  const float squared_weight = weight * weight;
+  // Nc is the global batch configuration count; Na is the atom count of the
+  // configuration that owns n1.  Both factors are required by the loss.
+  float per_Nc_e =
+    g_diff_gpu_e[batch_idx] * squared_weight * 2.0f * lambda_e / Nc / Na;
+  // Match the paper's global 1/(3*N) force normalization.
+  float force_factor = squared_weight * 2.0f * lambda_f / 3 / N_global;
+  float per_Nc_v = (g_has_virial[batch_idx] && virial_nums > 0)
+    ? squared_weight * 2.0f * lambda_v / virial_nums / Na
+    : 0.0f;
 
   float fx_ref_n1 = g_fx_ref[n1];
   float fy_ref_n1 = g_fy_ref[n1];
@@ -1022,12 +1091,16 @@ static __global__ void compute_grad_angular_NM(
     float force_magnitude = sqrt(fx_ref_n1 * fx_ref_n1 + fy_ref_n1 * fy_ref_n1 + fz_ref_n1 * fz_ref_n1);
     type_weight *= sqrt(force_delta / (force_delta + force_magnitude));
   }
+  type_weight *= type_weight;
   dx_n1 *= type_weight;
   dy_n1 *= type_weight;
   dz_n1 *= type_weight;
 
   int t1_net_index = t1 * ((annmb.dim + 2) * annmb.num_neurons1 + 1);
-  int n1_net_index_wb = n1 * annmb.num_ann * annmb.dim + t1_net_index * annmb.dim;
+  const size_t n1_net_index_wb =
+    static_cast<size_t>(n1) * static_cast<size_t>(annmb.num_ann) *
+      static_cast<size_t>(annmb.dim) +
+    static_cast<size_t>(t1_net_index) * static_cast<size_t>(annmb.dim);
   
   float diff[6] = {
     g_diff_gpu_v[batch_idx * 6 + 0] * per_Nc_v,
@@ -1053,12 +1126,13 @@ static __global__ void compute_grad_angular_NM(
     float force_magnitude = sqrt(fx_ref_n2 * fx_ref_n2 + fy_ref_n2 * fy_ref_n2 + fz_ref_n2 * fz_ref_n2);
     type_weight_n2 *= sqrt(force_delta / (force_delta + force_magnitude));
   }
+  type_weight_n2 *= type_weight_n2;
   dx_n2 *= type_weight_n2;
   dy_n2 *= type_weight_n2;
   dz_n2 *= type_weight_n2;
-  float dx_diff = per_Nc * (dx_n1 - dx_n2);
-  float dy_diff = per_Nc * (dy_n1 - dy_n2);
-  float dz_diff = per_Nc * (dz_n1 - dz_n2);
+  float dx_diff = force_factor * (dx_n1 - dx_n2);
+  float dy_diff = force_factor * (dy_n1 - dy_n2);
+  float dz_diff = force_factor * (dz_n1 - dz_n2);
   float r12_i1[3] = {g_x12[index], g_y12[index], g_z12[index]};
   float d12_i1 = sqrt(r12_i1[0] * r12_i1[0] + r12_i1[1] * r12_i1[1] + r12_i1[2] * r12_i1[2]);
   float feat_x[MAX_LN];
@@ -1090,7 +1164,7 @@ static __global__ void compute_grad_angular_NM(
       gnp12[n] += fnp12[k] * annmb.c[c_index];
       accumulate_ec(N, paramb.L_max, n, paramb.n_max_angular + 1, paramb.basis_size_angular+1, d12_i1, r12_i1, fn12[k], fnp12[k], &g_sum_fxyz[n1], &g_sum_s2xyz[n1], &g_sum_s2xyz123[n1], Fp, &e_c, qp_c_tmp, qp_c_tmp123);
       grad_c_index = c_index + annmb.num_ann;
-      grad_c_sum = per_Nc * (qp_c_tmp[0] * dx_n1 + qp_c_tmp[1] * dy_n1 + qp_c_tmp[2] * dz_n1);
+      grad_c_sum = force_factor * (qp_c_tmp[0] * dx_n1 + qp_c_tmp[1] * dy_n1 + qp_c_tmp[2] * dz_n1);
       grad_c_sum += per_Nc_e * e_c;
       grad_c_sum -= qp_c_tmp123[0] * diff[0] + qp_c_tmp123[1] * diff[1] + qp_c_tmp123[2] * diff[2] + qp_c_tmp123[3] * diff[3] + qp_c_tmp123[4] * diff[4] + qp_c_tmp123[5] * diff[5];
       atomicAdd(&g_grad_sum[grad_c_index], grad_c_sum);
@@ -1120,6 +1194,7 @@ static __global__ void compute_grad_angular_NM(
         float force_magnitude = sqrt(fx_ref_n2 * fx_ref_n2 + fy_ref_n2 * fy_ref_n2 + fz_ref_n2 * fz_ref_n2);
         type_weight_n2 *= sqrt(force_delta / (force_delta + force_magnitude));
       }
+      type_weight_n2 *= type_weight_n2;
       dx_n2_tmp *= type_weight_n2;
       dy_n2_tmp *= type_weight_n2;
       dz_n2_tmp *= type_weight_n2;
@@ -1169,7 +1244,7 @@ static __global__ void compute_grad_angular_NM(
         }
         accumulate_fc(N, paramb.L_max, n, paramb.n_max_angular + 1, paramb.basis_size_angular+1, d12, r12, fn12[k], fnp12[k], s, sum_s2xyz, Fp, qp_c_tmp1, qp_c_tmp2);
         grad_c_sum = f_c_n1[0] * dx_diff + f_c_n1[1] * dy_diff + f_c_n1[2] * dz_diff;
-        grad_c_sum -= per_Nc * (qp_c_tmp1[0] * dx_n2_tmp + qp_c_tmp1[1] * dy_n2_tmp + qp_c_tmp1[2] * dz_n2_tmp + qp_c_tmp2[0] * dx_n2 + qp_c_tmp2[1] * dy_n2 + qp_c_tmp2[2] * dz_n2);
+        grad_c_sum -= force_factor * (qp_c_tmp1[0] * dx_n2_tmp + qp_c_tmp1[1] * dy_n2_tmp + qp_c_tmp1[2] * dz_n2_tmp + qp_c_tmp2[0] * dx_n2 + qp_c_tmp2[1] * dy_n2 + qp_c_tmp2[2] * dz_n2);
         grad_c_sum -= v_c_n1[0] * diff[0] + v_c_n1[1] * diff[1] + v_c_n1[2] * diff[2] + v_c_n1[3] * diff[3] + v_c_n1[4] * diff[4] + v_c_n1[5] * diff[5];
 
         type_base = t1 * paramb.num_types + t2_tmp + paramb.num_c_radial;
@@ -1223,7 +1298,8 @@ static __global__ void compute_grad_angular_NM(
       }
     }
   } // end of loop over neighbors' neighbors
-  int index_dim, w0_index_dim, w1_index_dim, b0_index_dim;
+  int index_dim;
+  size_t w0_index_dim, w1_index_dim, b0_index_dim;
   float scale, g_ep_w1b, g_ep_wb0, g_ep_w0b, grad_w0_sum, grad_w1_sum, grad_b0_sum;
   for (int j = 0; j < annmb.num_neurons1; ++j) {
     float sum_dfeat_w1b0[6] = {0.0f};
@@ -1573,19 +1649,26 @@ void GNEP::find_force(
   std::vector<Dataset>& dataset,
   bool calculate_q_scaler,
   bool calculate_neighbor,
-  int device_in_this_iter)
+  int device_begin,
+  int device_count,
+  int global_num_configurations,
+  int global_num_atoms,
+  int global_virial_components)
 {
 
-  for (int device_id = 0; device_id < device_in_this_iter; ++device_id) {
+  for (int device_id = device_begin; device_id < device_begin + device_count; ++device_id) {
     CHECK(cudaSetDevice(device_id));
-    gnep_data[device_id].Fp2.resize(dataset[device_id].N * annmb[device_id].dim * annmb[device_id].dim, 0.0f);
-    gnep_data[device_id].sum_s2xyz.resize(dataset[device_id].N * (paramb.n_max_angular + 1) * NUM_OF_ABC * 3, 0.0f);
-    gnep_data[device_id].sum_s2xyz123.resize(dataset[device_id].N * (paramb.n_max_angular + 1) * NUM_OF_ABC * 6, 0.0f);
-    gnep_data[device_id].parameters.copy_from_host(parameters);
-    update_potential(para, gnep_data[device_id].parameters.data(), annmb[device_id]);
+    contexts[device_id]->data.Fp2.fill(0.0f);
+    contexts[device_id]->data.sum_s2xyz.fill(0.0f);
+    contexts[device_id]->data.sum_s2xyz123.fill(0.0f);
+    contexts[device_id]->data.parameters.copy_from_host(parameters);
+    update_potential(para, contexts[device_id]->data.parameters.data(), contexts[device_id]->ann);
+    if (require_grad) {
+      contexts[device_id]->gradients.clear();
+    }
   }
 
-  for (int device_id = 0; device_id < device_in_this_iter; ++device_id) {
+  for (int device_id = device_begin; device_id < device_begin + device_count; ++device_id) {
     CHECK(cudaSetDevice(device_id));
     const int block_size = 32;
     const int grid_size = (dataset[device_id].N - 1) / block_size + 1;
@@ -1603,56 +1686,56 @@ void GNEP::find_force(
         dataset[device_id].r.data(),
         dataset[device_id].r.data() + dataset[device_id].N,
         dataset[device_id].r.data() + dataset[device_id].N * 2,
-        gnep_data[device_id].NN_radial.data(),
-        gnep_data[device_id].NL_radial.data(),
-        gnep_data[device_id].NN_angular.data(),
-        gnep_data[device_id].NL_angular.data(),
-        gnep_data[device_id].x12_radial.data(),
-        gnep_data[device_id].y12_radial.data(),
-        gnep_data[device_id].z12_radial.data(),
-        gnep_data[device_id].x12_angular.data(),
-        gnep_data[device_id].y12_angular.data(),
-        gnep_data[device_id].z12_angular.data());
+        contexts[device_id]->data.NN_radial.data(),
+        contexts[device_id]->data.NL_radial.data(),
+        contexts[device_id]->data.NN_angular.data(),
+        contexts[device_id]->data.NL_angular.data(),
+        contexts[device_id]->data.x12_radial.data(),
+        contexts[device_id]->data.y12_radial.data(),
+        contexts[device_id]->data.z12_radial.data(),
+        contexts[device_id]->data.x12_angular.data(),
+        contexts[device_id]->data.y12_angular.data(),
+        contexts[device_id]->data.z12_angular.data());
       GPU_CHECK_KERNEL
     }
 
     find_descriptors_radial<<<grid_size, block_size>>>(
       dataset[device_id].N,
       dataset[device_id].max_NN_radial,
-      gnep_data[device_id].NN_radial.data(),
-      gnep_data[device_id].NL_radial.data(),
+      contexts[device_id]->data.NN_radial.data(),
+      contexts[device_id]->data.NL_radial.data(),
       paramb,
-      annmb[device_id],
+      contexts[device_id]->ann,
       dataset[device_id].type.data(),
-      gnep_data[device_id].x12_radial.data(),
-      gnep_data[device_id].y12_radial.data(),
-      gnep_data[device_id].z12_radial.data(),
-      gnep_data[device_id].descriptors.data());
+      contexts[device_id]->data.x12_radial.data(),
+      contexts[device_id]->data.y12_radial.data(),
+      contexts[device_id]->data.z12_radial.data(),
+      contexts[device_id]->data.descriptors.data());
     GPU_CHECK_KERNEL
 
     find_descriptors_angular<<<grid_size, block_size>>>(
       dataset[device_id].N,
-      gnep_data[device_id].NN_angular.data(),
-      gnep_data[device_id].NL_angular.data(),
+      contexts[device_id]->data.NN_angular.data(),
+      contexts[device_id]->data.NL_angular.data(),
       paramb,
-      annmb[device_id],
+      contexts[device_id]->ann,
       dataset[device_id].type.data(),
-      gnep_data[device_id].x12_angular.data(),
-      gnep_data[device_id].y12_angular.data(),
-      gnep_data[device_id].z12_angular.data(),
-      gnep_data[device_id].descriptors.data(),
-      gnep_data[device_id].sum_fxyz.data());
+      contexts[device_id]->data.x12_angular.data(),
+      contexts[device_id]->data.y12_angular.data(),
+      contexts[device_id]->data.z12_angular.data(),
+      contexts[device_id]->data.descriptors.data(),
+      contexts[device_id]->data.sum_fxyz.data());
     GPU_CHECK_KERNEL
 
     if (para.prediction == 1 && para.output_descriptor >= 1) {
       FILE* fid_descriptor = my_fopen("descriptor.out", "a");
-      std::vector<float> descriptor_cpu(gnep_data[device_id].descriptors.size());
-      gnep_data[device_id].descriptors.copy_to_host(descriptor_cpu.data());
+      std::vector<float> descriptor_cpu(contexts[device_id]->data.descriptors.size());
+      contexts[device_id]->data.descriptors.copy_to_host(descriptor_cpu.data());
       for (int nc = 0; nc < dataset[device_id].Nc; ++nc) {
         float q_structure[MAX_DIM] = {0.0f};
         for (int na = 0; na < dataset[device_id].Na_cpu[nc]; ++na) {
           int n = dataset[device_id].Na_sum_cpu[nc] + na;
-          for (int d = 0; d < annmb[device_id].dim; ++d) {
+          for (int d = 0; d < contexts[device_id]->ann.dim; ++d) {
             float q = descriptor_cpu[n + d * dataset[device_id].N] * para.q_scaler_cpu[d];
             q_structure[d] += q;
             if (para.output_descriptor == 2) {
@@ -1664,7 +1747,7 @@ void GNEP::find_force(
           }
         }
         if (para.output_descriptor == 1) {
-          for (int d = 0; d < annmb[device_id].dim; ++d) {
+          for (int d = 0; d < contexts[device_id]->ann.dim; ++d) {
             fprintf(fid_descriptor, "%g ", q_structure[d] / dataset[device_id].Na_cpu[nc]);
           }
         }
@@ -1676,12 +1759,12 @@ void GNEP::find_force(
     }
 
     if (calculate_q_scaler) {
-      find_max_min<<<annmb[device_id].dim, 1024>>>(
+      find_max_min<<<contexts[device_id]->ann.dim, 1024>>>(
         dataset[device_id].N,
-        gnep_data[device_id].descriptors.data(),
-        para.s_max[device_id].data(),
-        para.s_min[device_id].data(),
-        para.q_scaler_gpu[device_id].data());
+        contexts[device_id]->data.descriptors.data(),
+        para.s_max_gpu(device_id).data(),
+        para.s_min_gpu(device_id).data(),
+        para.q_scaler_gpu(device_id).data());
       GPU_CHECK_KERNEL
     }
 
@@ -1696,43 +1779,42 @@ void GNEP::find_force(
     GPU_CHECK_KERNEL
 
     if (require_grad) {
-      initialize_gradients(para, dataset[device_id].N);
       apply_ann<true><<<grid_size, block_size>>>(
         dataset[device_id].N,
         paramb,
-        annmb[device_id],
+        contexts[device_id]->ann,
         dataset[device_id].type.data(),
-        gnep_data[device_id].descriptors.data(),
-        para.q_scaler_gpu[device_id].data(),
+        contexts[device_id]->data.descriptors.data(),
+        para.q_scaler_gpu(device_id).data(),
         dataset[device_id].energy.data(),
-        gnep_data[device_id].Fp.data(),
-        gnep_data[device_id].Fp2.data(),
-        gradients.Fp_wb.data(),
-        gradients.E_wb_grad.data());
+        contexts[device_id]->data.Fp.data(),
+        contexts[device_id]->data.Fp2.data(),
+        contexts[device_id]->gradients.Fp_wb.data(),
+        contexts[device_id]->gradients.E_wb_grad.data());
       GPU_CHECK_KERNEL
     } else {
       apply_ann<false><<<grid_size, block_size>>>(
         dataset[device_id].N,
         paramb,
-        annmb[device_id],
+        contexts[device_id]->ann,
         dataset[device_id].type.data(),
-        gnep_data[device_id].descriptors.data(),
-        para.q_scaler_gpu[device_id].data(),
+        contexts[device_id]->data.descriptors.data(),
+        para.q_scaler_gpu(device_id).data(),
         dataset[device_id].energy.data(),
-        gnep_data[device_id].Fp.data());
+        contexts[device_id]->data.Fp.data());
       GPU_CHECK_KERNEL
     }
     find_force_radial<<<grid_size, block_size>>>(
       dataset[device_id].N,
-      gnep_data[device_id].NN_radial.data(),
-      gnep_data[device_id].NL_radial.data(),
+      contexts[device_id]->data.NN_radial.data(),
+      contexts[device_id]->data.NL_radial.data(),
       paramb,
-      annmb[device_id],
+      contexts[device_id]->ann,
       dataset[device_id].type.data(),
-      gnep_data[device_id].x12_radial.data(),
-      gnep_data[device_id].y12_radial.data(),
-      gnep_data[device_id].z12_radial.data(),
-      gnep_data[device_id].Fp.data(),
+      contexts[device_id]->data.x12_radial.data(),
+      contexts[device_id]->data.y12_radial.data(),
+      contexts[device_id]->data.z12_radial.data(),
+      contexts[device_id]->data.Fp.data(),
       dataset[device_id].force.data(),
       dataset[device_id].force.data() + dataset[device_id].N,
       dataset[device_id].force.data() + dataset[device_id].N * 2,
@@ -1742,18 +1824,18 @@ void GNEP::find_force(
     find_force_angular<<<grid_size, block_size>>>(
       require_grad,
       dataset[device_id].N,
-      gnep_data[device_id].NN_angular.data(),
-      gnep_data[device_id].NL_angular.data(),
+      contexts[device_id]->data.NN_angular.data(),
+      contexts[device_id]->data.NL_angular.data(),
       paramb,
-      annmb[device_id],
+      contexts[device_id]->ann,
       dataset[device_id].type.data(),
-      gnep_data[device_id].x12_angular.data(),
-      gnep_data[device_id].y12_angular.data(),
-      gnep_data[device_id].z12_angular.data(),
-      gnep_data[device_id].Fp.data(),
-      gnep_data[device_id].sum_fxyz.data(),
-      gnep_data[device_id].sum_s2xyz.data(),
-      gnep_data[device_id].sum_s2xyz123.data(),
+      contexts[device_id]->data.x12_angular.data(),
+      contexts[device_id]->data.y12_angular.data(),
+      contexts[device_id]->data.z12_angular.data(),
+      contexts[device_id]->data.Fp.data(),
+      contexts[device_id]->data.sum_fxyz.data(),
+      contexts[device_id]->data.sum_s2xyz.data(),
+      contexts[device_id]->data.sum_s2xyz123.data(),
       dataset[device_id].force.data(),
       dataset[device_id].force.data() + dataset[device_id].N,
       dataset[device_id].force.data() + dataset[device_id].N * 2,
@@ -1765,12 +1847,12 @@ void GNEP::find_force(
         dataset[device_id].N,
         paramb,
         zbl,
-        gnep_data[device_id].NN_angular.data(),
-        gnep_data[device_id].NL_angular.data(),
+        contexts[device_id]->data.NN_angular.data(),
+        contexts[device_id]->data.NL_angular.data(),
         dataset[device_id].type.data(),
-        gnep_data[device_id].x12_angular.data(),
-        gnep_data[device_id].y12_angular.data(),
-        gnep_data[device_id].z12_angular.data(),
+        contexts[device_id]->data.x12_angular.data(),
+        contexts[device_id]->data.y12_angular.data(),
+        contexts[device_id]->data.z12_angular.data(),
         dataset[device_id].force.data(),
         dataset[device_id].force.data() + dataset[device_id].N,
         dataset[device_id].force.data() + dataset[device_id].N * 2,
@@ -1799,12 +1881,7 @@ void GNEP::find_force(
       dataset[device_id].diff_gpu_v.data(),
       dataset[device_id].error_gpu.data());
     CHECK(cudaMemcpy(dataset[device_id].error_cpu_v.data(), dataset[device_id].error_gpu.data(), dataset[device_id].Nc * sizeof(float), cudaMemcpyDeviceToHost));
-    int virial_nums = 0;
-    for (int n = 0; n < dataset[device_id].Nc; ++n) {
-      if (dataset[device_id].has_virial[n]) {
-        virial_nums += 6;
-      }
-    }
+    const int virial_nums = global_virial_components;
 
     if (require_grad) {
       const int NM_radial = dataset[device_id].N * dataset[device_id].max_NN_radial;
@@ -1814,14 +1891,15 @@ void GNEP::find_force(
         compute_grad_radial_NM<<<blocks_per_grid, threads_per_block>>>(
           dataset[device_id].N,
           dataset[device_id].max_NN_radial,
-          gnep_data[device_id].NN_radial.data(),
-          gnep_data[device_id].NL_radial.data(),
-          gnep_data[device_id].NN_angular.data(),
-          gnep_data[device_id].NL_angular.data(),
+          contexts[device_id]->data.NN_radial.data(),
+          contexts[device_id]->data.NL_radial.data(),
+          contexts[device_id]->data.NN_angular.data(),
+          contexts[device_id]->data.NL_angular.data(),
           paramb,
-          annmb[device_id],
+          contexts[device_id]->ann,
           dataset[device_id].Na.data(),
-          dataset[device_id].Nc,
+          global_num_configurations,
+          global_num_atoms,
           para.lambda_e,
           para.lambda_f,
           para.lambda_v,
@@ -1831,16 +1909,16 @@ void GNEP::find_force(
           para.force_delta,
           dataset[device_id].batch_idx.data(),
           dataset[device_id].type.data(),
-          gnep_data[device_id].x12_radial.data(),
-          gnep_data[device_id].y12_radial.data(),
-          gnep_data[device_id].z12_radial.data(),
-          gnep_data[device_id].x12_angular.data(),
-          gnep_data[device_id].y12_angular.data(),
-          gnep_data[device_id].z12_angular.data(),
-          gnep_data[device_id].Fp.data(),
-          gnep_data[device_id].Fp2.data(),
-          gnep_data[device_id].sum_fxyz.data(),
-          gradients.E_wb_grad.data(),
+          contexts[device_id]->data.x12_radial.data(),
+          contexts[device_id]->data.y12_radial.data(),
+          contexts[device_id]->data.z12_radial.data(),
+          contexts[device_id]->data.x12_angular.data(),
+          contexts[device_id]->data.y12_angular.data(),
+          contexts[device_id]->data.z12_angular.data(),
+          contexts[device_id]->data.Fp.data(),
+          contexts[device_id]->data.Fp2.data(),
+          contexts[device_id]->data.sum_fxyz.data(),
+          contexts[device_id]->gradients.E_wb_grad.data(),
           dataset[device_id].diff_gpu_e.data(),
           dataset[device_id].diff_gpu_v.data(),
           dataset[device_id].force_ref_gpu.data(),
@@ -1850,24 +1928,25 @@ void GNEP::find_force(
           dataset[device_id].force.data(),
           dataset[device_id].force.data() + dataset[device_id].N,
           dataset[device_id].force.data() + dataset[device_id].N * 2,
-          para.q_scaler_gpu[device_id].data(),
-          gradients.Fp_wb.data(),
-          gradients.grad_sum.data());
+          para.q_scaler_gpu(device_id).data(),
+          contexts[device_id]->gradients.Fp_wb.data(),
+          contexts[device_id]->gradients.grad_sum.data());
         GPU_CHECK_KERNEL
       } else {
         const int blocks_per_grid = (dataset[device_id].N + threads_per_block - 1) / threads_per_block;
         compute_grad_e_without_neighbor<<<blocks_per_grid, threads_per_block>>>(
           dataset[device_id].N,
           paramb,
-          annmb[device_id],
-          dataset[device_id].Nc,
+          contexts[device_id]->ann,
+          dataset[device_id].Na.data(),
+          global_num_configurations,
           para.lambda_e,
           dataset[device_id].batch_idx.data(),
           dataset[device_id].type.data(),
-          gradients.E_wb_grad.data(),
+          contexts[device_id]->gradients.E_wb_grad.data(),
           dataset[device_id].diff_gpu_e.data(),
           dataset[device_id].weight_gpu.data(),
-          gradients.grad_sum.data());
+          contexts[device_id]->gradients.grad_sum.data());
         GPU_CHECK_KERNEL
       }
       const int NM_angular = dataset[device_id].N * dataset[device_id].max_NN_angular;
@@ -1876,14 +1955,15 @@ void GNEP::find_force(
         compute_grad_angular_NM<<<blocks_per_grid_angular, threads_per_block>>>(
           dataset[device_id].N,
           dataset[device_id].max_NN_angular,
-          gnep_data[device_id].NN_angular.data(),
-          gnep_data[device_id].NL_angular.data(),
-          gnep_data[device_id].NN_radial.data(),
-          gnep_data[device_id].NL_radial.data(),
+          contexts[device_id]->data.NN_angular.data(),
+          contexts[device_id]->data.NL_angular.data(),
+          contexts[device_id]->data.NN_radial.data(),
+          contexts[device_id]->data.NL_radial.data(),
           paramb,
-          annmb[device_id],
+          contexts[device_id]->ann,
           dataset[device_id].Na.data(),
-          dataset[device_id].Nc,
+          global_num_configurations,
+          global_num_atoms,
           para.lambda_e,
           para.lambda_f,
           para.lambda_v,
@@ -1893,17 +1973,17 @@ void GNEP::find_force(
           para.force_delta,
           dataset[device_id].batch_idx.data(),
           dataset[device_id].type.data(),
-          gnep_data[device_id].x12_angular.data(),
-          gnep_data[device_id].y12_angular.data(),
-          gnep_data[device_id].z12_angular.data(),
-          gnep_data[device_id].x12_radial.data(),
-          gnep_data[device_id].y12_radial.data(),
-          gnep_data[device_id].z12_radial.data(),
-          gnep_data[device_id].Fp.data(),
-          gnep_data[device_id].Fp2.data(),
-          gnep_data[device_id].sum_fxyz.data(),
-          gnep_data[device_id].sum_s2xyz.data(),
-          gnep_data[device_id].sum_s2xyz123.data(),
+          contexts[device_id]->data.x12_angular.data(),
+          contexts[device_id]->data.y12_angular.data(),
+          contexts[device_id]->data.z12_angular.data(),
+          contexts[device_id]->data.x12_radial.data(),
+          contexts[device_id]->data.y12_radial.data(),
+          contexts[device_id]->data.z12_radial.data(),
+          contexts[device_id]->data.Fp.data(),
+          contexts[device_id]->data.Fp2.data(),
+          contexts[device_id]->data.sum_fxyz.data(),
+          contexts[device_id]->data.sum_s2xyz.data(),
+          contexts[device_id]->data.sum_s2xyz123.data(),
           dataset[device_id].diff_gpu_e.data(),
           dataset[device_id].diff_gpu_v.data(),
           dataset[device_id].force_ref_gpu.data(),
@@ -1913,9 +1993,9 @@ void GNEP::find_force(
           dataset[device_id].force.data(),
           dataset[device_id].force.data() + dataset[device_id].N,
           dataset[device_id].force.data() + dataset[device_id].N * 2,
-          para.q_scaler_gpu[device_id].data(),
-          gradients.Fp_wb.data(),
-          gradients.grad_sum.data());
+          para.q_scaler_gpu(device_id).data(),
+          contexts[device_id]->gradients.Fp_wb.data(),
+          contexts[device_id]->gradients.grad_sum.data());
         GPU_CHECK_KERNEL
       }
     }

--- a/src/main_gnep/gnep.cuh
+++ b/src/main_gnep/gnep.cuh
@@ -18,6 +18,8 @@
 #include "utilities/common.cuh"
 #include "utilities/gpu_vector.cuh"
 #include "gradients.cuh"
+#include <memory>
+#include <vector>
 class Parameters;
 class Dataset;
 
@@ -39,6 +41,14 @@ struct GNEP_Data {
   GPU_Vector<float> sum_s2xyz; // Snlm_xyz
   GPU_Vector<float> sum_s2xyz123; // Snlm_xyz * xyz
   GPU_Vector<float> parameters; // parameters to be optimized
+};
+
+struct GNEPDeviceCapacity {
+  int max_atoms = 0;
+  int max_training_atoms = 0;
+  int max_configurations = 0;
+  int max_radial_pairs = 0;
+  int max_angular_pairs = 0;
 };
 
 class GNEP : public Potential
@@ -83,12 +93,18 @@ public:
     int atomic_numbers[NUM_ELEMENTS];
   };
 
+  struct DeviceContext {
+    explicit DeviceContext(int id) : device_id(id) {}
+    ~DeviceContext();
+    int device_id;
+    ANN ann;
+    GNEP_Data data;
+    Gradients gradients;
+  };
+
   GNEP(
     Parameters& para,
-    int N,
-    int N_times_max_NN_radial,
-    int N_times_max_NN_angular,
-    int deviceCount);
+    const std::vector<GNEPDeviceCapacity>& capacities);
   void find_force(
     Parameters& para,
     const float* parameters,
@@ -96,16 +112,20 @@ public:
     std::vector<Dataset>& dataset,
     bool calculate_q_scaler,
     bool calculate_neighbor,
-    int deviceCount);
+    int device_begin,
+    int device_count,
+    int global_num_configurations,
+    int global_num_atoms,
+    int global_virial_components);
 
-  Gradients gradients;
-  virtual Gradients& getGradients() override {return gradients;}
+  virtual Gradients& getGradients(int device_id) override
+  {
+    return contexts.at(device_id)->gradients;
+  }
 
 private:
   ParaMB paramb;
-  ANN annmb[16];
-  GNEP_Data gnep_data[16];
+  std::vector<std::unique_ptr<DeviceContext>> contexts;
   ZBL zbl;
   void update_potential(Parameters& para, const float* parameters, ANN& ann);
-  void initialize_gradients(Parameters& para, const int N);
 };

--- a/src/main_gnep/gradients.cuh
+++ b/src/main_gnep/gradients.cuh
@@ -16,24 +16,17 @@
 #pragma once
 #include "utilities/gpu_vector.cuh"
 
-static void print_memory_info(const char* stage) {
-    size_t free_memory, total_memory;
-    cudaMemGetInfo(&free_memory, &total_memory);
-    float free_gb = free_memory / (1024.0 * 1024.0 * 1024.0);
-    float total_gb = total_memory / (1024.0 * 1024.0 * 1024.0);
-    float used_gb = total_gb - free_gb;
-    
-    printf("%s:\n", stage);
-    printf("  Free memory:  %.2f GB\n", free_gb);
-    printf("  Used memory:  %.2f GB\n", used_gb);
-    printf("  Total memory: %.2f GB\n", total_gb);
-}
-
 struct Gradients {
-  void resize(int N, int num_variables, int number_of_variables_ann, int dim) {
-    grad_sum.resize(num_variables, 0.0f);
-    E_wb_grad.resize(N * number_of_variables_ann, 0.0f);
-    Fp_wb.resize(N * number_of_variables_ann * dim, 0.0f);
+  void allocate(int N, int Nc, int num_variables, int number_of_variables_ann, int dim) {
+    grad_sum.resize(
+      static_cast<size_t>(Nc) * static_cast<size_t>(num_variables), 0.0f);
+    local_sum.resize(num_variables, 0.0f);
+    E_wb_grad.resize(
+      static_cast<size_t>(N) * static_cast<size_t>(number_of_variables_ann), 0.0f);
+    Fp_wb.resize(
+      static_cast<size_t>(N) * static_cast<size_t>(number_of_variables_ann) *
+        static_cast<size_t>(dim),
+      0.0f);
   }
   void clear() {
     E_wb_grad.fill(0.0f);
@@ -41,6 +34,7 @@ struct Gradients {
     Fp_wb.fill(0.0f);
   }
   GPU_Vector<float> E_wb_grad;      // energy w.r.t. w0, b0, w1, b1
-  GPU_Vector<float> grad_sum;
+  GPU_Vector<double> grad_sum;
+  GPU_Vector<double> local_sum; // deterministic per-device configuration sum
   GPU_Vector<float> Fp_wb;          // gradient of descriptors w.r.t. w0, b0, w1, b1
 };

--- a/src/main_gnep/parameters.cu
+++ b/src/main_gnep/parameters.cu
@@ -14,12 +14,15 @@
 */
 
 #include "parameters.cuh"
+#include "device_guard.cuh"
 #include "utilities/common.cuh"
 #include "utilities/error.cuh"
 #include "utilities/read_file.cuh"
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <iostream>
+#include <limits>
 
 const std::string ELEMENTS[NUM_ELEMENTS] = {
   "H",  "He", "Li", "Be", "B",  "C",  "N",  "O",  "F",  "Ne", "Na", "Mg", "Al", "Si", "P",  "S",
@@ -48,6 +51,11 @@ Parameters::Parameters()
   print_line_2();
 }
 
+Parameters::~Parameters()
+{
+  cudaSetDevice(0);
+}
+
 void Parameters::set_default_parameters()
 {
   is_prediction_set = false;
@@ -69,6 +77,7 @@ void Parameters::set_default_parameters()
   is_use_typewise_cutoff_zbl_set = false;
   is_energy_shift_set = false;
   is_lr_cos_restart_set = false;
+  is_seed_set = false;
 
   prediction = 0;              // not prediction mode
   basis_size_radial = 8;       // large enough in most cases
@@ -93,6 +102,7 @@ void Parameters::set_default_parameters()
   typewise_cutoff_zbl_factor = -1.0f;
   energy_shift = 0;
   output_descriptor = false;
+  seed = 1234567;
 
   // default for lr cosine restart scheduler
   lr_restart_enable = 0;
@@ -178,15 +188,72 @@ void Parameters::calculate_parameters()
 
   number_of_variables = number_of_variables_ann + number_of_variables_descriptor;
 
-  int deviceCount;
-  CHECK(cudaGetDeviceCount(&deviceCount));
-  for (int device_id = 0; device_id < deviceCount; device_id++) {
-    CHECK(cudaSetDevice(device_id));
-    q_scaler_gpu[device_id].resize(dim);
-    s_max[device_id].resize(dim, -1000000.0f);
-    s_min[device_id].resize(dim, +1000000.0f);
-    q_scaler_gpu[device_id].copy_from_host(q_scaler_cpu.data());
-    energy_shift_gpu.resize(num_types, 0.0f);
+  int device_count;
+  CHECK(cudaGetDeviceCount(&device_count));
+  device_scalers.reserve(device_count);
+  for (int device_id = 0; device_id < device_count; ++device_id) {
+    DeviceGuard guard(device_id);
+    std::unique_ptr<GNEPDeviceScaler> state(new GNEPDeviceScaler(device_id));
+    state->q_scaler.resize(dim);
+    state->s_max.resize(dim, -1000000.0f);
+    state->s_min.resize(dim, +1000000.0f);
+    state->q_scaler.copy_from_host(q_scaler_cpu.data());
+    device_scalers.emplace_back(std::move(state));
+  }
+  DeviceGuard guard(0);
+  energy_shift_gpu.resize(num_types, 0.0f);
+}
+
+GPU_Vector<float>& Parameters::q_scaler_gpu(const int device_id)
+{
+  return device_scalers.at(device_id)->q_scaler;
+}
+
+GPU_Vector<float>& Parameters::s_max_gpu(const int device_id)
+{
+  return device_scalers.at(device_id)->s_max;
+}
+
+GPU_Vector<float>& Parameters::s_min_gpu(const int device_id)
+{
+  return device_scalers.at(device_id)->s_min;
+}
+
+int Parameters::num_devices() const
+{
+  return static_cast<int>(device_scalers.size());
+}
+
+void Parameters::reduce_and_broadcast_scaler()
+{
+#ifndef USE_FIXED_SCALER
+  std::vector<float> global_max(dim, -std::numeric_limits<float>::infinity());
+  std::vector<float> global_min(dim, +std::numeric_limits<float>::infinity());
+  std::vector<float> local_max(dim);
+  std::vector<float> local_min(dim);
+
+  for (int device_id = 0; device_id < num_devices(); ++device_id) {
+    DeviceGuard guard(device_id);
+    s_max_gpu(device_id).copy_to_host(local_max.data());
+    s_min_gpu(device_id).copy_to_host(local_min.data());
+    for (int d = 0; d < dim; ++d) {
+      global_max[d] = std::max(global_max[d], local_max[d]);
+      global_min[d] = std::min(global_min[d], local_min[d]);
+    }
+  }
+
+  for (int d = 0; d < dim; ++d) {
+    q_scaler_cpu[d] = 1.0f / (global_max[d] - global_min[d]);
+  }
+#endif
+
+  for (int device_id = 0; device_id < num_devices(); ++device_id) {
+    DeviceGuard guard(device_id);
+    q_scaler_gpu(device_id).copy_from_host(q_scaler_cpu.data());
+#ifndef USE_FIXED_SCALER
+    s_max_gpu(device_id).copy_from_host(global_max.data());
+    s_min_gpu(device_id).copy_from_host(global_min.data());
+#endif
   }
 }
 
@@ -330,6 +397,12 @@ void Parameters::report_inputs()
     printf("    (default) maximum number of epochs = %d.\n", epoch);
   }
 
+  if (is_seed_set) {
+    printf("    (input)   deterministic random seed = %d.\n", seed);
+  } else {
+    printf("    (default) parameter seed = %d; batch shuffle is non-deterministic.\n", seed);
+  }
+
   // report lr cosine restart settings
   if (lr_restart_enable) {
     printf("    (input)   lr_cos_restart enabled.\n");
@@ -406,6 +479,8 @@ void Parameters::parse_one_keyword(std::vector<std::string>& tokens)
     parse_output_descriptor(param, num_param);
   } else if (strcmp(param[0], "lr_cos_restart") == 0) {
     parse_lr_cos_restart(param, num_param);
+  } else if (strcmp(param[0], "seed") == 0) {
+    parse_seed(param, num_param);
   } else {
     PRINT_KEYWORD_ERROR(param[0]);
   }
@@ -856,6 +931,20 @@ void Parameters::parse_epoch(const char** param, int num_param)
     PRINT_INPUT_ERROR("maximum number of epochs should >= 0.");
   } else if (epoch > 10000) {
     PRINT_INPUT_ERROR("maximum number of epochs should <= 10000.");
+  }
+}
+
+void Parameters::parse_seed(const char** param, int num_param)
+{
+  is_seed_set = true;
+  if (num_param != 2) {
+    PRINT_INPUT_ERROR("seed should have 1 parameter.\n");
+  }
+  if (!is_valid_int(param[1], &seed)) {
+    PRINT_INPUT_ERROR("seed should be an integer.\n");
+  }
+  if (seed < 0) {
+    PRINT_INPUT_ERROR("seed should be non-negative.");
   }
 }
 

--- a/src/main_gnep/parameters.cuh
+++ b/src/main_gnep/parameters.cuh
@@ -15,13 +15,26 @@
 
 #pragma once
 #include "utilities/gpu_vector.cuh"
+#include <memory>
 #include <string>
 #include <vector>
+
+struct GNEPDeviceScaler
+{
+  explicit GNEPDeviceScaler(const int id) : device_id(id) {}
+  ~GNEPDeviceScaler() { cudaSetDevice(device_id); }
+
+  int device_id;
+  GPU_Vector<float> q_scaler;
+  GPU_Vector<float> s_max;
+  GPU_Vector<float> s_min;
+};
 
 class Parameters
 {
 public:
   Parameters();
+  ~Parameters();
 
   // parameters to be read in
   int batch_size;         // number of configurations in one batch
@@ -52,6 +65,7 @@ public:
   bool use_typewise_cutoff_zbl;
   float typewise_cutoff_zbl_factor;
   int output_descriptor;
+  int seed;
 
   // learning rate scheduler (cosine annealing with warmup restarts)
   int lr_restart_enable;                 // 0=off(use cosine), 1=on(use cosine with restarts)
@@ -84,6 +98,7 @@ public:
   bool is_use_typewise_cutoff_zbl_set;
   bool is_energy_shift_set;
   bool is_lr_cos_restart_set;
+  bool is_seed_set;
 
   // other parameters
   int dim;                            // dimension of the descriptor vector
@@ -106,10 +121,18 @@ public:
   float rc_angular_max = 0.0f;        // maximal angular cutoff
   bool has_multiple_cutoffs = false;
 
-  GPU_Vector<float> q_scaler_gpu[16]; // used to scale some descriptor components (GPU)
-  GPU_Vector<float> s_max[16];        // used to scale some descriptor components (GPU)
-  GPU_Vector<float> s_min[16];        // used to scale some descriptor components (GPU)
+private:
+  // Declared before the GPU-0-only buffer so the latter is destroyed first.
+  std::vector<std::unique_ptr<GNEPDeviceScaler>> device_scalers;
+
+public:
   GPU_Vector<float> energy_shift_gpu; // Energy shift for biased initialization of neural networks (GPU)
+
+  GPU_Vector<float>& q_scaler_gpu(int device_id);
+  GPU_Vector<float>& s_max_gpu(int device_id);
+  GPU_Vector<float>& s_min_gpu(int device_id);
+  int num_devices() const;
+  void reduce_and_broadcast_scaler();
 
 private:
   void set_default_parameters();
@@ -143,4 +166,5 @@ private:
   void parse_energy_shift(const char** param, int num_param);
   void parse_output_descriptor(const char** param, int num_param);
   void parse_lr_cos_restart(const char** param, int num_param);
+  void parse_seed(const char** param, int num_param);
 };

--- a/src/main_gnep/potential.cuh
+++ b/src/main_gnep/potential.cuh
@@ -31,6 +31,10 @@ public:
     std::vector<Dataset>& dataset,
     bool calculate_q_scaler,
     bool calculate_neighbor,
-    int DeviceCount) = 0;
-  virtual Gradients& getGradients() = 0;
+    int device_begin,
+    int device_count,
+    int global_num_configurations,
+    int global_num_atoms,
+    int global_virial_components) = 0;
+  virtual Gradients& getGradients(int device_id) = 0;
 };

--- a/src/makefile
+++ b/src/makefile
@@ -28,9 +28,18 @@ CFLAGS = -O3 $(CUDA_ARCH)
 else # For linux
 CFLAGS = -std=c++14 -O3 $(CUDA_ARCH) -Xcompiler="$(WARN_FLAGS)"
 endif
+ifeq ($(GNEP_TEST_DIAGNOSTICS),1)
+CFLAGS += -DGNEP_TEST_DIAGNOSTICS
+endif
+ifeq ($(GNEP_TEST_FIXED_SCALER),1)
+CFLAGS += -DUSE_FIXED_SCALER
+endif
 INC = -I./
 LDFLAGS = 
 LIBS = -lcublas -lcusolver -lcufft
+ifndef OS
+LIBS += -lpthread
+endif
 
 
 ###########################################################
@@ -167,4 +176,3 @@ ifdef OS
 else
 	rm -f */*.o gpumd nep gnep
 endif
-


### PR DESCRIPTION
## Summary

This PR adds deterministic single-node multi-GPU training to GNEP using
configuration-level synchronous data parallelism. The `batch` keyword remains
the global batch size, so the number of configurations and optimizer updates
per epoch are independent of the number of visible GPUs. Single-GPU training
uses the same execution path with one worker.

## Implementation

- Assign complete configurations to devices with a deterministic,
  atom-count-aware load balancer.
- Run per-device forward and backward calculations concurrently with dynamic,
  device-owned training contexts.
- Sum local gradients on the host in fixed device order using double precision.
- Apply gradient clipping once to the reduced global gradient, followed by one
  Adam update per global batch.
- Reduce descriptor extrema globally and broadcast a common `q_scaler` and
  parameter state to all workers.
- Use the global configuration count for energy, the global atom count for
  force, and the global valid-component count for virial normalization while
  retaining the required configuration-specific atom-count factors.
- Add an optional non-negative `seed` value for reproducible initialization and
  batch shuffling.
- Add host-thread linkage to the Make and CMake builds and document global batch
  semantics and multi-GPU utilization.

Complete configurations are never split between devices. Consequently,
`batch 1` remains valid but activates only one GPU for that optimizer step. A
fair 1/2/4-GPU comparison should use the same global batch size for every run.

## Validation

Validation was performed with CUDA 12.4 on four NVIDIA RTX 4090 GPUs.

- Make and CMake builds completed successfully; the `gpumd`, `nep`, and `gnep`
  targets were checked.
- Central finite-difference checks passed for representative ANN weights,
  biases, radial coefficients, and angular coefficients with energy-only,
  force-only, virial-only, and combined losses.
- Fixed-seed 1/2/4-GPU comparisons produced a maximum global-gradient
  difference of `5.83e-11`; serialized loss and RMSE values matched, and the
  maximum trained-model parameter difference was approximately `6e-8`.
- Configuration assignment and local-to-global gradient/count reconstruction
  checks passed without omissions or duplicates.
- One-, two-, and four-GPU training remained finite and decreased the loss over
  1000 epochs.
- `compute-sanitizer` reported no CUDA memory or API errors in the 1/2/4-GPU
  cases.

For a real-data benchmark with 3810 training configurations, 100 test
configurations, and a fixed global `batch 80`, the median step times after
excluding warm-up were:

| GPUs | Median step time | Speedup |
| ---: | ---: | ---: |
| 1 | 0.462856 s | 1.000x |
| 2 | 0.263450 s | 1.757x |
| 4 | 0.151553 s | 3.054x |
